### PR TITLE
Add ij2gidx & gidx2ij to structured grids

### DIFF
--- a/src/atlas/grid/StructuredGrid.h
+++ b/src/atlas/grid/StructuredGrid.h
@@ -115,6 +115,16 @@ public:
 
     const YSpace& yspace() const { return grid_->yspace(); }
 
+    gidx_t ij2gidx (idx_t i, idx_t j) const
+    {
+      return grid_->ij2gidx (i, j);
+    }
+
+    void gidx2ij (gidx_t gidx, idx_t ij[]) const
+    {
+      grid_->gidx2ij (gidx, ij);
+    }
+
 private:
     const grid_t* grid_;
 };

--- a/src/atlas/grid/StructuredGrid.h
+++ b/src/atlas/grid/StructuredGrid.h
@@ -115,14 +115,14 @@ public:
 
     const YSpace& yspace() const { return grid_->yspace(); }
 
-    gidx_t ij2gidx (idx_t i, idx_t j) const
+    gidx_t index (idx_t i, idx_t j) const
     {
-      return grid_->ij2gidx (i, j);
+      return grid_->index (i, j);
     }
 
-    void gidx2ij (gidx_t gidx, idx_t ij[]) const
+    void index2ij (gidx_t gidx, idx_t & i, idx_t & j) const
     {
-      grid_->gidx2ij (gidx, ij);
+      grid_->index2ij (gidx, i, j);
     }
 
 private:

--- a/src/atlas/grid/detail/grid/Structured.cc
+++ b/src/atlas/grid/detail/grid/Structured.cc
@@ -621,10 +621,10 @@ gidx_t atlas__grid__Structured__index (Structured* This, idx_t i, idx_t j)
     return This->index( i, j );
 }
 
