### PR TITLE
Add test to demonstrate a problem in interpolation2D

### DIFF
--- a/src/tests/interpolation/test_interpolation_structured2D.cc
+++ b/src/tests/interpolation/test_interpolation_structured2D.cc
@@ -389,6 +389,29 @@ CASE( "test_interpolation_structured for vectors" ) {
     }
 }
 
+CASE ("test_multiple_fs") {
+
+  Grid grid1 ("L90x45");
+  Grid grid2 ("O8");
+
+  Mesh mesh1 = StructuredMeshGenerator ().generate (grid1);
+  Mesh mesh2 = StructuredMeshGenerator ().generate (grid2);
+
+  functionspace::NodeColumns fs11 (mesh1, option::halo (1));
+  functionspace::NodeColumns fs12 (mesh1, option::halo (2));
+
+  auto fs1 = fs11;
+  functionspace::NodeColumns fs2 (mesh2, option::halo (1));
+
+  Interpolation interpolation12 (util::Config ("type", "k-nearest-neighbours") | util::Config ("k-nearest-neighbours", 5), fs1, fs2);
+  
+  auto f1 = fs1.createField<double> (util::Config ("name", "source"));
+  auto f2 = fs2.createField<double> (util::Config ("name", "target"));
+  
+  interpolation12.execute (f1, f2);
+
+}
+
 
 }  // namespace test
 }  // namespace atlas


### PR DESCRIPTION
This was reported by A. Piacentini (CERFACS). The problem seems to come from the fact that the mesh object is modified (some extra nodes are added to it when a halo is requested) by the nodeColumns functionspace, although the mesh object is passed by value to the functionspace ctor.

We can easily avoid this issue by creating two distinct mesh objects, but we would like to know whether this is a bug or not.

I am sorry I have forgotten to mark this request as a draft.

