### PR TITLE
Custom large grids are too expensive

### DIFF
--- a/src/atlas/grid/detail/grid/Structured.cc
+++ b/src/atlas/grid/detail/grid/Structured.cc
@@ -357,10 +357,10 @@ void Structured::crop( const Domain& dom ) {
 
     auto rect_domain = RectangularDomain( dom );
 
-    bool same = true;
+    bool samerows = true;
 
-    for (idx_t j = 0; same && (j < ny ()); j++)
-      same = same && (xmin (j) == xmin (0)) && (dx (j) == dx (0));
+    for (idx_t j = 0; samerows && (j < ny ()); j++)
+      samerows = samerows && (xmin (j) == xmin (0)) && (dx (j) == dx (0));
 
     if ( !rect_domain ) {
         std::stringstream errmsg;
@@ -395,7 +395,7 @@ void Structured::crop( const Domain& dom ) {
     // Cropping in X
     Normalise normalise( rect_domain );
     for ( idx_t j = jmin, jcropped = 0; j <= jmax; ++j, ++jcropped ) {
-        if ((j == jmin) || (! same))
+        if ((j == jmin) || (! samerows))
           {
             idx_t n = 0;
             for ( idx_t i = 0; i < nx( j ); ++i ) {
@@ -439,23 +439,16 @@ void Structured::crop( const Domain& dom ) {
     }
     idx_t cropped_npts = std::accumulate( cropped_nx.begin(), cropped_nx.end(), idx_t{0} );
 
-
-
-
     std::vector<Spacing> cropped_xspacings( cropped_ny );
     for ( idx_t j = 0; j < cropped_ny; ++j ) {
         spacing::LinearSpacing * sp = nullptr;
         idx_t i = j - 1;
-        if ((j > 0) 
-         && (cropped_xmin[i] == cropped_xmin[j]) 
-         && (cropped_xmax[i] == cropped_xmax[j]) 
-         && (cropped_nx[i] == cropped_nx[j]))
+        if ((j > 0) && samerows)
           sp = dynamic_cast<spacing::LinearSpacing*> (cropped_xspacings[i].get ());
         else
           sp = new spacing::LinearSpacing( cropped_xmin[j], cropped_xmax[j], cropped_nx[j], endpoint );
         cropped_xspacings[j] = sp;
     }
-
 
     XSpace cropped_xspace( cropped_xspacings );
 

--- a/src/atlas/grid/detail/grid/Structured.cc
+++ b/src/atlas/grid/detail/grid/Structured.cc
@@ -14,7 +14,6 @@
 #include <iomanip>
 #include <limits>
 #include <numeric>
-#include <iostream>
 
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/Hash.h"

--- a/src/tests/grid/CMakeLists.txt
+++ b/src/tests/grid/CMakeLists.txt
@@ -28,6 +28,7 @@ foreach(test
         test_vertical
         test_spacing
         test_state
+        test_largegrid
         test_grid_hash)
 
     ecbuild_add_test( TARGET atlas_${test} SOURCES ${test}.cc LIBS atlas ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )

--- a/src/tests/grid/test_largegrid.cc
+++ b/src/tests/grid/test_largegrid.cc
@@ -26,6 +26,11 @@ CASE( "largeGrid" ) {
   struct rusage usage; 
 
   EXPECT (getrusage (RUSAGE_SELF, &usage) == 0);
+  
+  if (usage.ru_maxrss > 30000)
+    std::cout << " usage.ru_maxrss = " << usage.ru_maxrss << std::endl;
+
+
   EXPECT (usage.ru_maxrss < 30000); // 30Mb
 
 }

--- a/src/tests/grid/test_largegrid.cc
+++ b/src/tests/grid/test_largegrid.cc
@@ -1,0 +1,44 @@
+#include <algorithm>
+#include <vector>
+
+#include "atlas/array.h"
+#include "atlas/functionspace.h"
+#include "atlas/grid.h"
+#include "atlas/library/Library.h"
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/util/Config.h"
+#include "atlas/util/UnitSphere.h"
+#include "eckit/types/FloatCompare.h"
+#include "tests/AtlasTestEnvironment.h"
+
+using namespace atlas::util;
+using namespace atlas::grid;
+using namespace atlas;
+
+
+namespace atlas {
+namespace test {
+CASE( "largeGrid" ) {
+
+
+
+  atlas::StructuredGrid grid (atlas::util::Config ("nx", 40000) | atlas::util::Config ("ny", 20000) 
+                            | atlas::util::Config ("type", "regular_lonlat") 
+                            | atlas::util::Config ("domain", atlas::util::Config ("type", "global") 
+                                                 | atlas::util::Config ("units", "degrees")
+                                                 | atlas::util::Config ("west", -180.)));
+ 
+                       
+  auto lonlat = grid.lonlat (0, 0);
+
+  printf (" %12.2f, %12.2f\n", lonlat.lon (), lonlat.lat ());
+
+
+}
+}  // namespace test
+}  // namespace atlas
+
+
+int main( int argc, char* argv[] ) {
+    return atlas::test::run( argc, argv );
+}

--- a/src/tests/grid/test_largegrid.cc
+++ b/src/tests/grid/test_largegrid.cc
@@ -1,26 +1,19 @@
 #include <algorithm>
 #include <vector>
 
-#include "atlas/array.h"
-#include "atlas/functionspace.h"
+#include <time.h>
+#include <sys/resource.h>
+
 #include "atlas/grid.h"
 #include "atlas/library/Library.h"
-#include "atlas/parallel/mpi/mpi.h"
 #include "atlas/util/Config.h"
-#include "atlas/util/UnitSphere.h"
-#include "eckit/types/FloatCompare.h"
 #include "tests/AtlasTestEnvironment.h"
-
-using namespace atlas::util;
-using namespace atlas::grid;
-using namespace atlas;
-
 
 namespace atlas {
 namespace test {
 CASE( "largeGrid" ) {
 
-
+  time_t t0 = time (NULL);
 
   atlas::StructuredGrid grid (atlas::util::Config ("nx", 40000) | atlas::util::Config ("ny", 20000) 
                             | atlas::util::Config ("type", "regular_lonlat") 
@@ -28,11 +21,12 @@ CASE( "largeGrid" ) {
                                                  | atlas::util::Config ("units", "degrees")
                                                  | atlas::util::Config ("west", -180.)));
  
-                       
-  auto lonlat = grid.lonlat (0, 0);
+  EXPECT ((time (NULL)) - t0 < 10);
 
-  printf (" %12.2f, %12.2f\n", lonlat.lon (), lonlat.lat ());
+  struct rusage usage; 
 
+  EXPECT (getrusage (RUSAGE_SELF, &usage) == 0);
+  EXPECT (usage.ru_maxrss < 30000); // 30Mb
 
 }
 }  // namespace test

--- a/src/tests/grid/test_largegrid.cc
+++ b/src/tests/grid/test_largegrid.cc
@@ -27,11 +27,11 @@ CASE( "largeGrid" ) {
 
   EXPECT (getrusage (RUSAGE_SELF, &usage) == 0);
   
-  if (usage.ru_maxrss > 30000)
+  if (usage.ru_maxrss > 100000)
     std::cout << " usage.ru_maxrss = " << usage.ru_maxrss << std::endl;
 
 
-  EXPECT (usage.ru_maxrss < 30000); // 30Mb
+  EXPECT (usage.ru_maxrss < 100000); // 100 Mb
 
 }
 }  // namespace test


### PR DESCRIPTION
Structured::crop requires too much memory and time. See the included test case.

This branch attempts to fix this problem for lat/lon grids.