-void atlas__grid__Structured__index2ij (Structured* This, gidx_t gidx, idx_t * i, idx_t * j)
+void atlas__grid__Structured__index2ij (Structured* This, gidx_t gidx, idx_t & i, idx_t & j)
 {
     ATLAS_ASSERT( This != nullptr, "Cannot access uninitialised atlas_StructuredGrid" );
-    This->index2ij (gidx, *i, *j);
+    This->index2ij (gidx, i, j);
 }
 
 void atlas__grid__Structured__nx_array( Structured* This, const idx_t*& nx_array, idx_t& size ) {

--- a/src/atlas/grid/detail/grid/Structured.cc
+++ b/src/atlas/grid/detail/grid/Structured.cc
@@ -615,16 +615,16 @@ idx_t atlas__grid__Structured__nx( Structured* This, idx_t jlat ) {
     return This->nx( jlat );
 }
 
-gidx_t atlas__grid__Structured__ij2gidx (Structured* This, idx_t i, idx_t j)
+gidx_t atlas__grid__Structured__index (Structured* This, idx_t i, idx_t j)
 {
     ATLAS_ASSERT( This != nullptr, "Cannot access uninitialised atlas_StructuredGrid" );
-    return This->ij2gidx( i, j );
+    return This->index( i, j );
 }
 
-void atlas__grid__Structured__gidx2ij (Structured* This, gidx_t gidx, idx_t ij[])
+void atlas__grid__Structured__index2ij (Structured* This, gidx_t gidx, idx_t * i, idx_t * j)
 {
     ATLAS_ASSERT( This != nullptr, "Cannot access uninitialised atlas_StructuredGrid" );
-    This->gidx2ij (gidx, ij);
+    This->index2ij (gidx, *i, *j);
 }
 
 void atlas__grid__Structured__nx_array( Structured* This, const idx_t*& nx_array, idx_t& size ) {

--- a/src/atlas/grid/detail/grid/Structured.cc
+++ b/src/atlas/grid/detail/grid/Structured.cc
@@ -80,6 +80,12 @@ Structured::Structured( const std::string& name, XSpace xspace, YSpace yspace, P
     crop( domain );
 
     computeTruePeriodicity();
+
+    jglooff_.resize (ny + 1);
+    jglooff_[0] = 0;
+    for (int j = 1; j < ny + 1; j++)
+      jglooff_[j] = jglooff_[j-1] + nx_[j-1];
+
 }
 
 Domain Structured::computeDomain() const {
@@ -607,6 +613,18 @@ idx_t atlas__grid__Structured__ny( Structured* This ) {
 idx_t atlas__grid__Structured__nx( Structured* This, idx_t jlat ) {
     ATLAS_ASSERT( This != nullptr, "Cannot access uninitialised atlas_StructuredGrid" );
     return This->nx( jlat );
+}
+
+gidx_t atlas__grid__Structured__ij2gidx (Structured* This, idx_t i, idx_t j)
+{
+    ATLAS_ASSERT( This != nullptr, "Cannot access uninitialised atlas_StructuredGrid" );
+    return This->ij2gidx( i, j );
+}
+
+void atlas__grid__Structured__gidx2ij (Structured* This, gidx_t gidx, idx_t ij[])
+{
+    ATLAS_ASSERT( This != nullptr, "Cannot access uninitialised atlas_StructuredGrid" );
+    This->gidx2ij (gidx, ij);
 }
 
 void atlas__grid__Structured__nx_array( Structured* This, const idx_t*& nx_array, idx_t& size ) {

--- a/src/atlas/grid/detail/grid/Structured.h
+++ b/src/atlas/grid/detail/grid/Structured.h
@@ -435,7 +435,7 @@ void atlas__grid__Structured__nx_array( Structured* This, const idx_t*& nx, idx_
 idx_t atlas__grid__Structured__nx( Structured* This, idx_t j );
 idx_t atlas__grid__Structured__ny( Structured* This );
 gidx_t atlas__grid__Structured__index (Structured* This, idx_t i, idx_t j);
-void atlas__grid__Structured__index2ij (Structured* This, gidx_t gidx, idx_t * i, idx_t * j);
+void atlas__grid__Structured__index2ij (Structured* This, gidx_t gidx, idx_t & i, idx_t & j);
 idx_t atlas__grid__Structured__nxmin( Structured* This );
 idx_t atlas__grid__Structured__nxmax( Structured* This );
 idx_t atlas__grid__Structured__size( Structured* This );

--- a/src/atlas/grid/detail/grid/Structured.h
+++ b/src/atlas/grid/detail/grid/Structured.h
@@ -345,15 +345,15 @@ public:
         return std::unique_ptr<Grid::IteratorLonLat>( new IteratorLonLat( *this, false ) );
     }
 
-    gidx_t ij2gidx (idx_t i, idx_t j) const
+    gidx_t index (idx_t i, idx_t j) const
     {
       return jglooff_[j] + i;
     }
 
-    void gidx2ij (gidx_t gidx, idx_t ij[]) const
+    void index2ij (gidx_t gidx, idx_t & i, idx_t & j) const
     {
       if ((gidx < 0) || (gidx >= jglooff_.back ()))
-        throw_Exception ("Structured::gidx2ij: gidx out of bounds", Here ());
+        throw_Exception ("Structured::index2ij: gidx out of bounds", Here ());
       idx_t ja = 0, jb = jglooff_.size ();
       while (jb - ja > 1)
         {
@@ -363,8 +363,8 @@ public:
           else 
             ja = jm;
         }
-      ij[0] = gidx - jglooff_[ja];
-      ij[1] = ja;
+      i = gidx - jglooff_[ja];
+      j = ja;
     }
 
 
@@ -434,8 +434,8 @@ Structured* atlas__grid__regular__ShiftedLat( long nx, long ny );
 void atlas__grid__Structured__nx_array( Structured* This, const idx_t*& nx, idx_t& size );
 idx_t atlas__grid__Structured__nx( Structured* This, idx_t j );
 idx_t atlas__grid__Structured__ny( Structured* This );
-gidx_t atlas__grid__Structured__ij2gidx (Structured* This, idx_t i, idx_t j);
-void atlas__grid__Structured__gidx2ij (Structured* This, gidx_t gidx, idx_t ij[]);
+gidx_t atlas__grid__Structured__index (Structured* This, idx_t i, idx_t j);
+void atlas__grid__Structured__index2ij (Structured* This, gidx_t gidx, idx_t * i, idx_t * j);
 idx_t atlas__grid__Structured__nxmin( Structured* This );
 idx_t atlas__grid__Structured__nxmax( Structured* This );
 idx_t atlas__grid__Structured__size( Structured* This );

--- a/src/atlas/grid/detail/grid/Structured.h
+++ b/src/atlas/grid/detail/grid/Structured.h
@@ -345,6 +345,29 @@ public:
         return std::unique_ptr<Grid::IteratorLonLat>( new IteratorLonLat( *this, false ) );
     }
 
+    gidx_t ij2gidx (idx_t i, idx_t j) const
+    {
+      return jglooff_[j] + i;
+    }
+
+    void gidx2ij (gidx_t gidx, idx_t ij[]) const
+    {
+      if ((gidx < 0) || (gidx >= jglooff_.back ()))
+        throw_Exception ("Structured::gidx2ij: gidx out of bounds", Here ());
+      idx_t ja = 0, jb = jglooff_.size ();
+      while (jb - ja > 1)
+        {
+          idx_t jm = (ja + jb) / 2;
+          if (gidx < jglooff_[jm])
+            jb = jm;
+          else 
+            ja = jm;
+        }
+      ij[0] = gidx - jglooff_[ja];
+      ij[1] = ja;
+    }
+
+
 protected:  // methods
     virtual void print( std::ostream& ) const override;
 
@@ -386,6 +409,9 @@ protected:
     /// Periodicity in x-direction
     bool periodic_x_;
 
+    /// Per-row offset
+    std::vector<gidx_t> jglooff_;
+
 private:
     std::string name_ = {"structured"};
     XSpace xspace_;
@@ -408,6 +434,8 @@ Structured* atlas__grid__regular__ShiftedLat( long nx, long ny );
 void atlas__grid__Structured__nx_array( Structured* This, const idx_t*& nx, idx_t& size );
 idx_t atlas__grid__Structured__nx( Structured* This, idx_t j );
 idx_t atlas__grid__Structured__ny( Structured* This );
+gidx_t atlas__grid__Structured__ij2gidx (Structured* This, idx_t i, idx_t j);
+void atlas__grid__Structured__gidx2ij (Structured* This, gidx_t gidx, idx_t ij[]);
 idx_t atlas__grid__Structured__nxmin( Structured* This );
 idx_t atlas__grid__Structured__nxmax( Structured* This );
 idx_t atlas__grid__Structured__size( Structured* This );

--- a/src/atlas_f/grid/atlas_Grid_module.F90
+++ b/src/atlas_f/grid/atlas_Grid_module.F90
@@ -562,7 +562,7 @@ function Structured__ny(this) result(ny)
 end function
 
 subroutine Structured__index2ij_int32(this, gidx, i, j) 
-  use, intrinsic :: iso_c_binding, only: c_long, c_int, c_loc
+  use, intrinsic :: iso_c_binding, only: c_long, c_int
   use atlas_grid_Structured_c_binding
   integer(c_int), intent (in) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
@@ -573,7 +573,7 @@ subroutine Structured__index2ij_int32(this, gidx, i, j)
 end subroutine
 
 subroutine Structured__index2ij_int64(this, gidx, i, j) 
-  use, intrinsic :: iso_c_binding, only: c_long, c_int, c_loc
+  use, intrinsic :: iso_c_binding, only: c_long, c_int
   use atlas_grid_Structured_c_binding
   integer(c_long), intent (in) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
@@ -584,7 +584,7 @@ subroutine Structured__index2ij_int64(this, gidx, i, j)
 end subroutine
 
 function Structured__ij_int32(this, gidx) result(ij)
-  use, intrinsic :: iso_c_binding, only: c_long, c_int, c_loc
+  use, intrinsic :: iso_c_binding, only: c_long, c_int
   use atlas_grid_Structured_c_binding
   integer(c_int), intent (in) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
@@ -594,7 +594,7 @@ function Structured__ij_int32(this, gidx) result(ij)
 end function
 
 function Structured__ij_int64(this, gidx) result(ij)
-  use, intrinsic :: iso_c_binding, only: c_long, c_int, c_loc
+  use, intrinsic :: iso_c_binding, only: c_long, c_int
   use atlas_grid_Structured_c_binding
   integer(c_long), intent (in) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this

--- a/src/atlas_f/grid/atlas_Grid_module.F90
+++ b/src/atlas_f/grid/atlas_Grid_module.F90
@@ -110,6 +110,12 @@ contains
   procedure, private   :: nx_int32 => Structured__nx_int32
   procedure, private   :: nx_int64 => Structured__nx_int64
   generic   :: nx => nx_int32, nx_int64
+  procedure, private :: Structured__ij2gidx_int32
+  procedure, private :: Structured__ij2gidx_int64
+  generic   :: ij2gidx => Structured__ij2gidx_int32, Structured__ij2gidx_int64
+  procedure, private :: Structured__gidx2ij_int32
+  procedure, private :: Structured__gidx2ij_int64
+  generic   :: gidx2ij => Structured__gidx2ij_int32, Structured__gidx2ij_int64
   procedure :: nx_array  => Structured__nx_array
   procedure :: nxmin     => Structured__nxmin
   procedure :: nxmax     => Structured__nxmax
@@ -553,6 +559,43 @@ function Structured__ny(this) result(ny)
   ny = atlas__grid__Structured__ny(this%CPTR_PGIBUG_A)
 end function
 
+function Structured__gidx2ij_int32(this, gidx) result(ij)
+  use, intrinsic :: iso_c_binding, only: c_long, c_int
+  use atlas_grid_Structured_c_binding
+  integer(c_int), intent (in) :: gidx
+  class(atlas_StructuredGrid), intent(in) :: this
+  integer(c_int) :: ij (2)
+  call atlas__grid__Structured__gidx2ij(this%CPTR_PGIBUG_A, int (gidx-1, c_long), ij)
+  ij = ij + 1
+end function
+
+function Structured__gidx2ij_int64(this, gidx) result(ij)
+  use, intrinsic :: iso_c_binding, only: c_long, c_int
+  use atlas_grid_Structured_c_binding
+  integer(c_long), intent (in) :: gidx
+  class(atlas_StructuredGrid), intent(in) :: this
+  integer(c_int) :: ij (2)
+  call atlas__grid__Structured__gidx2ij(this%CPTR_PGIBUG_A, gidx-1, ij)
+  ij = ij + 1
+end function
+
+function Structured__ij2gidx_int32(this, i, j) result(gidx)
+  use, intrinsic :: iso_c_binding, only: c_long, c_int
+  use atlas_grid_Structured_c_binding
+  integer(c_long) :: gidx
+  class(atlas_StructuredGrid), intent(in) :: this
+  integer(c_int), intent(in) :: i, j
+  gidx = 1 + atlas__grid__Structured__ij2gidx(this%CPTR_PGIBUG_A, c_idx(i), c_idx(j) )
+end function
+
+function Structured__ij2gidx_int64(this, i, j) result(gidx)
+  use, intrinsic :: iso_c_binding, only: c_long
+  use atlas_grid_Structured_c_binding
+  integer(c_long) :: gidx
+  class(atlas_StructuredGrid), intent(in) :: this
+  integer(c_long), intent(in) :: i, j
+  gidx = 1 + atlas__grid__Structured__ij2gidx(this%CPTR_PGIBUG_A, c_idx(i), c_idx(j) )
+end function
 
 function Structured__nx_int32(this, j) result(nx)
   use, intrinsic :: iso_c_binding, only: c_long, c_int

--- a/src/atlas_f/grid/atlas_Grid_module.F90
+++ b/src/atlas_f/grid/atlas_Grid_module.F90
@@ -567,7 +567,7 @@ subroutine Structured__index2ij_int32(this, gidx, i, j)
   integer(c_int), intent (in) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_int), intent(out) :: i, j
-  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, int (gidx-1, c_long), c_loc (i), c_loc(j))
+  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, int (gidx-1, c_long), i, j)
   i = i + 1
   j = j + 1
 end subroutine
@@ -578,7 +578,7 @@ subroutine Structured__index2ij_int64(this, gidx, i, j)
   integer(c_long), intent (in) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_int), intent(out) :: i, j
