### PR TITLE
Support memoryfree distributions

### DIFF
--- a/src/atlas/functionspace/detail/StructuredColumns_setup.cc
+++ b/src/atlas/functionspace/detail/StructuredColumns_setup.cc
@@ -180,13 +180,13 @@ void StructuredColumns::setup( const grid::Distribution& distribution, const eck
                     auto& __j_end         = thread_reduce_j_end[thread_num];
                     auto& __owned         = thread_reduce_owned[thread_num];
                     idx_t c               = begin;
-                    const auto& partition = distribution.partition();
+
                     for ( idx_t j = thread_j_begin; j < thread_j_end; ++j ) {
                         auto& __i_begin = thread_reduce_i_begin[j][thread_num];
                         auto& __i_end   = thread_reduce_i_end[j][thread_num];
                         bool j_in_partition{false};
                         for ( idx_t i = thread_i_begin[j]; i < thread_i_end[j]; ++i, ++c ) {
-                            if ( partition[c] == mpi_rank ) {
+                            if ( distribution.partition (c) == mpi_rank ) {
                                 j_in_partition = true;
                                 __i_begin      = std::min<idx_t>( __i_begin, i );
                                 __i_end        = std::max<idx_t>( __i_end, i + 1 );
@@ -542,7 +542,6 @@ void StructuredColumns::setup( const grid::Distribution& distribution, const eck
         auto index_i    = array::make_indexview<idx_t, 1>( field_index_i_ );
         auto index_j    = array::make_indexview<idx_t, 1>( field_index_j_ );
 
-        const auto& partition = distribution.partition();
         atlas_omp_parallel_for( idx_t n = 0; n < gridpoints.size(); ++n ) {
             const GridPoint& gp = gridpoints[n];
             if ( gp.j >= 0 && gp.j < grid_->ny() ) {
@@ -559,7 +558,7 @@ void StructuredColumns::setup( const grid::Distribution& distribution, const eck
                 if ( gp.i >= 0 && gp.i < grid_->nx( gp.j ) ) {
                     in_domain          = true;
                     gidx_t k           = global_offsets[gp.j] + gp.i;
-                    part( gp.r )       = partition[k];
+                    part( gp.r )       = distribution.partition (k);
                     global_idx( gp.r ) = k + 1;
                 }
             }

--- a/src/atlas/grid/Distribution.cc
+++ b/src/atlas/grid/Distribution.cc
@@ -22,6 +22,7 @@ namespace atlas {
 namespace grid {
 
 Distribution::Distribution( const Grid& grid ) : Handle( new Implementation( grid ) ) {}
+Distribution::Distribution( const Grid& grid, const Config & config ) : Handle( new Implementation( grid, config ) ) {}
 
 Distribution::Distribution( const Grid& grid, const Partitioner& partitioner ) :
     Handle( new Implementation( grid, partitioner ) ) {}
@@ -33,10 +34,6 @@ Distribution::Distribution( int nb_partitions, partition_t&& part ) :
     Handle( new Implementation( nb_partitions, std::move( part ) ) ) {}
 
 Distribution::~Distribution() = default;
-
-int Distribution::partition( const gidx_t gidx ) const {
-    return get()->partition( gidx );
-}
 
 const Distribution::partition_t& Distribution::partition() const {
     return get()->partition();

--- a/src/atlas/grid/Distribution.h
+++ b/src/atlas/grid/Distribution.h
@@ -15,6 +15,7 @@
 #include "atlas/grid/detail/distribution/DistributionImpl.h"
 #include "atlas/library/config.h"
 #include "atlas/util/ObjectHandle.h"
+#include "atlas/util/Config.h"
 
 namespace atlas {
 class Grid;
@@ -33,11 +34,14 @@ class Distribution : DOXYGEN_HIDE( public util::ObjectHandle<DistributionImpl> )
 
 public:
     using partition_t = DistributionImpl::partition_t;
+    using Config = DistributionImpl::Config;
 
     using Handle::Handle;
     Distribution() = default;
 
     Distribution( const Grid& );
+
+    Distribution( const Grid&, const Config& );
 
     Distribution( const Grid&, const Partitioner& );
 
@@ -47,7 +51,16 @@ public:
 
     ~Distribution();
 
-    int partition( const gidx_t gidx ) const;
+    // This method has to be inlined
+    int partition( const gidx_t gidx ) const
+    {
+      return get()->partition( gidx );
+    }
+
+    size_t footprint () const
+    {
+      return get()->footprint ();
+    }
 
     const partition_t& partition() const;
 

--- a/src/atlas/grid/Partitioner.cc
+++ b/src/atlas/grid/Partitioner.cc
@@ -43,7 +43,7 @@ detail::partitioner::Partitioner* partitioner_from_config( const Partitioner::Co
         throw_Exception( "'type' missing in configuration for Partitioner", Here() );
     }
     config.get( "partitions", partitions );
-    return Factory::build( type, partitions );
+    return Factory::build( type, partitions, config );
 }
 }  // namespace
 

--- a/src/atlas/grid/detail/distribution/DistributionImpl.h
+++ b/src/atlas/grid/detail/distribution/DistributionImpl.h
@@ -29,8 +29,6 @@ class Grid;
 namespace grid {
 class Partitioner;
 }
-}
-
 }  // namespace atlas
 
 namespace atlas {

--- a/src/atlas/grid/detail/partitioner/CheckerboardPartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/CheckerboardPartitioner.cc
@@ -41,6 +41,12 @@ CheckerboardPartitioner::CheckerboardPartitioner( int N ) : Partitioner( N ) {
     checkerboard_ = true;  // default
 }
 
+CheckerboardPartitioner::CheckerboardPartitioner( int N, const eckit::Parametrisation & config ) : Partitioner( N ) {
+    nbands_       = 0;     // to be computed later
+    config.get ("nbands", nbands_);
+    checkerboard_ = true;  // default
+}
+
 CheckerboardPartitioner::CheckerboardPartitioner( int N, int nbands ) : Partitioner( N ) {
     nbands_       = nbands;
     checkerboard_ = true;  // default

--- a/src/atlas/grid/detail/partitioner/CheckerboardPartitioner.h
+++ b/src/atlas/grid/detail/partitioner/CheckerboardPartitioner.h
@@ -24,6 +24,7 @@ public:
     CheckerboardPartitioner();
 
     CheckerboardPartitioner( int N );  // N is the number of parts (aka MPI tasks)
+    CheckerboardPartitioner( int N, const eckit::Parametrisation & );  
 
     CheckerboardPartitioner( int N, int nbands );
     CheckerboardPartitioner( int N, int nbands, bool checkerboard );

--- a/src/atlas/grid/detail/partitioner/EqualRegionsPartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/EqualRegionsPartitioner.cc
@@ -433,7 +433,8 @@ void eq_regions( int N, double xmin[], double xmax[], double ymin[], double ymax
     ymax[N - 1] = 0.5 * M_PI - s_cap[s_cap.size() - 2];
 }
 
-EqualRegionsPartitioner::EqualRegionsPartitioner() : Partitioner(), N_( nb_partitions() ) {
+void EqualRegionsPartitioner:: init ()
+{
     std::vector<double> s_cap;
     eq_caps( N_, sectors_, s_cap );
     bands_.resize( s_cap.size() );
@@ -442,13 +443,16 @@ EqualRegionsPartitioner::EqualRegionsPartitioner() : Partitioner(), N_( nb_parti
     }
 }
 
+EqualRegionsPartitioner::EqualRegionsPartitioner() : Partitioner(), N_( nb_partitions() ) {
+    init ();
+}
+
 EqualRegionsPartitioner::EqualRegionsPartitioner( int N ) : Partitioner( N ), N_( N ) {
-    std::vector<double> s_cap;
-    eq_caps( N_, sectors_, s_cap );
-    bands_.resize( s_cap.size() );
-    for ( size_t n = 0; n < s_cap.size(); ++n ) {
-        bands_[n] = 0.5 * M_PI - s_cap[n];
-    }
+    init ();
+}
+
+EqualRegionsPartitioner::EqualRegionsPartitioner( int N, const eckit::Parametrisation & config ) : Partitioner( N ), N_( N ) {
+    init ();
 }
 
 int EqualRegionsPartitioner::partition( const double& x, const double& y ) const {

--- a/src/atlas/grid/detail/partitioner/EqualRegionsPartitioner.h
+++ b/src/atlas/grid/detail/partitioner/EqualRegionsPartitioner.h
@@ -80,6 +80,7 @@ public:
     EqualRegionsPartitioner();
 
     EqualRegionsPartitioner( int N );
+    EqualRegionsPartitioner( int N, const eckit::Parametrisation & config );
 
     void where( int partition, int& band, int& sector ) const;
     int nb_bands() const { return bands_.size(); }
@@ -113,6 +114,7 @@ public:
     };
 
 private:
+    void init ();
     // Doesn't matter if nodes[] is in degrees or radians, as a sorting
     // algorithm is used internally
     void partition( int nb_nodes, NodeInt nodes[], int part[] ) const;

--- a/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerBruteForce.h
+++ b/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerBruteForce.h
@@ -24,6 +24,7 @@ public:
 public:
     MatchingMeshPartitionerBruteForce() : MatchingMeshPartitioner() {}
     MatchingMeshPartitionerBruteForce( const idx_t nb_partitions ) : MatchingMeshPartitioner( nb_partitions ) {}
+    MatchingMeshPartitionerBruteForce( const idx_t nb_partitions, const eckit::Parametrisation & ) : MatchingMeshPartitioner( nb_partitions ) {}
     MatchingMeshPartitionerBruteForce( const Mesh& mesh ) : MatchingMeshPartitioner( mesh ) {}
 
     virtual void partition( const Grid& grid, int partitioning[] ) const;

--- a/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerLonLatPolygon.h
+++ b/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerLonLatPolygon.h
@@ -24,6 +24,7 @@ public:
 public:
     MatchingMeshPartitionerLonLatPolygon() : MatchingMeshPartitioner() {}
     MatchingMeshPartitionerLonLatPolygon( const size_t nb_partitions ) : MatchingMeshPartitioner( nb_partitions ) {}
+    MatchingMeshPartitionerLonLatPolygon( const size_t nb_partitions, const eckit::Parametrisation & config ) : MatchingMeshPartitioner( nb_partitions ) {}
     MatchingMeshPartitionerLonLatPolygon( const Mesh& mesh ) : MatchingMeshPartitioner( mesh ) {}
 
     /**

--- a/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerSphericalPolygon.h
+++ b/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerSphericalPolygon.h
@@ -24,6 +24,7 @@ public:
 public:
     MatchingMeshPartitionerSphericalPolygon() : MatchingMeshPartitioner() {}
     MatchingMeshPartitionerSphericalPolygon( const idx_t nb_partitions ) : MatchingMeshPartitioner( nb_partitions ) {}
+    MatchingMeshPartitionerSphericalPolygon( const idx_t nb_partitions, const eckit::Parametrisation & config ) : MatchingMeshPartitioner( nb_partitions ) {}
     MatchingMeshPartitionerSphericalPolygon( const Mesh& mesh ) : MatchingMeshPartitioner( mesh ) {}
 
     /**

--- a/src/atlas/grid/detail/partitioner/Partitioner.cc
+++ b/src/atlas/grid/detail/partitioner/Partitioner.cc
@@ -16,6 +16,7 @@
 #include "eckit/thread/AutoLock.h"
 #include "eckit/thread/Mutex.h"
 
+#include "atlas/util/Config.h"
 #include "atlas/grid/Distribution.h"
 #include "atlas/grid/Partitioner.h"
 #include "atlas/grid/detail/partitioner/CheckerboardPartitioner.h"
@@ -148,6 +149,11 @@ Partitioner* PartitionerFactory::build( const std::string& name ) {
 }
 
 Partitioner* PartitionerFactory::build( const std::string& name, const idx_t nb_partitions ) {
+    atlas::util::Config config;
+    return build (name, nb_partitions, config);
+}
+
+Partitioner* PartitionerFactory::build( const std::string& name, const idx_t nb_partitions, const eckit::Parametrisation & config ) {
     pthread_once( &once, init );
 
     eckit::AutoLock<eckit::Mutex> lock( local_mutex );
@@ -167,7 +173,7 @@ Partitioner* PartitionerFactory::build( const std::string& name, const idx_t nb_
         throw_Exception( std::string( "No PartitionerFactory called " ) + name );
     }
 
-    return ( *j ).second->make( nb_partitions );
+    return ( *j ).second->make( nb_partitions, config );
 }
 
 

--- a/src/atlas/grid/detail/partitioner/Partitioner.h
+++ b/src/atlas/grid/detail/partitioner/Partitioner.h
@@ -13,7 +13,7 @@
 #include <string>
 
 #include "atlas/util/Object.h"
-
+#include "atlas/util/Config.h"
 #include "atlas/library/config.h"
 
 namespace atlas {
@@ -64,6 +64,7 @@ public:
    */
     static Partitioner* build( const std::string& );
     static Partitioner* build( const std::string&, const idx_t nb_partitions );
+    static Partitioner* build( const std::string&, const idx_t nb_partitions, const eckit::Parametrisation & );
 
     /*!
    * \brief list all registered partioner builders
@@ -73,8 +74,9 @@ public:
 
 private:
     std::string name_;
-    virtual Partitioner* make()                            = 0;
-    virtual Partitioner* make( const idx_t nb_partitions ) = 0;
+    virtual Partitioner* make()                                                            = 0;
+    virtual Partitioner* make( const idx_t nb_partitions )                                 = 0;
+    virtual Partitioner* make( const idx_t nb_partitions, const eckit::Parametrisation & ) = 0;
 
 protected:
     PartitionerFactory( const std::string& );
@@ -88,6 +90,7 @@ class PartitionerBuilder : public PartitionerFactory {
     virtual Partitioner* make() { return new T(); }
 
     virtual Partitioner* make( const idx_t nb_partitions ) { return new T( nb_partitions ); }
+    virtual Partitioner* make( const idx_t nb_partitions, const eckit::Parametrisation & config ) { return new T( nb_partitions, config ); }
 
 public:
     PartitionerBuilder( const std::string& name ) : PartitionerFactory( name ) {}

--- a/src/tests/grid/CMakeLists.txt
+++ b/src/tests/grid/CMakeLists.txt
@@ -25,6 +25,7 @@ foreach(test
         test_grid_cropping
         test_vertical
         test_state
+        test_distribution
         test_grid_hash)
 
     ecbuild_add_test( TARGET atlas_${test} SOURCES ${test}.cc LIBS atlas ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )

--- a/src/tests/grid/test_distribution.cc
+++ b/src/tests/grid/test_distribution.cc
@@ -1,0 +1,75 @@
+/*
+ * (C) Copyright 2013 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <algorithm>
+#include <iomanip>
+#include <sstream>
+
+#include "atlas/grid.h"
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/util/Config.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using Grid   = atlas::Grid;
+using Config = atlas::util::Config;
+
+namespace atlas {
+namespace test {
+
+//-----------------------------------------------------------------------------
+
+CASE( "test_nbands" ) 
+{
+  auto & comm = atlas::mpi::comm ();
+  int nproc = comm.size ();
+
+  StructuredGrid grid = Grid ("L200x100");
+  atlas::grid::Distribution dist (grid, atlas::util::Config ("type", "checkerboard") | Config ("nbands", nproc));
+
+  for (int i = 1; i < grid.size (); i++)
+    EXPECT (dist.partition (i-1) <= dist.partition (i));
+}
+
+CASE( "test_light" ) 
+{
+  auto & comm = atlas::mpi::comm ();
+  int nproc = comm.size ();
+
+  const int nx = 400, ny = 200;
+
+  StructuredGrid grid = Grid (std::string ("L") + std::to_string (nx) + "x" + std::to_string (ny));
+  atlas::grid::Distribution dist1 (grid, atlas::util::Config ("type", "checkerboard") | Config ("nbands", nproc));
+
+  atlas::grid::Distribution dist2 (grid, Config ("light", true) | Config ("blocksize", nx));
+  
+  EXPECT (dist2.footprint () < 100);
+
+  if ((ny % nproc) == 0)
+  for (int i = 0; i < grid.size (); i++)
+    EXPECT (dist1.partition (i) == dist2.partition (i));
+
+  for (int iy = 0, jglo = 0; iy < ny; iy++)
+    {
+      int jglo0 = jglo;
+      for (int ix = 0; ix < nx; ix++, jglo++)
+        EXPECT (dist2.partition (jglo) == dist2.partition (jglo0));
+    }
+
+}
+
+//-----------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace atlas
+
+int main( int argc, char** argv ) {
+    return atlas::test::run( argc, argv );
+}

--- a/src/tests/grid/test_distribution.cc
+++ b/src/tests/grid/test_distribution.cc
@@ -69,24 +69,6 @@ CASE( "test_light" )
   auto & comm = atlas::mpi::comm ();
   int nproc = comm.size ();
 
-  {
-    char f[128];
-    sprintf (f, "pid.%4.4d.txt", comm.rank ());  
-    FILE * fp = fopen (f, "w");
-    fprintf (fp, "%d\n", getpid ());
-    fclose (fp);
-  }
-
-  while (1)
-    {
-      struct stat st;
-      comm.barrier ();
-      if (stat ("go", &st) == 0)
-        break;
-      sleep (1);
-    }
-
-
   const int nx = 400, ny = 200;
 
   StructuredGrid grid = Grid (std::string ("L") + std::to_string (nx) + "x" + std::to_string (ny));
@@ -127,7 +109,6 @@ CASE( "test_light" )
 
   fs1.haloExchange (ij1);
   fs2.haloExchange (ij2);
-#ifdef UNDEF
 
   if (same)
     {
@@ -152,7 +133,6 @@ CASE( "test_light" )
        EXPECT (fs2.i_begin_halo (j) == -1);
        EXPECT (fs2.i_end_halo (j) == nx + 2);
      }
-#endif
 
 }
 


### PR DESCRIPTION
Solves issue #41 .

Allows creating a distribution using a Config object. This Config object is either used directly by the DistributionImpl class, or passed to the Partitioner class.

A nbands option was added to the CheckerBoard partitioner; this option makes it possible to ask for a partition with nbands stripes along the N/S direction. 

A light option was added to the DistributionImpl ctor; setting this option to true creates a trivial N/S partition. The blocksize option makes it possible to force the size of each MPI partition to be a multiple of this value (useful for lat/lon grids). When this light option is enabled, the big partition array is not allocated; instead (as this partitioning is very simple), we directly can compute the rank each point belongs to.

To be efficient, the partition method of the Distribution class had to be implemented in the header file, so that it be inlined. The setup of the functionspace StructuredColumns (which is the one we intend to use) has been modified so that it uses this accessor method, instead of requesting access to the big partition array.

A test case has been added to demonstrate the use of the light and nbands options.



