### PR TITLE
The test case test_functionspace_StructuredColumns_no_halo is broken …

### DIFF
--- a/src/atlas/functionspace/detail/StructuredColumns_setup.cc
+++ b/src/atlas/functionspace/detail/StructuredColumns_setup.cc
@@ -461,17 +461,25 @@ void StructuredColumns::setup( const grid::Distribution& distribution, const eck
                         if ( j > thread_j_begin ) {
                             thread_i_begin[j] = i_begin_[j];
                         }
-                        idx_t remaining = static_cast<idx_t>( end - n );
                         idx_t j_size    = ( i_end_[j] - i_begin_[j] );
-                        if ( remaining > j_size ) {
+ 
+                        idx_t remaining = static_cast<idx_t>(end - n);
+                        if (j_size <= remaining) {
                             thread_i_end[j] = i_end_[j];
                             n += j_size;
-                        }
+                            if (n == end)
+                              goto stop;
+                        } 
                         else {
-                            thread_i_end[j] = thread_i_begin[j] + remaining;
-                            thread_j_end    = j + 1;
-                            break;
+                            thread_i_end[j] = i_begin_[j] + remaining;
+                            goto stop;
                         }
+
+                       continue;
+
+                       stop:
+                          thread_j_end    = j + 1;
+                          break;
                     }
 
                     idx_t r = idx_t( begin );

--- a/src/tests/functionspace/test_structuredcolumns.cc
+++ b/src/tests/functionspace/test_structuredcolumns.cc
@@ -329,6 +329,7 @@ CASE( "test_functionspace_StructuredColumns halo exchange registration" ) {
 
 //-----------------------------------------------------------------------------
 
+
 }  // namespace test
 }  // namespace atlas
 


### PR DESCRIPTION
…when run on a single task with OMP_NUM_THREADS=20.

The problem is not a race condition nor is it related to OpenMP but rather to the distribution of the work to the threads.

This commit fixes the issue.