-  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, gidx-1, c_loc (i), c_loc (j))
+  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, gidx-1, i, j)
   i = i + 1
   j = j + 1
 end subroutine
@@ -589,7 +589,7 @@ function Structured__ij_int32(this, gidx) result(ij)
   integer(c_int), intent (in) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_int) :: ij (2)
-  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, int (gidx-1, c_long), c_loc(ij(1)), c_loc(ij(2)))
+  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, int (gidx-1, c_long), ij(1), ij(2))
   ij = ij + 1
 end function
 
@@ -599,7 +599,7 @@ function Structured__ij_int64(this, gidx) result(ij)
   integer(c_long), intent (in) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_int) :: ij (2)
-  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, gidx-1, c_loc (ij(1)), c_loc (ij(2)))
+  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, gidx-1, ij(1), ij(2))
   ij = ij + 1
 end function
 

--- a/src/atlas_f/grid/atlas_Grid_module.F90
+++ b/src/atlas_f/grid/atlas_Grid_module.F90
@@ -110,12 +110,14 @@ contains
   procedure, private   :: nx_int32 => Structured__nx_int32
   procedure, private   :: nx_int64 => Structured__nx_int64
   generic   :: nx => nx_int32, nx_int64
-  procedure, private :: Structured__ij2gidx_int32
-  procedure, private :: Structured__ij2gidx_int64
-  generic   :: ij2gidx => Structured__ij2gidx_int32, Structured__ij2gidx_int64
-  procedure, private :: Structured__gidx2ij_int32
-  procedure, private :: Structured__gidx2ij_int64
-  generic   :: gidx2ij => Structured__gidx2ij_int32, Structured__gidx2ij_int64
+  procedure, private :: Structured__index_int32
+  procedure, private :: Structured__index_int64
+  generic   :: index => Structured__index_int32, Structured__index_int64
+  procedure, private :: Structured__index2ij_int32
+  procedure, private :: Structured__index2ij_int64
+  generic   :: index2ij => Structured__index2ij_int32, Structured__index2ij_int64
+  procedure, private :: Structured__ij_int32, Structured__ij_int64
+  generic   :: ij => Structured__ij_int32, Structured__ij_int64
   procedure :: nx_array  => Structured__nx_array
   procedure :: nxmin     => Structured__nxmin
   procedure :: nxmax     => Structured__nxmax
