### PR TITLE
Try to change Atlas communicator using eckit setDefaultComm

### DIFF
--- a/src/atlas/parallel/mpi/mpi.h
+++ b/src/atlas/parallel/mpi/mpi.h
@@ -20,8 +20,7 @@ namespace mpi {
 using Comm = eckit::mpi::Comm;
 
 inline const Comm& comm() {
-    static const Comm& _comm = eckit::mpi::comm();
-    return _comm;
+    return eckit::mpi::comm();
 }
 
 inline idx_t rank() {

--- a/src/tests/parallel/CMakeLists.txt
+++ b/src/tests/parallel/CMakeLists.txt
@@ -14,6 +14,14 @@ ecbuild_add_test( TARGET atlas_test_haloexchange_adjoint
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )
 
+ecbuild_add_test( TARGET atlas_test_setcomm
+  MPI        3
+  CONDITION  eckit_HAVE_MPI
+  SOURCES    test_setcomm.cc
+  LIBS       atlas
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
+
 ecbuild_add_test( TARGET atlas_test_haloexchange
   MPI        3
   CONDITION  eckit_HAVE_MPI

--- a/src/tests/parallel/test_setcomm.cc
+++ b/src/tests/parallel/test_setcomm.cc
@@ -1,0 +1,46 @@
+#include "eckit/mpi/Comm.h"
+#include "atlas/library/Library.h"
+#include "atlas/util/Config.h"
+#include "atlas/parallel/mpi/mpi.h"
+#include "tests/AtlasTestEnvironment.h"
+
+#include <iostream>
+#include <stdio.h>
+
+namespace atlas {
+namespace test {
+
+CASE ("test_setcomm")
+{
+
+  printf (" eckit::mpi::comm () = 0x%llx, eckit::mpi::comm ().size () = %8d\n", &eckit::mpi::comm (), eckit::mpi::comm ().size ());
+  std::cout << eckit::mpi::comm ().name () << std::endl;
+  printf (" atlas::mpi::comm () = 0x%llx, atlas::mpi::comm ().size () = %8d\n", &atlas::mpi::comm (), atlas::mpi::comm ().size ());
+  std::cout << atlas::mpi::comm ().name () << std::endl;
+
+  EXPECT_EQ (eckit::mpi::comm ().size (), atlas::mpi::comm ().size ());
+
+  int irank = eckit::mpi::comm ().rank (); 
+
+  auto & comm = eckit::mpi::comm ().split (irank, "SPLIT");
+
+  eckit::mpi::setCommDefault ("SPLIT");
+
+  printf (" eckit::mpi::comm () = 0x%llx, eckit::mpi::comm ().size () = %8d\n", &eckit::mpi::comm (), eckit::mpi::comm ().size ());
+  std::cout << eckit::mpi::comm ().name () << std::endl;
+  printf (" atlas::mpi::comm () = 0x%llx, atlas::mpi::comm ().size () = %8d\n", &atlas::mpi::comm (), atlas::mpi::comm ().size ());
+  std::cout << atlas::mpi::comm ().name () << std::endl;
+
+  EXPECT_EQ (eckit::mpi::comm ().size (), atlas::mpi::comm ().size ());
+
+  std::cout << "----- STOP -----" << std::endl;
+
+}
+
+}
+}
+
+int main (int argc, char* argv[]) 
+{
+  return atlas::test::run (argc, argv);
+}


### PR DESCRIPTION
I would like to change temporarily Atlas communicator; I tried using eckit setDefaultComm, but without success. 

Atlas communicator is a static variable, initialized to eckit default communicator on startup : 

```
inline const Comm& comm() {
    static const Comm& _comm = eckit::mpi::comm();
    return _comm;
}
```

Should I change this to : 

```
inline const Comm& comm() {
    return eckit::mpi::comm();
}
```

Or should I introduce a atlas::mpi::setDefaultComm function ?



