### PR TITLE
Distribution setup hangs with L160000x80000

### DIFF
--- a/src/atlas/grid/detail/distribution/BandsDistribution.h
+++ b/src/atlas/grid/detail/distribution/BandsDistribution.h
@@ -30,7 +30,7 @@ public:
     BandsDistribution( const Grid& grid, idx_t nb_partitions, const std::string& type, size_t blocksize = 1 );
 
     ATLAS_ALWAYS_INLINE int function( gidx_t index ) const {
-        Int iblock = Int( index ) / blocksize_;
+        Int iblock = static_cast<Int> (index / blocksize_);
         return ( iblock * nb_partitions_Int_ ) / nb_blocks_;
     }
 

--- a/src/tests/grid/test_distribution_regular_bands.cc
+++ b/src/tests/grid/test_distribution_regular_bands.cc
@@ -192,6 +192,11 @@ CASE( "test regular_bands performance test" ) {
     }
 }
 
+CASE( "test regular_bands with a very large grid" ) {
+    auto grid = StructuredGrid( sizeof (atlas::idx_t) == 4 ?  "L40000x20000" : "L160000x80000" );  
+    auto dist = grid::Distribution( grid, grid::Partitioner( "regular_bands" ) );
+}
+
 
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
The band distribution setup hangs when distributing a L160000x80000 grid on two tasks.

This branch solves the problem and implements a new test.

Please note that defining a L160000x80000 requires compiling Atlas with -DATLAS_BITS_LOCAL=64. 