@@ -559,42 +561,64 @@ function Structured__ny(this) result(ny)
   ny = atlas__grid__Structured__ny(this%CPTR_PGIBUG_A)
 end function
 
-function Structured__gidx2ij_int32(this, gidx) result(ij)
-  use, intrinsic :: iso_c_binding, only: c_long, c_int
+subroutine Structured__index2ij_int32(this, gidx, i, j) 
+  use, intrinsic :: iso_c_binding, only: c_long, c_int, c_loc
+  use atlas_grid_Structured_c_binding
+  integer(c_int), intent (in) :: gidx
+  class(atlas_StructuredGrid), intent(in) :: this
+  integer(c_int), intent(out) :: i, j
+  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, int (gidx-1, c_long), c_loc (i), c_loc(j))
+  i = i + 1
+  j = j + 1
+end subroutine
+
+subroutine Structured__index2ij_int64(this, gidx, i, j) 
+  use, intrinsic :: iso_c_binding, only: c_long, c_int, c_loc
+  use atlas_grid_Structured_c_binding
+  integer(c_long), intent (in) :: gidx
+  class(atlas_StructuredGrid), intent(in) :: this
+  integer(c_int), intent(out) :: i, j
+  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, gidx-1, c_loc (i), c_loc (j))
+  i = i + 1
+  j = j + 1
+end subroutine
+
+function Structured__ij_int32(this, gidx) result(ij)
+  use, intrinsic :: iso_c_binding, only: c_long, c_int, c_loc
   use atlas_grid_Structured_c_binding
   integer(c_int), intent (in) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_int) :: ij (2)
