### PR TITLE
Copy constructor & assignment operator for atlas::vector

### DIFF
--- a/src/atlas/util/vector.h
+++ b/src/atlas/util/vector.h
@@ -37,10 +37,24 @@ public:
         assign( size, value );
     }
 
-    vector( vector&& other ) : data_( other.data_ ), size_( other.size_ ) {
-        other.data_     = nullptr;
-        other.size_     = 0;
-        other.capacity_ = 0;
+    vector (const vector & other)
+    {
+      assign (other.data_, other.data_ + other.size_);
+    }
+
+    vector (vector && other)
+    {
+      std::swap (data_, other.data_);
+      std::swap (size_, other.size_);
+      std::swap (capacity_, other.capacity_);
+    }
+    
+    vector & operator= (vector other)
+    {
+      std::swap (data_, other.data_);
+      std::swap (size_, other.size_);
+      std::swap (capacity_, other.capacity_);
+      return *this;
     }
 
     ~vector() {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -106,6 +106,7 @@ endif()
 
 add_subdirectory( acc )
 add_subdirectory( array )
+add_subdirectory( vector )
 add_subdirectory( util )
 add_subdirectory( runtime )
 add_subdirectory( parallel )

--- a/src/tests/vector/CMakeLists.txt
+++ b/src/tests/vector/CMakeLists.txt
@@ -1,0 +1,15 @@
+# (C) Copyright 2013 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+
+ecbuild_add_test( TARGET atlas_test_vector
+  SOURCES  test_vector.cc
+  LIBS     atlas
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
+

--- a/src/tests/vector/test_vector.cc
+++ b/src/tests/vector/test_vector.cc
@@ -1,0 +1,83 @@
+/*
+ * (C) Copyright 2013 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <memory>
+
+#include "atlas/util/vector.h"
+#include "atlas/library/config.h"
+#include "tests/AtlasTestEnvironment.h"
+
+namespace atlas {
+namespace test {
+
+//-----------------------------------------------------------------------------
+//
+
+
+template <typename T>
+atlas::vector<T> square (const int n)
+{
+  atlas::vector<T> x (n);
+  for (int i = 0; i < n; i++)
+    x[i] = static_cast<T> (i) * static_cast <T> (i);
+ 
+  return x;
+}
+
+template <typename T>
+void pp (const std::string & t, T & v)
+{
+  std::cout << t << " = " << std::endl;
+  std::cout << v.size () << std::endl;
+  for (int i = 0; i < v.size (); i++)
+    std::cout << i << " > " << v[i] << std::endl;
+}
+
+
+CASE( "test_vector" ) {
+
+  const int N = 100;
+
+  // Ctor
+  atlas::vector<double> x (N);
+
+  std::iota (std::begin (x), std::end (x), 0);
+
+  // Copy ctor
+  atlas::vector<double> y = x;
+
+  EXPECT (x.size () == y.size ());
+
+  for (int i = 0; i < x.size (); i++)
+    EXPECT (x[i] == y[i]);
+
+
+  // Assignment operator
+  auto z = square<int> (20);
+
+  for (int i = 0; i < z.size (); i++)
+    EXPECT (z[i] == i * i);
+
+  // Assignment operator
+  x = y;
+
+  for (int i = 0; i < x.size (); i++)
+    EXPECT (static_cast<int> (x[i]) == i);
+
+}
+
+//-----------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace atlas
+
+int main( int argc, char** argv ) {
+    return atlas::test::run( argc, argv );
+}


### PR DESCRIPTION
Solves issue #43 .

A test has been added. 

a = b

The assignment operator creates a copy of the object to be copied (b), and its contents are swapped with the object being assigned (a). The temporary copy (which holds the contents of the object being assigned, ie a) is then deleted, which implies that the memory use by a is freed.

 