### PR TITLE
Projection jacobian

### DIFF
--- a/src/atlas/projection/Projection.cc
+++ b/src/atlas/projection/Projection.cc
@@ -47,6 +47,12 @@ void atlas::Projection::lonlat2xy( Point2& point ) const {
     return get()->lonlat2xy( point );
 }
 
+atlas::Projection::Jacobian 
+atlas::Projection::getJacobianAtLonLat (const PointLonLat & p) const
+{
+  return get ()->getJacobianAtLonLat (p);
+}
+
 PointLonLat atlas::Projection::lonlat( const PointXY& xy ) const {
     return get()->lonlat( xy );
 }

--- a/src/atlas/projection/Projection.cc
+++ b/src/atlas/projection/Projection.cc
@@ -48,9 +48,9 @@ void atlas::Projection::lonlat2xy( Point2& point ) const {
 }
 
 atlas::Projection::Jacobian 
-atlas::Projection::getJacobianAtLonLat (const PointLonLat & p) const
+atlas::Projection::jacobian (const PointLonLat & p) const
 {
-  return get ()->getJacobianAtLonLat (p);
+  return get ()->jacobian (p);
 }
 
 PointLonLat atlas::Projection::lonlat( const PointXY& xy ) const {

--- a/src/atlas/projection/Projection.h
+++ b/src/atlas/projection/Projection.h
@@ -13,6 +13,7 @@
 #include <string>
 
 #include "atlas/domain/Domain.h"
+#include "atlas/projection/detail/ProjectionImpl.h"
 #include "atlas/library/config.h"
 #include "atlas/util/ObjectHandle.h"
 
@@ -48,6 +49,7 @@ class ProjectionImpl;
 class Projection : DOXYGEN_HIDE( public util::ObjectHandle<projection::detail::ProjectionImpl> ) {
 public:
     using Spec = util::Config;
+    using Jacobian = projection::detail::ProjectionImpl::Jacobian;
 
 public:
     using Handle::Handle;
@@ -60,6 +62,8 @@ public:
     void xy2lonlat( Point2& ) const;
     void lonlat2xy( double crd[] ) const;
     void lonlat2xy( Point2& ) const;
+
+    Jacobian getJacobianAtLonLat (const PointLonLat &) const;
 
     PointLonLat lonlat( const PointXY& ) const;
     PointXY xy( const PointLonLat& ) const;

--- a/src/atlas/projection/Projection.h
+++ b/src/atlas/projection/Projection.h
@@ -63,7 +63,7 @@ public:
     void lonlat2xy( double crd[] ) const;
     void lonlat2xy( Point2& ) const;
 
-    Jacobian getJacobianAtLonLat (const PointLonLat &) const;
+    Jacobian jacobian (const PointLonLat &) const;
 
     PointLonLat lonlat( const PointXY& ) const;
     PointXY xy( const PointLonLat& ) const;

--- a/src/atlas/projection/detail/LambertAzimuthalEqualAreaProjection.cc
+++ b/src/atlas/projection/detail/LambertAzimuthalEqualAreaProjection.cc
@@ -86,6 +86,11 @@ void LambertAzimuthalEqualAreaProjection::xy2lonlat( double crd[] ) const {
 }
 
 
+ProjectionImpl::Jacobian LambertAzimuthalEqualAreaProjection::getJacobianAtLonLat (const PointLonLat &) const 
+{
+  throw_NotImplemented ("LambertAzimuthalEqualAreaProjection::getJacobianAtLonLat", Here ());
+}
+
 LambertAzimuthalEqualAreaProjection::Spec LambertAzimuthalEqualAreaProjection::spec() const {
     Spec proj;
     proj.set( "type", static_type() );

--- a/src/atlas/projection/detail/LambertAzimuthalEqualAreaProjection.cc
+++ b/src/atlas/projection/detail/LambertAzimuthalEqualAreaProjection.cc
@@ -86,9 +86,9 @@ void LambertAzimuthalEqualAreaProjection::xy2lonlat( double crd[] ) const {
 }
 
 
-ProjectionImpl::Jacobian LambertAzimuthalEqualAreaProjection::getJacobianAtLonLat (const PointLonLat &) const 
+ProjectionImpl::Jacobian LambertAzimuthalEqualAreaProjection::jacobian (const PointLonLat &) const 
 {
-  throw_NotImplemented ("LambertAzimuthalEqualAreaProjection::getJacobianAtLonLat", Here ());
+  throw_NotImplemented ("LambertAzimuthalEqualAreaProjection::jacobian", Here ());
 }
 
 LambertAzimuthalEqualAreaProjection::Spec LambertAzimuthalEqualAreaProjection::spec() const {

--- a/src/atlas/projection/detail/LambertAzimuthalEqualAreaProjection.h
+++ b/src/atlas/projection/detail/LambertAzimuthalEqualAreaProjection.h
@@ -30,6 +30,8 @@ public:
     void xy2lonlat( double crd[] ) const override;
     void lonlat2xy( double crd[] ) const override;
 
+    Jacobian getJacobianAtLonLat (const PointLonLat &) const override;
+
     bool strictlyRegional() const override { return true; }
     RectangularLonLatDomain lonlatBoundingBox( const Domain& domain ) const override {
         return ProjectionImpl::lonlatBoundingBox( domain );

--- a/src/atlas/projection/detail/LambertAzimuthalEqualAreaProjection.h
+++ b/src/atlas/projection/detail/LambertAzimuthalEqualAreaProjection.h
@@ -30,7 +30,7 @@ public:
     void xy2lonlat( double crd[] ) const override;
     void lonlat2xy( double crd[] ) const override;
 
-    Jacobian getJacobianAtLonLat (const PointLonLat &) const override;
+    Jacobian jacobian (const PointLonLat &) const override;
 
     bool strictlyRegional() const override { return true; }
     RectangularLonLatDomain lonlatBoundingBox( const Domain& domain ) const override {

--- a/src/atlas/projection/detail/LambertConformalConicProjection.cc
+++ b/src/atlas/projection/detail/LambertConformalConicProjection.cc
@@ -100,6 +100,40 @@ void LambertConformalConicProjection::xy2lonlat( double crd[] ) const {
             : util::Constants::radiansToDegrees() * 2. * std::atan( std::pow( radius_ * F_ / rho, inv_n_ ) ) - 90.;
 }
 
+ProjectionImpl::Jacobian LambertConformalConicProjection::getJacobianAtLonLat (const PointLonLat & lonlat) const 
+{
+  ProjectionImpl::Jacobian jac;
+  
+  const double deg2rad = util::Constants::degreesToRadians ();
+
+  double lat = lonlat.lat (), lon = lonlat.lon ();
+  double tanlat = tan_d (lat), coslat = cos_d (45. + lat * 0.5);
+
+  double rho   = radius_ * F_ * std::pow (tanlat, -n_);
+  double theta = n_ * normalise (lon - lon0_, -180, 360);
+
+  double costheta = cos_d (theta), sintheta = sin_d (theta);
+
+  double x = rho * sintheta;
+  double y = rho0_ - rho * costheta;
+  
+  auto cpj = [&] (const double dlon, const double dlat, double & dx, double & dy)
+  {
+    double drho   = deg2rad * radius_ * F_ * (-n_) * std::pow (tanlat, -n_-1) / (coslat * coslat) * dlat * 0.5;
+    double dtheta = + n_ * dlon;
+    dx = + drho * sintheta + rho * costheta * deg2rad * dtheta;
+    dy = - drho * costheta + rho * sintheta * deg2rad * dtheta;
+  };
+
+  const double dlat = 1.0f;
+  const double dlon = 1.0f;
+
+  cpj (dlon,    0, jac[0][0], jac[1][0]);
+  cpj (   0, dlat, jac[0][1], jac[1][1]);
+
+  return jac;
+}
+
 LambertConformalConicProjection::Spec LambertConformalConicProjection::spec() const {
     Spec spec;
     spec.set( "type", static_type() );

--- a/src/atlas/projection/detail/LambertConformalConicProjection.cc
+++ b/src/atlas/projection/detail/LambertConformalConicProjection.cc
@@ -100,7 +100,7 @@ void LambertConformalConicProjection::xy2lonlat( double crd[] ) const {
             : util::Constants::radiansToDegrees() * 2. * std::atan( std::pow( radius_ * F_ / rho, inv_n_ ) ) - 90.;
 }
 
-ProjectionImpl::Jacobian LambertConformalConicProjection::getJacobianAtLonLat (const PointLonLat & lonlat) const 
+ProjectionImpl::Jacobian LambertConformalConicProjection::jacobian (const PointLonLat & lonlat) const 
 {
   ProjectionImpl::Jacobian jac;
   

--- a/src/atlas/projection/detail/LambertConformalConicProjection.h
+++ b/src/atlas/projection/detail/LambertConformalConicProjection.h
@@ -30,6 +30,8 @@ public:
     void xy2lonlat( double crd[] ) const override;
     void lonlat2xy( double crd[] ) const override;
 
+    Jacobian getJacobianAtLonLat (const PointLonLat &) const override;
+
     bool strictlyRegional() const override { return true; }
 
     RectangularLonLatDomain lonlatBoundingBox( const Domain& domain ) const override {

--- a/src/atlas/projection/detail/LambertConformalConicProjection.h
+++ b/src/atlas/projection/detail/LambertConformalConicProjection.h
@@ -30,7 +30,7 @@ public:
     void xy2lonlat( double crd[] ) const override;
     void lonlat2xy( double crd[] ) const override;
 
-    Jacobian getJacobianAtLonLat (const PointLonLat &) const override;
+    Jacobian jacobian (const PointLonLat &) const override;
 
     bool strictlyRegional() const override { return true; }
 

--- a/src/atlas/projection/detail/LonLatProjection.cc
+++ b/src/atlas/projection/detail/LonLatProjection.cc
@@ -36,6 +36,21 @@ template <>
 void LonLatProjectionT<NotRotated>::lonlat2xy( double[] ) const {}
 
 template <>
+ProjectionImpl::Jacobian LonLatProjectionT<NotRotated>::getJacobianAtLonLat (const PointLonLat &) const 
+{
+  Jacobian jac;
+  jac[0] = {1.0, 0.0};
+  jac[1] = {0.0, 1.0};
+  return jac;
+}
+
+template <typename Rotation>
+ProjectionImpl::Jacobian LonLatProjectionT<Rotation>::getJacobianAtLonLat (const PointLonLat &) const 
+{
+  throw_NotImplemented ("LonLatProjectionT::getJacobianAtLonLat", Here ());
+}
+
+template <>
 RectangularLonLatDomain LonLatProjectionT<NotRotated>::lonlatBoundingBox( const Domain& domain ) const {
     return domain;
 }

--- a/src/atlas/projection/detail/LonLatProjection.cc
+++ b/src/atlas/projection/detail/LonLatProjection.cc
@@ -36,7 +36,7 @@ template <>
 void LonLatProjectionT<NotRotated>::lonlat2xy( double[] ) const {}
 
 template <>
-ProjectionImpl::Jacobian LonLatProjectionT<NotRotated>::getJacobianAtLonLat (const PointLonLat &) const 
+ProjectionImpl::Jacobian LonLatProjectionT<NotRotated>::jacobian (const PointLonLat &) const 
 {
   Jacobian jac;
   jac[0] = {1.0, 0.0};
@@ -45,9 +45,9 @@ ProjectionImpl::Jacobian LonLatProjectionT<NotRotated>::getJacobianAtLonLat (con
 }
 
 template <typename Rotation>
-ProjectionImpl::Jacobian LonLatProjectionT<Rotation>::getJacobianAtLonLat (const PointLonLat &) const 
+ProjectionImpl::Jacobian LonLatProjectionT<Rotation>::jacobian (const PointLonLat &) const 
 {
-  throw_NotImplemented ("LonLatProjectionT::getJacobianAtLonLat", Here ());
+  throw_NotImplemented ("LonLatProjectionT::jacobian", Here ());
 }
 
 template <>

--- a/src/atlas/projection/detail/LonLatProjection.h
+++ b/src/atlas/projection/detail/LonLatProjection.h
@@ -41,6 +41,8 @@ public:
     void xy2lonlat( double crd[] ) const override { rotation_.rotate( crd ); }
     void lonlat2xy( double crd[] ) const override { rotation_.unrotate( crd ); }
 
+    Jacobian getJacobianAtLonLat (const PointLonLat &) const override;
+
     bool strictlyRegional() const override { return false; }
     RectangularLonLatDomain lonlatBoundingBox( const Domain& ) const override;
 

--- a/src/atlas/projection/detail/LonLatProjection.h
+++ b/src/atlas/projection/detail/LonLatProjection.h
@@ -41,7 +41,7 @@ public:
     void xy2lonlat( double crd[] ) const override { rotation_.rotate( crd ); }
     void lonlat2xy( double crd[] ) const override { rotation_.unrotate( crd ); }
 
-    Jacobian getJacobianAtLonLat (const PointLonLat &) const override;
+    Jacobian jacobian (const PointLonLat &) const override;
 
     bool strictlyRegional() const override { return false; }
     RectangularLonLatDomain lonlatBoundingBox( const Domain& ) const override;

--- a/src/atlas/projection/detail/MercatorProjection.cc
+++ b/src/atlas/projection/detail/MercatorProjection.cc
@@ -16,6 +16,7 @@
 
 #include "atlas/projection/detail/MercatorProjection.h"
 #include "atlas/projection/detail/ProjectionFactory.h"
+#include "atlas/runtime/Exception.h"
 #include "atlas/util/Config.h"
 #include "atlas/util/Constants.h"
 #include "atlas/util/Earth.h"
@@ -75,6 +76,12 @@ void MercatorProjectionT<Rotation>::xy2lonlat( double crd[] ) const {
 
     // then rotate
     rotation_.rotate( crd );
+}
+
+template <typename Rotation>
+ProjectionImpl::Jacobian MercatorProjectionT<Rotation>::getJacobianAtLonLat (const PointLonLat &) const 
+{
+  throw_NotImplemented ("MercatorProjectionT::getJacobianAtLonLat", Here ());
 }
 
 // specification

--- a/src/atlas/projection/detail/MercatorProjection.cc
+++ b/src/atlas/projection/detail/MercatorProjection.cc
@@ -79,9 +79,9 @@ void MercatorProjectionT<Rotation>::xy2lonlat( double crd[] ) const {
 }
 
 template <typename Rotation>
-ProjectionImpl::Jacobian MercatorProjectionT<Rotation>::getJacobianAtLonLat (const PointLonLat &) const 
+ProjectionImpl::Jacobian MercatorProjectionT<Rotation>::jacobian (const PointLonLat &) const 
 {
-  throw_NotImplemented ("MercatorProjectionT::getJacobianAtLonLat", Here ());
+  throw_NotImplemented ("MercatorProjectionT::jacobian", Here ());
 }
 
 // specification

--- a/src/atlas/projection/detail/MercatorProjection.h
+++ b/src/atlas/projection/detail/MercatorProjection.h
@@ -31,6 +31,8 @@ public:
     void xy2lonlat( double crd[] ) const override;
     void lonlat2xy( double crd[] ) const override;
 
+    Jacobian getJacobianAtLonLat (const PointLonLat &) const override;
+
     bool strictlyRegional() const override { return true; }  // Mercator projection cannot be used for global grids
     RectangularLonLatDomain lonlatBoundingBox( const Domain& domain ) const override {
         return ProjectionImpl::lonlatBoundingBox( domain );

--- a/src/atlas/projection/detail/MercatorProjection.h
+++ b/src/atlas/projection/detail/MercatorProjection.h
@@ -31,7 +31,7 @@ public:
     void xy2lonlat( double crd[] ) const override;
     void lonlat2xy( double crd[] ) const override;
 
-    Jacobian getJacobianAtLonLat (const PointLonLat &) const override;
+    Jacobian jacobian (const PointLonLat &) const override;
 
     bool strictlyRegional() const override { return true; }  // Mercator projection cannot be used for global grids
     RectangularLonLatDomain lonlatBoundingBox( const Domain& domain ) const override {

--- a/src/atlas/projection/detail/ProjProjection.cc
+++ b/src/atlas/projection/detail/ProjProjection.cc
@@ -139,6 +139,11 @@ void ProjProjection::lonlat2xy( double crd[] ) const {
 }
 
 
+ProjectionImpl::Jacobian ProjProjection::getJacobianAtLonLat (const PointLonLat &) const 
+{
+  throw_NotImplemented ("ProjProjection::getJacobianAtLonLat", Here ());
+}
+
 PointXYZ ProjProjection::xyz( const PointLonLat& lonlat ) const {
     PJ_COORD P = proj_coord( lonlat.lon(), lonlat.lat(), 0, 0 );
     P          = proj_trans( sourceToGeocentric_, PJ_FWD, P );

--- a/src/atlas/projection/detail/ProjProjection.cc
+++ b/src/atlas/projection/detail/ProjProjection.cc
@@ -139,9 +139,9 @@ void ProjProjection::lonlat2xy( double crd[] ) const {
 }
 
 
-ProjectionImpl::Jacobian ProjProjection::getJacobianAtLonLat (const PointLonLat &) const 
+ProjectionImpl::Jacobian ProjProjection::jacobian (const PointLonLat &) const 
 {
-  throw_NotImplemented ("ProjProjection::getJacobianAtLonLat", Here ());
+  throw_NotImplemented ("ProjProjection::jacobian", Here ());
 }
 
 PointXYZ ProjProjection::xyz( const PointLonLat& lonlat ) const {

--- a/src/atlas/projection/detail/ProjProjection.h
+++ b/src/atlas/projection/detail/ProjProjection.h
@@ -55,6 +55,9 @@ public:
 
     void xy2lonlat( double[] ) const override;
     void lonlat2xy( double[] ) const override;
+
+    Jacobian getJacobianAtLonLat (const PointLonLat &) const override;
+
     PointXYZ xyz( const PointLonLat& ) const override;
 
     bool strictlyRegional() const override { return false; }

--- a/src/atlas/projection/detail/ProjProjection.h
+++ b/src/atlas/projection/detail/ProjProjection.h
@@ -56,7 +56,7 @@ public:
     void xy2lonlat( double[] ) const override;
     void lonlat2xy( double[] ) const override;
 
-    Jacobian getJacobianAtLonLat (const PointLonLat &) const override;
+    Jacobian jacobian (const PointLonLat &) const override;
 
     PointXYZ xyz( const PointLonLat& ) const override;
 

--- a/src/atlas/projection/detail/ProjectionImpl.h
+++ b/src/atlas/projection/detail/ProjectionImpl.h
@@ -37,7 +37,95 @@ namespace detail {
 class ProjectionImpl : public util::Object {
 public:
     using Spec = atlas::util::Config;
+    class Jacobian : public std::array<std::array<double, 2>, 2>
+    {
+    public:
 
+      static Jacobian Id () 
+      {
+        Jacobian id;
+        id[0] = {1.0, 0.0};
+        id[1] = {0.0, 1.0};
+        return id;
+      }
+
+      Jacobian inverse () const
+      {
+        const Jacobian & jac = *this;
+        Jacobian inv;
+        double det = jac[0][0] * jac[1][1] - jac[0][1] * jac[1][0];
+        inv[0][0] = + jac[1][1] / det;
+        inv[0][1] = - jac[0][1] / det;
+        inv[1][0] = - jac[1][0] / det;
+        inv[1][1] = + jac[0][0] / det;
+        return inv;
+      };
+
+      Jacobian transpose () const
+      {
+        Jacobian tra = *this;
+        std::swap (tra[0][1], tra[1][0]);
+        return tra;
+      };
+
+      Jacobian operator - (const Jacobian & jac2) const
+      {
+        const Jacobian & jac1 = *this;
+        Jacobian jac;
+        jac[0][0] = jac1[0][0] - jac2[0][0]; jac[0][1] = jac1[0][1] - jac2[0][1];
+        jac[1][0] = jac1[1][0] - jac2[1][0]; jac[1][1] = jac1[1][1] - jac2[1][1];
+        return jac;
+      }
+
+      Jacobian operator + (const Jacobian & jac2) const
+      {
+        const Jacobian & jac1 = *this;
+        Jacobian jac;
+        jac[0][0] = jac1[0][0] + jac2[0][0]; jac[0][1] = jac1[0][1] + jac2[0][1];
+        jac[1][0] = jac1[1][0] + jac2[1][0]; jac[1][1] = jac1[1][1] + jac2[1][1];
+        return jac;
+      }
+
+      double norm () const
+      {
+        const Jacobian & jac = *this;
+        return sqrt (jac[0][0] * jac[0][0] + jac[0][1] * jac[0][1]
+                   + jac[1][0] * jac[1][0] + jac[1][1] * jac[1][1]);
+      }
+
+      Jacobian operator * (const Jacobian & jac2) const
+      {
+        const Jacobian & jac1 = *this;
+        Jacobian jac;
+        jac[0][0] = jac1[0][0] * jac2[0][0] + jac1[0][1] * jac2[1][0];
+        jac[0][1] = jac1[0][0] * jac2[0][1] + jac1[0][1] * jac2[1][1];
+        jac[1][0] = jac1[1][0] * jac2[0][0] + jac1[1][1] * jac2[1][0];
+        jac[1][1] = jac1[1][0] * jac2[0][1] + jac1[1][1] * jac2[1][1];
+        return jac;
+      }
+
+      double dx_dlon () const { const Jacobian & jac = *this; return jac[JDX][JDLON]; }
+      double dy_dlon () const { const Jacobian & jac = *this; return jac[JDY][JDLON]; }
+      double dx_dlat () const { const Jacobian & jac = *this; return jac[JDX][JDLAT]; }
+      double dy_dlat () const { const Jacobian & jac = *this; return jac[JDY][JDLAT]; }
+      
+      double dlon_dx () const { const Jacobian & jac = *this; return jac[JDLON][JDX]; }
+      double dlon_dy () const { const Jacobian & jac = *this; return jac[JDLON][JDY]; }
+      double dlat_dx () const { const Jacobian & jac = *this; return jac[JDLAT][JDX]; }
+      double dlat_dy () const { const Jacobian & jac = *this; return jac[JDLAT][JDY]; }
+      
+    private:
+      enum
+      {
+        JDX=0, 
+        JDY=1
+      };
+      enum
+      {
+        JDLON=0,
+        JDLAT=1
+      };
+    };
 public:
     static const ProjectionImpl* create( const eckit::Parametrisation& p );
 
@@ -48,6 +136,8 @@ public:
 
     virtual void xy2lonlat( double crd[] ) const = 0;
     virtual void lonlat2xy( double crd[] ) const = 0;
+
+    virtual Jacobian getJacobianAtLonLat (const PointLonLat &) const = 0;
 
     void xy2lonlat( Point2& ) const;
     void lonlat2xy( Point2& ) const;

--- a/src/atlas/projection/detail/ProjectionImpl.h
+++ b/src/atlas/projection/detail/ProjectionImpl.h
@@ -137,7 +137,7 @@ public:
     virtual void xy2lonlat( double crd[] ) const = 0;
     virtual void lonlat2xy( double crd[] ) const = 0;
 
-    virtual Jacobian getJacobianAtLonLat (const PointLonLat &) const = 0;
+    virtual Jacobian jacobian (const PointLonLat &) const = 0;
 
     void xy2lonlat( Point2& ) const;
     void lonlat2xy( Point2& ) const;

--- a/src/atlas/projection/detail/SchmidtProjection.cc
+++ b/src/atlas/projection/detail/SchmidtProjection.cc
@@ -18,6 +18,7 @@
 #include "atlas/runtime/Exception.h"
 #include "atlas/util/Config.h"
 #include "atlas/util/Constants.h"
+#include "atlas/util/UnitSphere.h"
 
 namespace {
 static double D2R( const double x ) {
@@ -63,6 +64,57 @@ void SchmidtProjectionT<Rotation>::lonlat2xy( double crd[] ) const {
     // unstretch
     crd[1] =
         R2D( std::asin( std::cos( 2. * std::atan( c_ * std::tan( std::acos( std::sin( D2R( crd[1] ) ) ) * 0.5 ) ) ) ) );
+}
+
+template <>
+ProjectionImpl::Jacobian SchmidtProjectionT<NotRotated>::getJacobianAtLonLat (const PointLonLat &) const 
+{
+  throw_NotImplemented ("SchmidtProjectionT<NotRotated>::getJacobianAtLonLat", Here ());
+}
+
+template <typename Rotation>
+ProjectionImpl::Jacobian SchmidtProjectionT<Rotation>::getJacobianAtLonLat (const PointLonLat & lonlat) const 
+{
+
+  double xy[2] = {lonlat.lon (), lonlat.lat ()};
+
+  lonlat2xy (xy);
+
+  PointXYZ xyz, north1, north0 (0.0, 0.0, 1.0);
+  atlas::util::UnitSphere::convertSphericalToCartesian (rotation_.northPole (), north1);
+  atlas::util::UnitSphere::convertSphericalToCartesian (lonlat, xyz);
+
+  north1 = PointXYZ::normalize (north1);
+
+// Base vectors in unrotated frame
+  auto u0 = PointXYZ::normalize (PointXYZ::cross (north0, xyz));
+  auto v0 = PointXYZ::normalize (PointXYZ::cross (xyz, u0));
+
+// Base vectors in rotated frame
+  auto u1 = PointXYZ::normalize (PointXYZ::cross (north1, xyz));
+  auto v1 = PointXYZ::normalize (PointXYZ::cross (xyz, u1));
+
+  double u0u1 = PointXYZ::dot (u0, u1);
+  double v0u1 = PointXYZ::dot (v0, u1);
+  double u0v1 = PointXYZ::dot (u0, v1);
+  double v0v1 = PointXYZ::dot (v0, v1);
+
+  Jacobian jac;
+
+  double zomc2 = 1.0 - 1.0 / (c_ * c_);
+  double zopc2 = 1.0 + 1.0 / (c_ * c_);
+
+  double zcosy = cos (D2R (xy[1])), zsiny = sin (D2R (xy[1]));
+  double zcoslat = cos (D2R (lonlat.lat ()));
+
+  double zfactor = sqrt ((zopc2 + zsiny * zomc2) * (zopc2 + zsiny * zomc2) 
+                       / (zopc2 * zopc2 - zomc2 * zomc2));
+
+
+  jac[0] = {zcoslat * u0u1 * zfactor / zcosy, v0u1 * zfactor / zcosy};
+  jac[1] = {zcoslat * u0v1 * zfactor        , v0v1 * zfactor        };
+
+  return jac;
 }
 
 // specification

--- a/src/atlas/projection/detail/SchmidtProjection.cc
+++ b/src/atlas/projection/detail/SchmidtProjection.cc
@@ -67,13 +67,13 @@ void SchmidtProjectionT<Rotation>::lonlat2xy( double crd[] ) const {
 }
 
 template <>
-ProjectionImpl::Jacobian SchmidtProjectionT<NotRotated>::getJacobianAtLonLat (const PointLonLat &) const 
+ProjectionImpl::Jacobian SchmidtProjectionT<NotRotated>::jacobian (const PointLonLat &) const 
 {
-  throw_NotImplemented ("SchmidtProjectionT<NotRotated>::getJacobianAtLonLat", Here ());
+  throw_NotImplemented ("SchmidtProjectionT<NotRotated>::jacobian", Here ());
 }
 
 template <typename Rotation>
-ProjectionImpl::Jacobian SchmidtProjectionT<Rotation>::getJacobianAtLonLat (const PointLonLat & lonlat) const 
+ProjectionImpl::Jacobian SchmidtProjectionT<Rotation>::jacobian (const PointLonLat & lonlat) const 
 {
 
   double xy[2] = {lonlat.lon (), lonlat.lat ()};

--- a/src/atlas/projection/detail/SchmidtProjection.h
+++ b/src/atlas/projection/detail/SchmidtProjection.h
@@ -32,6 +32,8 @@ public:
     void xy2lonlat( double crd[] ) const override;
     void lonlat2xy( double crd[] ) const override;
 
+    Jacobian getJacobianAtLonLat (const PointLonLat &) const override;
+
     bool strictlyRegional() const override { return false; }  // schmidt is global grid
     RectangularLonLatDomain lonlatBoundingBox( const Domain& domain ) const override {
         return ProjectionImpl::lonlatBoundingBox( domain );

--- a/src/atlas/projection/detail/SchmidtProjection.h
+++ b/src/atlas/projection/detail/SchmidtProjection.h
@@ -32,7 +32,7 @@ public:
     void xy2lonlat( double crd[] ) const override;
     void lonlat2xy( double crd[] ) const override;
 
-    Jacobian getJacobianAtLonLat (const PointLonLat &) const override;
+    Jacobian jacobian (const PointLonLat &) const override;
 
     bool strictlyRegional() const override { return false; }  // schmidt is global grid
     RectangularLonLatDomain lonlatBoundingBox( const Domain& domain ) const override {

--- a/src/tests/projection/CMakeLists.txt
+++ b/src/tests/projection/CMakeLists.txt
@@ -9,6 +9,7 @@
 foreach(test
           test_bounding_box
           test_projection_LAEA
+          test_jacobian
           test_rotation )
 
     ecbuild_add_test( TARGET atlas_${test} SOURCES ${test}.cc LIBS atlas ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )

--- a/src/tests/projection/test_jacobian.cc
+++ b/src/tests/projection/test_jacobian.cc
@@ -1,0 +1,175 @@
+/*
+ * (C) Copyright 2013 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+
+#include "atlas/projection.h"
+#include "atlas/grid.h"
+#include "atlas/util/Config.h"
+#include "atlas/util/Point.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+
+namespace atlas {
+namespace test {
+
+//-----------------------------------------------------------------------------
+
+
+atlas::Projection::Jacobian
+getJacobian (const atlas::Projection & proj, const atlas::PointLonLat & lonlat0)
+{
+  double dlon = 0.0001, dlat = 0.0001;
+
+  double xy0[2] = {lonlat0.lon () + 0.00, lonlat0.lat () + 0.00};
+  double xy1[2] = {lonlat0.lon () + dlon, lonlat0.lat () + 0.00};
+  double xy2[2] = {lonlat0.lon () + 0.00, lonlat0.lat () + dlat};
+
+  proj.lonlat2xy (xy0);
+  proj.lonlat2xy (xy1);
+  proj.lonlat2xy (xy2);
+
+  atlas::Projection::Jacobian jac;
+
+  jac[0] = {(xy1[0] - xy0[0]) / dlon, (xy2[0] - xy0[0]) / dlat};
+  jac[1] = {(xy1[1] - xy0[1]) / dlon, (xy2[1] - xy0[1]) / dlat};
+
+  return jac;
+}
+
+void printJacobian (const atlas::Projection::Jacobian & jac, const std::string & name)
+{
+  printf (" %s = \n", name.c_str ());
+  printf ("  %12.4f, %12.4f | %12.4f\n", jac[0][0], jac[0][1], sqrt (jac[0][0] * jac[0][0] + jac[0][1] * jac[0][1]));
+  printf ("  %12.4f, %12.4f | %12.4f\n", jac[1][0], jac[1][1], sqrt (jac[1][0] * jac[1][0] + jac[1][1] * jac[1][1]));
+  printf ("  %12.4f, %12.4f\n", sqrt (jac[0][0] * jac[0][0] + jac[1][0] * jac[1][0]),
+                                sqrt (jac[0][1] * jac[0][1] + jac[1][1] * jac[1][1]));
+}
+
+template <typename SKIP>
+void doTaylorTest (const atlas::StructuredGrid & grid, double dmax, SKIP skip)
+{
+  const auto & proj = grid.projection ();
+
+  for (int j = 0, jglo = 0; j < grid.ny ( ); j++)
+  for (int i = 0; i < grid.nx (j); i++, jglo++)
+  if (! skip (grid, i, j))
+    {
+      double lonlat[2];
+      grid.lonlat (i, j, lonlat);
+
+      auto jacA = proj.getJacobianAtLonLat (atlas::PointLonLat (lonlat[0], lonlat[1]));
+      auto jacB = getJacobian (proj, atlas::PointLonLat (lonlat[0], lonlat[1]));
+      auto jacC = jacB * jacA.inverse () - atlas::Projection::Jacobian::Id ();
+
+      double diff = jacC.norm ();
+
+      if (diff > dmax)
+        {
+          printf ("------------------\n");
+          printf (" i, j = %8d, %8d\n", i, j);
+          printJacobian (jacA, "jacA");
+          printf ("\n");
+          printJacobian (jacB, "jacB");
+          printf ("\n");
+          printf ("%12.4e\n", diff);
+          printf ("\n");
+        }
+
+      EXPECT (diff < dmax);
+    }
+
+}
+
+
+void doTaylorTest (const atlas::StructuredGrid & grid, double dmax)
+{
+  auto noskip = [] (const atlas::StructuredGrid & grid, int i, int j) { return false; };
+  doTaylorTest (grid, dmax, noskip);
+}
+
+CASE ("test_rotated_schmidt")
+{
+
+  const std::vector<int> nx =
+  { 
+    20, 27, 32, 40, 45, 48, 60, 60, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 60, 60, 48, 45, 40, 32, 27, 20
+  };
+  
+  const double stretch = 2.4, centre[2] = {2.0, 46.7};
+  
+  std::vector<atlas::grid::Spacing> spacings (nx.size ());
+  
+  for (int i = 0; i < nx.size (); i++)
+    {   
+      double lonmax = 360.0 * double (nx[i] - 1) / double (nx[i]);
+      spacings[i] = atlas::grid::Spacing (atlas::util::Config ("type", "linear") | atlas::util::Config ("N", nx[i])
+                                        | atlas::util::Config ("start", 0) | atlas::util::Config ("end", lonmax));
+    }
+  
+  atlas::StructuredGrid::XSpace xspace (spacings);
+  atlas::StructuredGrid::YSpace yspace (atlas::util::Config ("type", "gaussian") | atlas::util::Config ("N", nx.size ()));
+  
+  auto
+  proj = atlas::Projection (atlas::util::Config ("type", "rotated_schmidt") 
+                          | atlas::util::Config ("stretching_factor", stretch)
+                          | atlas::util::Config ("rotation_angle", 0.0)
+                          | atlas::util::Config ("north_pole", std::vector<double>{centre[0], centre[1]})
+                          | atlas::util::Config ("arpege", true));
+  
+
+  doTaylorTest (atlas::StructuredGrid (xspace, yspace, proj, atlas::Domain (atlas::util::Config ("type", "global"))), 1e-3,
+  // Avoid large jumps of pseudo-longitude (ie 359.5 -> 0)
+                [] (const atlas::StructuredGrid & grid, int i, int j) { return (i == 0) || (i == grid.nx (j) - 1) || (i == grid.nx (j) / 2); });
+}
+
+
+CASE ("test_lambert_conformal_conic")
+{
+  const int Nx = 64, Ny = 64, Nux = 53, Nuy = 53; 
+  const double DxInMetres = 50000., DyInMetres = 50000.;
+  const double LaDInDegrees = 46.2, Latin1InDegrees = 46.2, Latin2InDegrees = 46.2, LoVInDegrees = 2.0;
+  const double XMinInMeters = -Nux / 2 * DxInMetres, YMinInMetres = -Nuy / 2 * DyInMetres;
+  
+  std::vector<atlas::grid::Spacing> spacings (Ny);
+  
+  for (int i = 0; i < Ny; i++)
+    spacings[i] = atlas::grid::Spacing (atlas::util::Config ("type", "linear") | atlas::util::Config ("N", Nx) 
+                                      | atlas::util::Config ("start", XMinInMeters) 
+                                      | atlas::util::Config ("end", XMinInMeters + (Nx - 1) * DxInMetres));
+  
+  atlas::StructuredGrid::XSpace xspace (spacings);
+  atlas::StructuredGrid::YSpace yspace (atlas::util::Config ("type", "linear") | atlas::util::Config ("N", Ny) 
+                                      | atlas::util::Config ("start", YMinInMetres) 
+                                      | atlas::util::Config ("end", YMinInMetres + (Ny - 1 ) * DyInMetres));
+
+  auto proj = atlas::Projection (atlas::util::Config ("type", "lambert_conformal_conic") | atlas::util::Config ("longitude0", LoVInDegrees)
+                               | atlas::util::Config ("latitude0", LaDInDegrees) | atlas::util::Config ("latitude1", Latin1InDegrees) 
+                               | atlas::util::Config ("latitude2", Latin2InDegrees));
+  
+  doTaylorTest (atlas::StructuredGrid (xspace, yspace, proj, atlas::Domain ()), 1e-6);
+}
+
+CASE ("test_lonlat")
+{
+  doTaylorTest (atlas::StructuredGrid ("N16"), 1e-9);
+}
+
+
+
+//-----------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace atlas
+
+int main( int argc, char** argv ) {
+    return atlas::test::run( argc, argv );
+}

--- a/src/tests/projection/test_jacobian.cc
+++ b/src/tests/projection/test_jacobian.cc
@@ -65,7 +65,7 @@ void doTaylorTest (const atlas::StructuredGrid & grid, double dmax, SKIP skip)
       double lonlat[2];
       grid.lonlat (i, j, lonlat);
 
-      auto jacA = proj.getJacobianAtLonLat (atlas::PointLonLat (lonlat[0], lonlat[1]));
+      auto jacA = proj.jacobian (atlas::PointLonLat (lonlat[0], lonlat[1]));
       auto jacB = getJacobian (proj, atlas::PointLonLat (lonlat[0], lonlat[1]));
       auto jacC = jacB * jacA.inverse () - atlas::Projection::Jacobian::Id ();
 


### PR DESCRIPTION
Solves issue #39 .

The jacobian method (ie dx/dlon, dx/dlat, dy/dlon, dy/dlat) is implemented for the following projections : 
- unrotated lon/lat (trivial 2x2 id matrix)
- rotated Schmidt transform
- Lambert conformal conic projection

A Taylor test has been added to test these jacobians.