-  call atlas__grid__Structured__gidx2ij(this%CPTR_PGIBUG_A, int (gidx-1, c_long), ij)
+  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, int (gidx-1, c_long), c_loc(ij(1)), c_loc(ij(2)))
   ij = ij + 1
 end function
 
-function Structured__gidx2ij_int64(this, gidx) result(ij)
-  use, intrinsic :: iso_c_binding, only: c_long, c_int
+function Structured__ij_int64(this, gidx) result(ij)
+  use, intrinsic :: iso_c_binding, only: c_long, c_int, c_loc
   use atlas_grid_Structured_c_binding
   integer(c_long), intent (in) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_int) :: ij (2)
-  call atlas__grid__Structured__gidx2ij(this%CPTR_PGIBUG_A, gidx-1, ij)
+  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, gidx-1, c_loc (ij(1)), c_loc (ij(2)))
   ij = ij + 1
 end function
 
-function Structured__ij2gidx_int32(this, i, j) result(gidx)
+function Structured__index_int32(this, i, j) result(gidx)
   use, intrinsic :: iso_c_binding, only: c_long, c_int
   use atlas_grid_Structured_c_binding
   integer(c_long) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_int), intent(in) :: i, j
-  gidx = 1 + atlas__grid__Structured__ij2gidx(this%CPTR_PGIBUG_A, c_idx(i), c_idx(j) )
+  gidx = 1 + atlas__grid__Structured__index(this%CPTR_PGIBUG_A, c_idx(i), c_idx(j) )
 end function
 
-function Structured__ij2gidx_int64(this, i, j) result(gidx)
+function Structured__index_int64(this, i, j) result(gidx)
   use, intrinsic :: iso_c_binding, only: c_long
   use atlas_grid_Structured_c_binding
   integer(c_long) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_long), intent(in) :: i, j
-  gidx = 1 + atlas__grid__Structured__ij2gidx(this%CPTR_PGIBUG_A, c_idx(i), c_idx(j) )
+  gidx = 1 + atlas__grid__Structured__index(this%CPTR_PGIBUG_A, c_idx(i), c_idx(j) )
 end function
 
 function Structured__nx_int32(this, j) result(nx)

--- a/src/tests/grid/CMakeLists.txt
+++ b/src/tests/grid/CMakeLists.txt
@@ -9,6 +9,7 @@
 if( HAVE_FCTEST )
     foreach(test
             fctest_griddistribution
+            fctest_grids
             fctest_state )
 
         add_fctest( TARGET atlas_${test} SOURCES ${test}.F90 LINKER_LANGUAGE Fortran LIBS atlas_f ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )

--- a/src/tests/grid/fctest_grids.F90
+++ b/src/tests/grid/fctest_grids.F90
@@ -1,0 +1,59 @@
+! (C) Copyright 2013 ECMWF.
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation nor
+! does it submit to any jurisdiction.
+
+! This File contains Unit Tests for testing the
+! C++ / Fortran Interfaces to the Mesh Datastructure
+! @author Willem Deconinck
+
+#include "fckit/fctest.h"
+
+! -----------------------------------------------------------------------------
+
+TESTSUITE(fctest_Grid)
+
+! -----------------------------------------------------------------------------
+
+TESTSUITE_INIT
+  use atlas_module
+  call atlas_library%initialise()
+END_TESTSUITE_INIT
+
+! -----------------------------------------------------------------------------
+
+TESTSUITE_FINALIZE
+  use atlas_module
+  call atlas_library%finalise()
+END_TESTSUITE_FINALIZE
+
+TEST( test_ij2gidx )
+  use atlas_module
+  implicit none
+  type(atlas_StructuredGrid) :: grid
+  integer :: jglo, i, j, i1, j1, jglo1
+
+  grid = atlas_StructuredGrid ("N16")
+
+  jglo = 1
+  do j = 1, grid%ny ()
+  do i = 1, grid%nx (j)
+    call grid%index2ij (jglo, i1, j1)
+    jglo1 = grid%index (i, j)
+    FCTEST_CHECK_EQUAL( jglo, jglo1 )
+    FCTEST_CHECK_EQUAL( i, i1 )
+    FCTEST_CHECK_EQUAL( j, j1 )
+    jglo = jglo + 1
+  enddo
+  enddo
+
+  call grid%final()
+  
+END_TEST
+
+! -----------------------------------------------------------------------------
+
+END_TESTSUITE
+

--- a/src/tests/grid/test_grids.cc
+++ b/src/tests/grid/test_grids.cc
@@ -37,11 +37,11 @@ CASE( "test_ij2gidx") {
     for (int j = 0, jglo = 0; j < n16.ny (); j++)
     for (int i = 0; i < n16.nx (j); i++, jglo++)
       {
-        idx_t ij[2];
-        n16.gidx2ij (jglo, ij);
-        EXPECT (n16.ij2gidx (i, j) == jglo);
-        EXPECT (ij[0] == i);
-        EXPECT (ij[1] == j);
+        idx_t i1, j1;
+        n16.index2ij (jglo, i1, j1);
+        EXPECT (n16.index (i, j) == jglo);
+        EXPECT (i1 == i);
+        EXPECT (j1 == j);
       }
 }
 

--- a/src/tests/grid/test_grids.cc
+++ b/src/tests/grid/test_grids.cc
@@ -30,6 +30,21 @@ namespace test {
 
 //-----------------------------------------------------------------------------
 
+
+CASE( "test_ij2gidx") {
+    StructuredGrid n16 = Grid( "N16" );
+
+    for (int j = 0, jglo = 0; j < n16.ny (); j++)
+    for (int i = 0; i < n16.nx (j); i++, jglo++)
+      {
+        idx_t ij[2];
+        n16.gidx2ij (jglo, ij);
+        EXPECT (n16.ij2gidx (i, j) == jglo);
+        EXPECT (ij[0] == i);
+        EXPECT (ij[1] == j);
+      }
+}
+
 CASE( "test_factory" ) {
     StructuredGrid structured = Grid( "N80" );
 


### PR DESCRIPTION
Solves issue #29 . 

Fortran bindings have been included. These two methods are tested in test program test_grids.cc.