### PR TITLE
Cubed sphere parallel mesh generator with halos.

### DIFF
--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -381,6 +381,8 @@ meshgenerator/detail/MeshGeneratorInterface.cc
 meshgenerator/detail/MeshGeneratorInterface.h
 meshgenerator/detail/HealpixMeshGenerator.h
 meshgenerator/detail/HealpixMeshGenerator.cc
+meshgenerator/detail/cubedsphere/CubedSphereUtility.h
+meshgenerator/detail/cubedsphere/CubedSphereUtility.cc
 )
 
 list( APPEND atlas_output_srcs

--- a/src/atlas/grid/detail/tiles/FV3Tiles.cc
+++ b/src/atlas/grid/detail/tiles/FV3Tiles.cc
@@ -444,8 +444,7 @@ void FV3CubedSphereTiles::enforceXYdomain( double xy[] ) const {
 
 atlas::PointXY FV3CubedSphereTiles::tileCubePeriodicity( const atlas::PointXY& xyExtended,
                                                          const atlas::idx_t tile ) const {
-    atlas::PointXY xyOwned;
-    return xyOwned;
+    throw_NotImplemented("tileCubePeriodicity not implemented for FV3Tiles", Here());
 }
 
 void FV3CubedSphereTiles::print( std::ostream& os ) const {

--- a/src/atlas/grid/detail/tiles/FV3Tiles.cc
+++ b/src/atlas/grid/detail/tiles/FV3Tiles.cc
@@ -444,7 +444,7 @@ void FV3CubedSphereTiles::enforceXYdomain( double xy[] ) const {
 
 atlas::PointXY FV3CubedSphereTiles::tileCubePeriodicity( const atlas::PointXY& xyExtended,
                                                          const atlas::idx_t tile ) const {
-    throw_NotImplemented("tileCubePeriodicity not implemented for FV3Tiles", Here());
+    throw_NotImplemented( "tileCubePeriodicity not implemented for FV3Tiles", Here() );
 }
 
 void FV3CubedSphereTiles::print( std::ostream& os ) const {

--- a/src/atlas/mesh/actions/BuildHalo.cc
+++ b/src/atlas/mesh/actions/BuildHalo.cc
@@ -1309,8 +1309,11 @@ void BuildHalo::operator()( int nb_elems ) {
         if ( haloLocked && halo < nb_elems ) {
             const auto errMsg =
                 "Error: Halo size locked. Please set MeshGenerator "
-                "parameter \"halo\" to at least " + std::to_string( nb_elems ) + ".\n"
-                "Current halo size is " + std::to_string( halo ) + ".\n";
+                "parameter \"halo\" to at least " +
+                std::to_string( nb_elems ) +
+                ".\n"
+                "Current halo size is " +
+                std::to_string( halo ) + ".\n";
             throw_Exception( errMsg, Here() );
         }
     }

--- a/src/atlas/mesh/actions/BuildHalo.cc
+++ b/src/atlas/mesh/actions/BuildHalo.cc
@@ -1306,17 +1306,12 @@ void BuildHalo::operator()( int nb_elems ) {
     // Locked halos must be set at mesh generation.
     bool haloLocked = false;
     if ( mesh_.metadata().get( "halo_locked", haloLocked ) ) {
-        if ( haloLocked ) {
-            if ( halo < nb_elems ) {
-                const auto errMsg =
-                    "Error: Halo size locked. Please set MeshGenerator "
-                    " parameter \"halo\" to at least  " +
-                    std::to_string( nb_elems ) +
-                    "\n"
-                    " Current halo size is " +
-                    std::to_string( halo ) + "\n";
-                throw_Exception( errMsg, Here() );
-            }
+        if ( haloLocked && halo < nb_elems ) {
+            const auto errMsg =
+                "Error: Halo size locked. Please set MeshGenerator "
+                "parameter \"halo\" to at least " + std::to_string( nb_elems ) + ".\n"
+                "Current halo size is " + std::to_string( halo ) + ".\n";
+            throw_Exception( errMsg, Here() );
         }
     }
 

--- a/src/atlas/mesh/actions/BuildHalo.cc
+++ b/src/atlas/mesh/actions/BuildHalo.cc
@@ -1305,15 +1305,19 @@ void BuildHalo::operator()( int nb_elems ) {
 
     // Locked halos must be set at mesh generation.
     bool haloLocked = false;
-    if (mesh_.metadata().get("halo_locked", haloLocked)) {
-      if (haloLocked) {
-        if (halo < nb_elems) {
-          const auto errMsg = "Error: Halo size locked. Please set MeshGenerator "
-            " parameter \"halo\" to at least  " + std::to_string(nb_elems) + "\n"
-            " Current halo size is " + std::to_string(halo) + "\n";
-          throw_Exception(errMsg, Here());
+    if ( mesh_.metadata().get( "halo_locked", haloLocked ) ) {
+        if ( haloLocked ) {
+            if ( halo < nb_elems ) {
+                const auto errMsg =
+                    "Error: Halo size locked. Please set MeshGenerator "
+                    " parameter \"halo\" to at least  " +
+                    std::to_string( nb_elems ) +
+                    "\n"
+                    " Current halo size is " +
+                    std::to_string( halo ) + "\n";
+                throw_Exception( errMsg, Here() );
+            }
         }
-      }
     }
 
     if ( halo == nb_elems ) {

--- a/src/atlas/mesh/actions/BuildHalo.cc
+++ b/src/atlas/mesh/actions/BuildHalo.cc
@@ -1303,6 +1303,19 @@ void BuildHalo::operator()( int nb_elems ) {
     int halo = 0;
     mesh_.metadata().get( "halo", halo );
 
+    // Locked halos must be set at mesh generation.
+    bool haloLocked = false;
+    if (mesh_.metadata().get("halo_locked", haloLocked)) {
+      if (haloLocked) {
+        if (halo < nb_elems) {
+          const auto errMsg = "Error: Halo size locked. Please set MeshGenerator "
+            " parameter \"halo\" to at least  " + std::to_string(nb_elems) + "\n"
+            " Current halo size is " + std::to_string(halo) + "\n";
+          throw_Exception(errMsg, Here());
+        }
+      }
+    }
+
     if ( halo == nb_elems ) {
         return;
     }

--- a/src/atlas/mesh/actions/BuildParallelFields.cc
+++ b/src/atlas/mesh/actions/BuildParallelFields.cc
@@ -1072,12 +1072,12 @@ Field& build_cells_remote_idx( mesh::Cells& cells, const mesh::Nodes& nodes ) {
 }
 
 void build_cells_parallel_fields( Mesh& mesh ) {
-
     bool parallel = false;
     mesh.cells().metadata().get( "parallel", parallel );
-    if ( !parallel ) build_cells_remote_idx( mesh.cells(), mesh.nodes() );
+    if ( !parallel )
+        build_cells_remote_idx( mesh.cells(), mesh.nodes() );
 
-    mesh.cells().metadata().set( "parallel", true);
+    mesh.cells().metadata().set( "parallel", true );
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/atlas/mesh/actions/BuildParallelFields.cc
+++ b/src/atlas/mesh/actions/BuildParallelFields.cc
@@ -1072,7 +1072,12 @@ Field& build_cells_remote_idx( mesh::Cells& cells, const mesh::Nodes& nodes ) {
 }
 
 void build_cells_parallel_fields( Mesh& mesh ) {
-    build_cells_remote_idx( mesh.cells(), mesh.nodes() );
+
+    bool parallel = false;
+    mesh.cells().metadata().get( "parallel", parallel );
+    if ( !parallel ) build_cells_remote_idx( mesh.cells(), mesh.nodes() );
+
+    mesh.cells().metadata().set( "parallel", true);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
@@ -394,7 +394,7 @@ void CubedSphereMeshGenerator::generate_mesh(const CubedSphereGrid& csGrid,
   auto cellLocalIdxCount = std::vector<idx_t>(nParts, 0);
 
   // Give possible edge-halo cells a unique global ID.
-  idx_t cellGlobalIdxCount = nCellsUnique + 1;
+  gidx_t cellGlobalIdxCount = nCellsUnique + 1;
 
   for (idx_t t = 0; t < 6; ++t) {
     for (idx_t j = -nHalo; j < N + nHalo; ++j) {
@@ -439,7 +439,7 @@ void CubedSphereMeshGenerator::generate_mesh(const CubedSphereGrid& csGrid,
   auto nodeLocalIdxCount = std::vector<idx_t>(nParts, 0);
 
   // Set counter for global indices.
-  idx_t nodeGlobalOwnedIdxCount = 1;
+  gidx_t nodeGlobalOwnedIdxCount = 1;
   idx_t nodeGlobalGhostIdxCount = nNodesUnique + 1;
 
   for (idx_t t = 0; t < 6; ++t) {

--- a/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
@@ -28,6 +28,7 @@
 #include "atlas/mesh/Nodes.h"
 #include "atlas/meshgenerator/detail/CubedSphereMeshGenerator.h"
 #include "atlas/meshgenerator/detail/MeshGeneratorFactory.h"
+#include "atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h"
 #include "atlas/parallel/mpi/mpi.h"
 #include "atlas/projection/detail/CubedSphereProjectionBase.h"
 #include "atlas/runtime/Exception.h"
@@ -38,625 +39,937 @@
 #define DEBUG_OUTPUT 0
 #define DEBUG_OUTPUT_DETAIL 0
 
-using Topology = atlas::mesh::Nodes::Topology;
-
 namespace atlas {
 namespace meshgenerator {
 
 // -----------------------------------------------------------------------------
 
-CubedSphereMeshGenerator::CubedSphereMeshGenerator( const eckit::Parametrisation& p ) {
-    configure_defaults();
+CubedSphereMeshGenerator::CubedSphereMeshGenerator(const eckit::Parametrisation& p) {
 
-    // Get number of partitions.
-    size_t nb_parts;
-    if ( p.get( "nb_parts", nb_parts ) )
-        options.set( "nb_parts", nb_parts );
+  configure_defaults();
 
-    // Get this partition.
-    size_t part;
-    if ( p.get( "part", part ) )
-        options.set( "part", part );
+  // Get number of partitions.
+  size_t nb_parts;
+  if (p.get("nb_parts", nb_parts)) options.set("nb_parts", nb_parts);
 
-    // Get partitioner.
-    std::string partitioner;
-    if ( p.get( "partitioner", partitioner ) )
-        options.set( "partitioner", partitioner );
+  // Get this partition.
+  size_t part;
+  if (p.get("part", part)) options.set("part", part);
+
+  // Get halo size.
+  idx_t halo;
+  if (p.get("halo", halo)) options.set("halo", halo);
+
+  // Get partitioner.
+  std::string partitioner;
+  if (p.get("partitioner", partitioner)) options.set("partitioner", partitioner);
+
 }
 
 // -----------------------------------------------------------------------------
 
 
 void CubedSphereMeshGenerator::configure_defaults() {
-    // This option sets number of parts the mesh will be split in.
-    options.set( "nb_parts", mpi::size() );
 
-    // This option sets the part that will be generated.
-    options.set( "part", mpi::rank() );
+  // This option sets number of partitions.
+  options.set( "nb_parts", mpi::size() );
 
-    // This options sets the default partitioner.
-    options.set<std::string>( "partitioner", "cubedsphere" );
+  // This option sets the part that will be generated.
+  options.set("part", mpi::rank());
+
+  // This options sets the number of halo elements around each partition.
+  options.set("halo", idx_t{1});
+
+  // This options sets the default partitioner.
+  options.set<std::string>("partitioner", "cubedsphere");
 }
 
 // -----------------------------------------------------------------------------
 
-void CubedSphereMeshGenerator::generate( const Grid& grid, Mesh& mesh ) const {
-    // Get partitioner type and number of partitions from config.
-    const auto nParts   = static_cast<idx_t>( options.get<size_t>( "nb_parts" ) );
-    const auto partType = options.get<std::string>( "partitioner" );
-    auto partConfig     = util::Config{};
-    partConfig.set( "type", partType );
-    partConfig.set( "partitions", nParts );
+void CubedSphereMeshGenerator::generate(const Grid& grid, Mesh& mesh) const {
 
-    // Use lonlat instead of xy for equal_regions partitioner.
-    if ( partType == "equal_regions" )
-        partConfig.set( "coordinates", "lonlat" );
+  // Get partitioner type and number of partitions from config.
+  const auto nParts = static_cast<idx_t>(options.get<size_t>("nb_parts"));
+  const auto partType = options.get<std::string>("partitioner");
 
-    // Set distribution.
-    const auto partitioner  = grid::Partitioner( partConfig );
-    const auto distribution = grid::Distribution( grid, partitioner );
+  auto partConfig = util::Config{};
+  partConfig.set("type", partType);
+  partConfig.set("partitions", nParts);
 
-    generate( grid, distribution, mesh );
+  // Use lonlat instead of xy for equal_regions partitioner.
+  if (partType == "equal_regions") partConfig.set("coordinates", "lonlat");
+
+  // Set distribution.
+  const auto partitioner = grid::Partitioner(partConfig);
+  const auto distribution = grid::Distribution(grid, partitioner);
+
+  generate(grid, distribution, mesh);
+
 }
 
 // -----------------------------------------------------------------------------
 
-void CubedSphereMeshGenerator::generate( const Grid& grid, const grid::Distribution& distribution, Mesh& mesh ) const {
-    // Check for correct grid and need for mesh
-    ATLAS_ASSERT( !mesh.generated() );
-    if ( !CubedSphereGrid( grid ) ) {
-        throw_Exception(
-            "CubedSphereMeshGenerator can only work "
-            "with a cubedsphere grid.",
-            Here() );
+void CubedSphereMeshGenerator::generate(const Grid& grid,
+  const grid::Distribution& distribution, Mesh& mesh) const {
+
+  // Check for correct grid and need for mesh
+  ATLAS_ASSERT(!mesh.generated());
+  if (!CubedSphereGrid(grid)) {
+    throw_Exception("CubedSphereMeshGenerator can only work "
+    "with a cubedsphere grid.", Here());
+  }
+
+  // Cast grid to cubed sphere grid.
+  const auto csGrid = CubedSphereGrid(grid);
+
+  // Clone some grid properties.
+  setGrid(mesh, csGrid, distribution);
+
+  generate_mesh(csGrid, distribution, mesh);
+}
+
+// -----------------------------------------------------------------------------
+
+void CubedSphereMeshGenerator::generate_mesh(const CubedSphereGrid& csGrid,
+  const grid::Distribution& distribution, Mesh& mesh) const {
+
+  ATLAS_TRACE("CubedSphereMeshGenerator::generate");
+
+  // ---------------------------------------------------------------------------
+  // CUBED SPHERE MESH GENERATOR
+  // ---------------------------------------------------------------------------
+  //
+  // Mesh generator creates a cubed sphere mesh by generating individual meshes
+  // for each cubed sphere tile and then working out the correspondence between
+  // overlapping nodes and cells.
+  //
+  // Meshgenerator places cell at each grid point on this partition. Halo
+  // cells are added to the mesh if options.get("halo") > 0. The halo cells may
+  // either be interior to the tile, || exterior. Interior halo cells share
+  // their xy coordinate and global ID with the corresponding cells on other
+  // partitions. Exterior halo cells have a unique global ID and their xy
+  // coordinates are extrapolated from the interior tile. The global IDs of non-
+  // halo cells match the global IDs of the cell-centre grid points.
+  //
+  // Nodes are added around cells. The nodes around interior cells are assigned
+  // an owner by the following rules:
+  //    * node (i > 0, j > 0) is owned by cell (i - 1, j - 1)
+  //    * node (i = 0, j > 0) is owned by cell (0    , j - 1)
+  //    * node (i > 0, j = 0) is owned by cell (i - 1, 0    )
+  //    * node (i = 0, j = 0) is owned by cell (0    , 0    )
+  //
+  // The partition of the owning cell determines the partition of the node.
+  // Ghost nodes are added to the mesh to complete cells at partition
+  // boundaries, cells exterior to the tiles, or on tile edges which do not
+  // own nodes.
+  //
+  // There are several stages to the mesh generator:
+  //    1. Preamble.
+  //    2. Define global cell distribution.
+  //    3. Define global node distribution.
+  //    4. Locate local cells.
+  //    5. Locate local nodes
+  //    6. Assign nodes to mesh.
+  //    7. Assign cells to mesh.
+  //    8. Finalise.
+
+  // ---------------------------------------------------------------------------
+  // 1. PREAMBLE
+  //    Setup some general parameters of the mesh, as well as define useful
+  //    lambda functions and structs.
+  // ---------------------------------------------------------------------------
+
+  using Topology = atlas::mesh::Nodes::Topology;
+  using atlas::array::make_datatype;
+  using atlas::array::make_shape;
+
+  using namespace detail::cubedsphere;
+
+  struct GlobalElem;
+  struct LocalElem;
+
+  // Define bad index values.
+  constexpr idx_t undefinedIdx = -1;
+
+  // Define cell/node type.
+  enum class ElemType {
+    UNDEFINED,  // Not set. Writing this type to mesh is an error.
+    OWNER,      // Owner element on this partition.
+    HALO        // Ghost or halo element.
+  };
+
+  // Struct to store the information of globals cells/nodes.
+  // These must be generated for all cells/nodes on all partitions. Data is
+  // stored in (t, j, i) row-major order.
+  struct GlobalElem {
+    LocalElem* localPtr{};                    // Pointer to local element.
+    idx_t      globalIdx{undefinedIdx};       // Global index.
+    idx_t      remoteIdx{undefinedIdx};       // Remote index.
+    idx_t      part{undefinedIdx};            // Partition.
+  };
+
+  // Struct to store additional information of local cells/nodes.
+  // These are only generated for nodes on this partition. Data is stored as a
+  // list which can be sorted.
+  struct LocalElem {
+    GlobalElem* globalPtr{};                  // Pointer to global element.
+    ElemType    type{ElemType::UNDEFINED};    // Cell/node Type.
+    idx_t       halo{undefinedIdx};           // Halo level.
+    idx_t       i{}, j{}, t{};                // i, j and t.
+  };
+
+  // Define ij bounding box for each face (this partition only).
+  struct BoundingBox {
+    idx_t iBegin{std::numeric_limits<idx_t>::max()};
+    idx_t iEnd{std::numeric_limits<idx_t>::min()};
+    idx_t jBegin{std::numeric_limits<idx_t>::max()};
+    idx_t jEnd{std::numeric_limits<idx_t>::min()};
+  };
+
+
+  // Check for correct grid stagger.
+  if (csGrid.stagger() != "C") {
+    throw_Exception("CubedSphereMeshGenerator will only work with a"
+    "cell-centroid grid. Try NodalCubedSphereMeshGenerator instead.", Here());
+  }
+
+  // Get dimensions of grid
+  const idx_t N = csGrid.N();
+
+  // Get size of halo.
+  idx_t nHalo = 0;
+  options.get("halo", nHalo);
+
+  // Unique non-halo nodes and cells.
+  const idx_t nNodesUnique = 6 * N * N + 2;
+  const idx_t nCellsUnique = 6 * N * N;
+
+  // Total array sizes (including invalid corner ijs).
+  const idx_t nNodesArray   = 6 * (N + 2 * nHalo + 1) * (N + 2 * nHalo + 1);
+  const idx_t nCellsArray   = 6 * (N + 2 * nHalo) * (N + 2 * nHalo);
+
+  // Total number of possible cells and nodes (including halos).
+  const idx_t nNodesTotal  = nNodesArray - 6 * 4 * nHalo * nHalo;
+  const idx_t nCellsTotal  = nCellsArray - 6 * 4 * nHalo * nHalo;
+
+  // Projection and tiles
+  const auto* const csProjection = castProjection(csGrid.projection().get());
+
+  // Get partition information.
+  const auto nParts = options.get<size_t>("nb_parts");
+  const auto thisPart = options.get<size_t>("part");
+
+  // Define an index counter.
+  const auto idxSum = [](const std::vector<idx_t>& idxCounts) -> idx_t {
+    return std::accumulate(idxCounts.begin(), idxCounts.end(), 0);};
+
+  // Helper functions to get node vector idx from (i, j, t).
+  const auto getNodeIdx = [&](idx_t i, idx_t j, idx_t t) -> size_t {
+
+    const idx_t rowSize = (N + 2 * nHalo + 1);
+    const idx_t tileSize = rowSize * rowSize;
+
+    return static_cast<size_t>(t * tileSize + (j + nHalo) * rowSize + i + nHalo);
+  };
+
+  // Helper functions to get cell vector idx from (i, j, t).
+  const auto getCellIdx = [&](idx_t i, idx_t j, idx_t t) -> size_t {
+
+    const idx_t rowSize = (N + 2 * nHalo);
+    const idx_t tileSize = rowSize * rowSize;
+
+    return static_cast<size_t>(t * tileSize + (j + nHalo) * rowSize + i + nHalo);
+
+  };
+
+  // Return true for nodes interior to tile (excluding edge).
+  const auto interiorNode = [&](idx_t i, idx_t j) -> bool {
+    return i > 0 && i < N && j > 0 && j < N;
+  };
+
+  // return true for nodes exterior to tile (excluding edge).
+  const auto exteriorNode = [&](idx_t i, idx_t j) -> bool {
+    return i < 0 || i > N || j < 0 || j > N;
+  };
+
+  // Return true for cells interior to tile.
+  const auto interiorCell = [&](idx_t i, idx_t j) -> bool {
+    return i >= 0 && i < N && j >= 0 && j < N;
+  };
+
+  // Return true for impossible node (i, j) combinations.
+  const auto invalidNode = [&](idx_t i, idx_t j) -> bool {
+
+    const bool inCorner = (i < 0 && j < 0) ||  // Bottom-left corner.
+                          (i > N && j < 0) ||  // Bottom-right corner.
+                          (i > N && j > N) ||  // Top-right corner.
+                          (i < 0 && j > N);    // Top-left corner.
+
+    if (inCorner) return true;
+
+    const bool outOfBounds = i < -nHalo || i > N + nHalo ||
+                             j < -nHalo || j > N + nHalo;
+
+    if (outOfBounds) return true;
+
+    return false;
+  };
+
+  // Return true for impossible cell (i, j) combinations.
+  const auto invalidCell = [&](idx_t i, idx_t j) -> bool {
+
+    const bool inCorner = (i < 0     && j < 0    ) ||  // Bottom-left corner.
+                          (i > N - 1 && j < 0    ) ||  // Bottom-right corner.
+                          (i > N - 1 && j > N - 1) ||  // Top-right corner.
+                          (i < 0     && j > N - 1);    // Top-left corner.
+
+    if (inCorner) return true;
+
+    const bool outOfBounds = i < -nHalo || i > N + nHalo - 1 ||
+                             j < -nHalo || j > N + nHalo - 1;
+
+    if (outOfBounds) return true;
+
+    return false;
+  };
+
+  // Return the (i, j) of cell that owns node (i, j).
+  // It's possible that this may need to be user-defined in the future.
+  const auto nodeOwnerCell =
+    [](idx_t iNode, idx_t jNode) -> std::pair<idx_t, idx_t> {
+    return std::make_pair(iNode > 0 ? iNode - 1 : iNode,
+                          jNode > 0 ? jNode - 1 : jNode);
+  };
+
+  // ---------------------------------------------------------------------------
+  // 2. GLOBAL CELL DISTRIBUTION
+  //    Need to construct a lightweight global mesh. This will help us pair up
+  //    local and remote indices on different partitions.
+  // ---------------------------------------------------------------------------
+
+  // Make vector of all possible cells.
+  auto globalCells = std::vector<GlobalElem>(static_cast<size_t>(nCellsArray));
+
+  // Initialise bounding box.
+  auto cellBounds = std::vector<BoundingBox>(static_cast<size_t>(6));
+
+  // Set xy and tji grid iterators.
+  auto ijtIt = csGrid.tij().begin();
+
+  for (idx_t gridIdx = 0; gridIdx < csGrid.size(); ++gridIdx) {
+
+    // It's more than likely that the grid order follows the same (t, j, i) row-
+    // major order of the mesh. However, we shouldn't assume this is true.
+
+    // Get cell index.
+    const idx_t i = (*ijtIt).i();
+    const idx_t j = (*ijtIt).j();
+    const idx_t t = (*ijtIt).t();
+    const size_t cellIdx = getCellIdx(i, j, t);
+    GlobalElem& cell = globalCells[cellIdx];
+
+    // Set global index.
+    cell.globalIdx = gridIdx + 1;
+
+    // Set partition.
+    cell.part = distribution.partition(gridIdx);
+
+    if (cell.part == static_cast<idx_t>(thisPart)) {
+
+      // Keep track of local (t, j, i) bounds.
+      BoundingBox& bounds = cellBounds[static_cast<size_t>(t)];
+      bounds.iBegin = std::min(bounds.iBegin, i - nHalo    );
+      bounds.iEnd   = std::max(bounds.iEnd  , i + nHalo + 1);
+      bounds.jBegin = std::min(bounds.jBegin, j - nHalo    );
+      bounds.jEnd   = std::max(bounds.jEnd  , j + nHalo + 1);
+
     }
+    // Increment iterators.
+    ++ijtIt;
+  }
 
-    // Cast grid to cubed sphere grid.
-    const auto csGrid = CubedSphereGrid( grid );
+  // Set counters for cell local indices.
+  auto cellLocalIdxCount = std::vector<idx_t>(nParts, 0);
 
-    // Check for correct stagger
-    const auto gridName = grid.name();
+  // Give possible edge-halo cells a unique global ID.
+  const auto jacobian = NeighbourJacobian(csGrid);
 
-    if ( csGrid.stagger() != "C" ) {
-        throw_Exception(
-            "CubedSphereMeshGenerator can only work with a "
-            "cell-centroid grid. Try NodalCubedSphereMeshGenerator instead." );
-    }
+  idx_t cellGlobalIdxCount = nCellsUnique + 1;
 
+  for (idx_t t = 0; t < 6; ++t) {
+    for (idx_t j = -nHalo; j < N + nHalo; ++j) {
+      for (idx_t i = -nHalo; i < N + nHalo; ++i) {
 
-    // Clone some grid properties.
-    setGrid( mesh, csGrid, distribution );
+        // Skip invalid cell.
+        if (invalidCell(i, j)) continue;
 
-    generate_mesh( csGrid, distribution, mesh );
-}
+        // Get cell.
+        GlobalElem& cell = globalCells[getCellIdx(i, j, t)];
 
-// -----------------------------------------------------------------------------
+        // Set cell remote index if interior cell.
+        if (interiorCell(i, j)) {
 
-void CubedSphereMeshGenerator::generate_mesh( const CubedSphereGrid& csGrid, const grid::Distribution& distribution,
-                                              Mesh& mesh ) const {
-    ATLAS_TRACE( "CubedSphereMeshGenerator::generate" );
+          // Set remote index.
+          cell.remoteIdx = cellLocalIdxCount[static_cast<size_t>(cell.part)]++;
 
-    // ---------------------------------------------------------------------------
-    // CUBED SPHERE MESH GENERATOR
-    // ---------------------------------------------------------------------------
-    //
-    // Mesh generator creates a mesh by placing cells with centroid positions at
-    // grid xy coordinates. Nodes are then placed around cells by the generator.
-    //
-    // The node-ownership of cells is determined by the following rules:
-    //    * node (i > 0, j > 0) is owned by cell (i - 1, j - 1)
-    //    * node (i = 0, j > 0) is owned by cell (i    , j - 1)
-    //    * node (i > 0, j = 0) is owned by cell (i - 1, j    )
-    //    * node (i = 0, j = 0) is owned by cell (i    , j    )
-    //
-    // In addtion, there are two types of ghost node that need to be added to the
-    // mesh:
-    //    * Type-A ghost nodes. These are added to an edge between two tiles. One
-    //      tile owns the nodes, the other tile has ghost nodes in the same place.
-    //      The ownership rules are determined the CubedSphereTiles class. These
-    //      nodes are defined globally and have their own unique global index.
-    //      Their placement and local indexing is unaffected by the partitioner.
-    //    * Type-B ghost nodes. These are added when a tile is partitioned. One
-    //      side of the partation boundary has cells which own the nodes
-    //      (see ownership rules above). The other side has ghost nodes. The
-    //      placement and indexing of these ghost nodes may vary with different
-    //      partitioners. The global index of these nodes are taken from their
-    //      owned counterparts on the other side of the partition boundary.
-    //
-    // Global indices of cells are the same as the grid point indices. Global
-    // indices of nodes first count the owned nodes, then the type-A ghost points.
-    //
-    // Local indices of cells follows the order of the local grid points. Local
-    // indces of the nodes first count the owned nodes, followed by type-A ghost
-    // nodes, followed by type-B ghost nodes.
-    //
-    // There are several stages to the mesh generator:
-    //    1. Preamble.
-    //    2. Define global cell distribution.
-    //    3. Define global owned node and type-A ghost node distribution.
-    //    4. Locate and count local type-B ghost nodes.
-    //    5. Assign nodes to mesh.
-    //    6. Assign cells to mesh.
-    //    7. Finalise.
+        } else {
 
-    // ---------------------------------------------------------------------------
-    // 1. PREAMBLE
-    // ---------------------------------------------------------------------------
-
-    // Get dimensions of grid
-    const idx_t N      = csGrid.N();
-    const idx_t nTiles = csGrid.tiles().size();
-
-    const auto nNodesUnique = nTiles * N * N + 2;
-    const auto nNodesAll    = nTiles * ( N + 1 ) * ( N + 1 );
-    const auto nCells       = nTiles * N * N;
-
-    Log::debug() << "Number of cells per tile edge = " << std::to_string( N ) << std::endl;
-
-    // Define bad index values.
-    constexpr auto undefinedIdx       = -1;
-    constexpr auto undefinedGlobalIdx = -1;
-
-    // Projection and tiles
-    const auto* const csProjection =
-        dynamic_cast<const projection::detail::CubedSphereProjectionBase*>( csGrid.projection().get() );
-    ATLAS_ASSERT( csProjection );
-    const auto csTiles = csProjection->getCubedSphereTiles();
-
-    // Get partition information.
-    const auto nParts   = mpi::comm().size();
-    const auto thisPart = mpi::comm().rank();
-
-    // Set some casting helper functions to avoid annoying warnings.
-    const auto st2idx = []( size_t i ) { return static_cast<idx_t>( i ); };
-    const auto idx2st = []( idx_t i ) { return static_cast<size_t>( i ); };
-
-    // Define an index counter.
-    const auto idxSum = []( const std::vector<idx_t>& idxCounts ) -> idx_t {
-        return std::accumulate( idxCounts.begin(), idxCounts.end(), 0 );
-    };
-
-    // Helper functions to get node and cell idx from (t, j, i).
-    const auto getNodeIdx = [&]( idx_t t, idx_t j, idx_t i ) {
-        // Adjust bounds.
-        constexpr idx_t zero = 0;
-        t                    = std::max( std::min<idx_t>( t, nTiles - 1 ), zero );
-        j                    = std::max( std::min( j, N ), zero );
-        i                    = std::max( std::min( i, N ), zero );
-        return idx2st( t * ( N + 1 ) * ( N + 1 ) + j * ( N + 1 ) + i );
-    };
-
-    const auto getCellIdx = [&]( idx_t t, idx_t j, idx_t i ) {
-        // Adjust bounds.
-        constexpr idx_t zero = 0;
-        t                    = std::max( std::min( t, nTiles - 1 ), zero );
-        j                    = std::max( std::min( j, N - 1 ), zero );
-        i                    = std::max( std::min( i, N - 1 ), zero );
-        return idx2st( t * N * N + j * N + i );
-    };
-
-    // ---------------------------------------------------------------------------
-    // 2. GLOBAL CELL DISTRIBUTION
-    // ---------------------------------------------------------------------------
-
-    // Define cell record.
-    // This currently keeps track of more information than we probably need.
-    // This may be reduced once we've implemented halos.
-    struct CellRecord {
-        gidx_t globalIdx{undefinedGlobalIdx};  // Global ID.
-        idx_t localIdx{undefinedIdx};          // Local ID.
-        idx_t part{undefinedIdx};              // Partition.
-        PointXY xy{};                          // Position.
-    };
-
-    // Define ij bounding box for each face (this partition only).
-    struct BoundingBox {
-        idx_t iBegin{std::numeric_limits<idx_t>::max()};
-        idx_t iEnd{std::numeric_limits<idx_t>::min()};
-        idx_t jBegin{std::numeric_limits<idx_t>::max()};
-        idx_t jEnd{std::numeric_limits<idx_t>::min()};
-    };
-
-    // Make list of all cells.
-    auto globalCells = std::vector<CellRecord>( idx2st( nCells ) );
-
-    // Initialise bounding box.
-    auto cellBounds = std::vector<BoundingBox>( idx2st( nTiles ) );
-
-    // Set xy and tji grid iterators.
-    auto tjiIt = csGrid.tij().begin();
-    auto xyIt  = csGrid.xy().begin();
-
-    // Set counters for cell local indices.
-    auto cellIdxCount = std::vector<idx_t>( nParts, 0 );
-
-    for ( gidx_t gridIdx = 0; gridIdx < csGrid.size(); ++gridIdx ) {
-        // Grid (t, j, i) order does not have to match mesh (t, j, i), although
-        // in practice it probably does.
-
-        // Get cell index.
-        const auto t       = ( *tjiIt ).t();
-        const auto j       = ( *tjiIt ).j();
-        const auto i       = ( *tjiIt ).i();
-        const auto cellIdx = getCellIdx( t, j, i );
-        auto& cell         = globalCells[cellIdx];
-
-        // Set global index.
-        cell.globalIdx = gridIdx + 1;
-
-        // Set partition and remote index.
-        cell.part = distribution.partition( gridIdx );
-
-        // Set local index.
-        cell.localIdx = cellIdxCount[idx2st( cell.part )]++;
-
-        // Set xy
-        cell.xy = *xyIt;
-
-        if ( cell.part == st2idx( thisPart ) ) {
-            // Keep track of local (t, j, i) bounds.
-            auto& bounds  = cellBounds[idx2st( t )];
-            bounds.iBegin = std::min( bounds.iBegin, i );
-            bounds.iEnd   = std::max( bounds.iEnd, i + 1 );
-            bounds.jBegin = std::min( bounds.jBegin, j );
-            bounds.jEnd   = std::max( bounds.jEnd, j + 1 );
+          // Set global index.
+          cell.globalIdx = cellGlobalIdxCount++;
+          // Leave remote index and part undefined.
         }
-        // Increment iterators.
-        ++tjiIt;
-        ++xyIt;
+      }
     }
+  }
 
-    ATLAS_ASSERT( idxSum( cellIdxCount ) == nCells );
+  ATLAS_ASSERT(idxSum(cellLocalIdxCount) == nCellsUnique);
+  ATLAS_ASSERT(cellGlobalIdxCount == nCellsTotal + 1);
 
-    // ---------------------------------------------------------------------------
-    // 3. GLOBAL OWNED NODE AND TYPE-A GHOST NODE DISTRIBUTION
-    // ---------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // 3. GLOBAL NODE DISTRIBUTION
+  //    Construct a lightweight global distribution of nodes. Again, this will
+  //    help us match up local and remote indices accross partitions.
+  // ---------------------------------------------------------------------------
 
-    // Define Jacobian of xy wrt ij for each tile so that we can easily
-    // switch between the two. This will be needed to set node xy positions
-    // and figure out the ij indices for type-A ghost nodes.
-    struct XyJacobian {
-        double dxByDi{};  // dx/di
-        double dxByDj{};  // dx/dj
-        double dyByDi{};  // dy/di
-        double dyByDj{};  // dy/dj
-        double diByDx{};  // di/dx
-        double diByDy{};  // di/dy
-        double djByDx{};  // dj/dx
-        double djByDy{};  // dj/dy
-        PointXY xy00{};   // xy coordinate of node(i = 0, j = 0).
-    };
+  // Make list of all nodes.
+  auto globalNodes = std::vector<GlobalElem>(static_cast<size_t>(nNodesArray));
 
-    // Calculate Jacobians.
-    idx_t t   = 0;
-    auto jacs = std::vector<XyJacobian>{};
-    std::generate_n( std::back_inserter( jacs ), nTiles, [&]() {
-        // Initialise element.
-        auto jacElem = XyJacobian{};
+  // Set counters for local node indices.
+  auto nodeLocalIdxCount = std::vector<idx_t>(nParts, 0);
 
-        // Get cell positions.
-        const auto& xy00 = globalCells[getCellIdx( t, 0, 0 )].xy;
-        const auto& xy10 = globalCells[getCellIdx( t, 0, 1 )].xy;
-        const auto& xy01 = globalCells[getCellIdx( t, 1, 0 )].xy;
+  // Set counter for global indices.
+  idx_t nodeGlobalOwnedIdxCount = 1;
+  idx_t nodeGlobalGhostIdxCount = nNodesUnique + 1;
 
-        // Calculate Jacobian.
-        jacElem.dxByDi = xy10.x() - xy00.x();
-        jacElem.dxByDj = xy01.x() - xy00.x();
-        jacElem.dyByDi = xy10.y() - xy00.y();
-        jacElem.dyByDj = xy01.y() - xy00.y();
+  for (idx_t t = 0; t < 6; ++t) {
+    for (idx_t j = -nHalo; j < N + nHalo + 1; ++j) {
+      for (idx_t i = -nHalo; i < N + nHalo + 1; ++i) {
 
-        // Calculate inverse Jacobian.
-        const auto invDet = 1. / ( jacElem.dxByDi * jacElem.dyByDj - jacElem.dxByDj * jacElem.dyByDi );
-        jacElem.diByDx    = jacElem.dyByDj * invDet;
-        jacElem.diByDy    = -jacElem.dxByDj * invDet;
-        jacElem.djByDx    = -jacElem.dyByDi * invDet;
-        jacElem.djByDy    = jacElem.dxByDi * invDet;
+        // Skip if not a valid node.
+        if (invalidNode(i, j)) continue;
 
-        // Extrapolate cell(t, 0, 0) xy to get node(t, 0, 0) xy.
-        jacElem.xy00 = PointXY{xy00.x() - 0.5 * jacElem.dxByDi - 0.5 * jacElem.dxByDj,
-                               xy00.y() - 0.5 * jacElem.dyByDi - 0.5 * jacElem.dyByDj};
+        // Get this node.
+        GlobalElem& node = globalNodes[getNodeIdx(i, j, t)];
 
-        ++t;
-        return jacElem;
-    } );
+        // Get owner cell.
+        idx_t iCell, jCell;
+        std::tie(iCell, jCell) = nodeOwnerCell(i, j);
+        const GlobalElem& cell = globalCells[getCellIdx(iCell, jCell, t)];
 
-    // Define node record.
-    // This currently keeps track of more information than we probably need.
-    // This may be reduced once we've implemented halos.
-    struct NodeRecord {
-        gidx_t globalIdx{undefinedGlobalIdx};  // Global ID,
-        idx_t localIdx{undefinedIdx};          // Local ID.
-        idx_t localPart{undefinedIdx};         // Partition node is on.
-        idx_t remoteIdx{undefinedIdx};         // Local ID of owned node.
-        idx_t remotePart{undefinedIdx};        // Partion that owned node is on.
-        idx_t t{undefinedIdx};                 // Tile that owned node is on.
-        bool ghost{false};                     // True if node is a ghost.
-        PointXY localXy{};                     // Position of this node.
-        PointXY remoteXy{};                    // Position of owned node.
-    };
+        if (interiorNode(i, j)) {
 
-    // Make list of all nodes.
-    auto globalNodes = std::vector<NodeRecord>( idx2st( nNodesAll ) );
+          // Node is definitely an owner.
+          node.globalIdx = nodeGlobalOwnedIdxCount++;
+          node.part = cell.part;
+          node.remoteIdx = nodeLocalIdxCount[static_cast<size_t>(node.part)]++;
 
-    // Set counters for local node indices.
-    auto nodeLocalIdxCount = std::vector<idx_t>( nParts, 0 );
+        } else if (exteriorNode(i, j)) {
 
-    // Set counter for global indices.
-    gidx_t nodeGlobalIdxCount = 1;
+          // Node is definitely a ghost.
+          node.globalIdx = nodeGlobalGhostIdxCount++;
+          // Leave remote index and partition undefined.
 
-    // Make a list of type-A ghost nodes and process later.
-    auto typeAGhostNodes = std::vector<NodeRecord*>{};
+        } else {
 
-    for ( idx_t t = 0; t < nTiles; ++t ) {
-        for ( idx_t j = 0; j < N + 1; ++j ) {
-            for ( idx_t i = 0; i < N + 1; ++i ) {
-                // Get node.
-                auto& node = globalNodes[getNodeIdx( t, j, i )];
+          // We're not sure (i.e., node is on a tile edge).
 
-                // Get owning cell.
-                const auto& cell = globalCells[getCellIdx( t, j - 1, i - 1 )];
+          // check that xy is on this tile.
+          PointXY xy = jacobian.xy(PointIJ(i, j) ,t);
+          xy = jacobian.snapToEdge(xy, t);
 
-                // Extrapolate local xy from cell centre.
-                // Nodes are +/- half a grid spacing relative to cells.
-                const auto di   = i == 0 ? -0.5 : 0.5;
-                const auto dj   = j == 0 ? -0.5 : 0.5;
-                const auto& jac = jacs[idx2st( t )];
-                node.localXy    = PointXY{cell.xy.x() + di * jac.dxByDi + dj * jac.dxByDj,
-                                       cell.xy.y() + di * jac.dyByDi + dj * jac.dyByDj};
+          idx_t tGlobal =
+            csProjection->getCubedSphereTiles().indexFromXY(xy.data());
 
-                // Get remote xy from tile class and local t.
-                node.remoteXy = csTiles.tileCubePeriodicity( node.localXy, t );
+          if (tGlobal == t) {
 
-                // Local taken from owning cell.
-                node.localPart = cell.part;
+            // Node is an owner.
+            node.globalIdx = nodeGlobalOwnedIdxCount++;
+            node.part = cell.part;
+            node.remoteIdx = nodeLocalIdxCount[static_cast<size_t>(node.part)]++;
 
-                // Get remote t from tile class.
-                node.t = csTiles.indexFromXY( node.remoteXy.data() );
+          } else {
 
-                // Node is a type-A ghost if local t and remote t differ.
-                // Otherwise node is owned.
-                if ( t == node.t ) {
-                    // Owned point.
+            // Node is a ghost.
+            node.globalIdx = nodeGlobalGhostIdxCount++;
 
-                    // Set global index.
-                    node.globalIdx = nodeGlobalIdxCount++;
+          }
+        } // Finished with this node.
+      }
+    } // Finished with all nodes on tile.
+  } // Finished with all tiles.
 
-                    // Set local index.
-                    node.localIdx = nodeLocalIdxCount[idx2st( node.localPart )]++;
+  ATLAS_ASSERT(nodeGlobalOwnedIdxCount == nNodesUnique + 1);
+  ATLAS_ASSERT(nodeGlobalGhostIdxCount == nNodesTotal + 1);
+  ATLAS_ASSERT(idxSum(nodeLocalIdxCount) == nNodesUnique);
 
-                    // Remote partition same as local.
-                    node.remotePart = node.localPart;
+  // ---------------------------------------------------------------------------
+  // 4. LOCATE LOCAL CELLS.
+  //    Now that we know where all the nodes and cells are, we can make a list
+  //    of local cells to add the the mesh. "Owner" cells correspond to grid
+  //    points on this parition. "Halo" cells are at most nHalo grid points
+  //    away from an owner cell.
+  // ---------------------------------------------------------------------------
 
-                    // Remote index same as local.
-                    node.remoteIdx = node.localIdx;
-                }
-                else {
-                    // Type-A ghost. Deal with this later.
-                    typeAGhostNodes.push_back( &node );
-                }
+  // Make vector of local cells.
+  auto localCells = std::vector<LocalElem>{};
+
+  // Loop over all possible local cells.
+  for (idx_t t = 0; t < 6; ++t) {
+
+    // Limit range to bounds recorded earlier.
+    const BoundingBox& bounds = cellBounds[static_cast<size_t>(t)];
+
+    for (idx_t j = bounds.jBegin; j < bounds.jEnd; ++j) {
+      for (idx_t i = bounds.iBegin; i < bounds.iEnd; ++i) {
+
+        if (invalidCell(i, j)) continue;
+
+        // Get cell
+        GlobalElem& globalCell = globalCells[getCellIdx(i, j, t)];
+
+        // Check if cell is an owner.
+        if (globalCell.part == static_cast<idx_t>(thisPart)) {
+
+          // Cell is an owner.
+          localCells.emplace_back();
+          LocalElem& localCell = localCells.back();
+
+          localCell.type = ElemType::OWNER;
+          localCell.halo = 0;
+          localCell.i = i;
+          localCell.j = j;
+          localCell.t = t;
+          localCell.globalPtr = &globalCell;
+
+        } else {
+
+          // Check if cell is halo.
+          bool haloFound = false;
+          idx_t halo = nHalo;
+          for (idx_t jHalo = j - nHalo; jHalo < j + nHalo + 1; ++jHalo) {
+            for (idx_t iHalo = i - nHalo; iHalo < i + nHalo + 1; ++iHalo) {
+
+              if (invalidCell(iHalo, jHalo) ||
+                 (iHalo == i && jHalo == j)) continue;
+
+              // Is there a nearby owner cell?
+              const GlobalElem& ownerCell = globalCells[getCellIdx(iHalo, jHalo, t)];
+
+              const bool isHalo =
+                ownerCell.part == static_cast<idx_t>(thisPart);
+
+              haloFound = haloFound || isHalo;
+
+              if (isHalo) {
+
+                // Determine halo level from cell distance (l-infinity norm).
+                const idx_t dist =
+                  std::max(std::abs(iHalo - i), std::abs(jHalo - j));
+
+                halo = std::min(dist, halo);
+              }
             }
-        }
+          }
+
+          if (haloFound) {
+
+            // Cell is a halo.
+            localCells.emplace_back();
+            LocalElem& localCell = localCells.back();
+
+            localCell.type = ElemType::HALO;
+            localCell.halo = halo;
+            localCell.i = i;
+            localCell.j = j;
+            localCell.t = t;
+            localCell.globalPtr = &globalCell;
+
+          } // Finished with halo search.
+        } // Finished with cell.
+      }
+    } // Finished with all cells on tile.
+  } // Finished with all tiles.
+
+  // Partition by cell type.
+  auto haloBeginIt =
+    std::stable_partition(localCells.begin(), localCells.end(),
+    [](const LocalElem& cell) -> bool {return cell.type == ElemType::OWNER;});
+
+  // Sort by halo.
+  std::stable_sort(haloBeginIt, localCells.end(),
+    [](const LocalElem& cellA, const LocalElem& cellB) -> bool
+    {return cellA.halo < cellB.halo;});
+
+  // Point global cell to local cell. This is needed to determine node halos.
+  // Need to determine remote index and partition if we haven't done so already.
+  for (LocalElem& cell : localCells) {
+
+    cell.globalPtr->localPtr = &cell;
+
+    if (cell.globalPtr->remoteIdx == undefinedIdx) {
+
+      const auto ijtGlobal =
+        jacobian.ijLocalToGlobal(PointIJ(cell.i + 0.5, cell.j + 0.5), cell.t);
+
+      const idx_t i = ijtGlobal.first.iCell();
+      const idx_t j = ijtGlobal.first.jCell();
+      const idx_t t = ijtGlobal.second;
+
+      ATLAS_ASSERT(interiorCell(i, j));
+
+      const GlobalElem& ownerCell = globalCells[getCellIdx(i, j, t)];
+
+      cell.globalPtr->remoteIdx = ownerCell.remoteIdx;
+      cell.globalPtr->part = ownerCell.part;
     }
+  }
 
-    ATLAS_ASSERT( nodeGlobalIdxCount == nNodesUnique + 1 );
-    ATLAS_ASSERT( idxSum( nodeLocalIdxCount ) == nNodesUnique );
+  // ---------------------------------------------------------------------------
+  // 5. LOCATE LOCAL NODES.
+  //    We can now locate the nodes surrounding the owner and halo cells on the
+  //    mesh.
+  // ---------------------------------------------------------------------------
 
-    // Deal with type-A ghost nodes.
-    for ( auto* nodePtr : typeAGhostNodes ) {
-        // Set global index.
-        nodePtr->globalIdx = nodeGlobalIdxCount++;
+  // Make vector of local nodes.
+  auto localNodes = std::vector<LocalElem>{};
 
-        // Set local index.
-        nodePtr->localIdx = nodeLocalIdxCount[idx2st( nodePtr->localPart )]++;
+  // Loop over all possible local nodes.
+  for (idx_t t = 0; t < 6; ++t) {
 
-        // Get jacobian.
-        const auto& jac = jacs[idx2st( nodePtr->t )];
+    // Limit range to bounds recorded earlier.
+    const BoundingBox& bounds = cellBounds[static_cast<size_t>(t)];
 
-        // Get actual i and j.
-        const auto dx = nodePtr->remoteXy.x() - jac.xy00.x();
-        const auto dy = nodePtr->remoteXy.y() - jac.xy00.y();
-        const auto i  = static_cast<idx_t>( std::round( dx * jac.diByDx + dy * jac.diByDy ) );
-        const auto j  = static_cast<idx_t>( std::round( dx * jac.djByDx + dy * jac.djByDy ) );
+    for (idx_t j = bounds.jBegin; j < bounds.jEnd + 1; ++j) {
+      for (idx_t i = bounds.iBegin; i < bounds.iEnd + 1; ++i) {
 
-        // Get remote node.
-        const auto& remoteNode = globalNodes[getNodeIdx( nodePtr->t, j, i )];
+        if (invalidNode(i, j)) continue;
 
-        // Set partition and remote index.
-        nodePtr->remotePart = remoteNode.localPart;
-        nodePtr->remoteIdx  = remoteNode.localIdx;
+        // Get node.
+        GlobalElem& globalNode = globalNodes[getNodeIdx(i, j, t)];
 
-        // Node is a ghost.
-        nodePtr->ghost = true;
+        // Check if node is an owner.
+        if (globalNode.part == static_cast<idx_t>(thisPart)) {
 
-        // Check that remote index is now defined.
-        ATLAS_ASSERT( nodePtr->remoteIdx != undefinedIdx );
-    }
+          // Node is an owner.
+          localNodes.emplace_back();
+          LocalElem& localNode = localNodes.back();
 
-    ATLAS_ASSERT( nodeGlobalIdxCount == nNodesAll + 1 );
-    ATLAS_ASSERT( idxSum( nodeLocalIdxCount ) == nNodesAll );
+          localNode.type = ElemType::OWNER;
+          localNode.halo = 0;
+          localNode.i = i;
+          localNode.j = j;
+          localNode.t = t;
+          localNode.globalPtr = &globalNode;
 
-    // ---------------------------------------------------------------------------
-    // 4. LOCATE AND COUNT LOCAL TYPE-B GHOST NODES.
-    // ---------------------------------------------------------------------------
+        } else {
 
-    // Make list of local nodes (this simplifies part 5).
-    auto localNodes = std::vector<const NodeRecord*>{};
+          // Node is possibly a ghost or halo.
 
-    // Loop over all possible local nodes.
-    for ( idx_t t = 0; t < nTiles; ++t ) {
-        // Limit range to bounds recorded earlier.
-        const auto bounds = cellBounds[idx2st( t )];
+          // Search four neighbouring cells of node.
+          bool isGhost = false;
+          idx_t halo = nHalo;
 
-        for ( idx_t j = bounds.jBegin; j < bounds.jEnd + 1; ++j ) {
-            for ( idx_t i = bounds.iBegin; i < bounds.iEnd + 1; ++i ) {
-                // Get node.
-                auto& node = globalNodes[getNodeIdx( t, j, i )];
+          // A double-loop with no more than four iterations!
+          for (idx_t iCell = i - 1; iCell < i + 1; ++iCell) {
+            for (idx_t jCell = j - 1; jCell < j + 1; ++jCell) {
 
-                // Get four neighbouring cells of node. (cell0 is owner of node).
-                const auto& cell0 = globalCells[getCellIdx( t, j - 1, i - 1 )];
-                const auto& cell1 = globalCells[getCellIdx( t, j - 1, i )];
-                const auto& cell2 = globalCells[getCellIdx( t, j, i )];
-                const auto& cell3 = globalCells[getCellIdx( t, j, i - 1 )];
+              if (invalidCell(iCell, jCell)) continue;
 
-                if ( cell0.part == st2idx( thisPart ) ) {
-                    // Check that node-cell partitions match.
-                    ATLAS_ASSERT( node.localPart == cell0.part );
+              const GlobalElem& cell = globalCells[getCellIdx(iCell, jCell, t)];
 
-                    // Node is either owned or Type-A ghost.
-                    localNodes.push_back( &node );
-                }
-                else if ( cell1.part == st2idx( thisPart ) || cell2.part == st2idx( thisPart ) ||
-                          cell3.part == st2idx( thisPart ) ) {
-                    // Node has a non-owning neighbouring cell and is a type-B ghost.
-
-                    // Change local index to match this partition.
-                    node.localPart = st2idx( thisPart );
-                    node.localIdx  = nodeLocalIdxCount[thisPart]++;
-                    node.ghost     = true;
-
-                    // Check remote index is defined.
-                    ATLAS_ASSERT( node.remoteIdx != undefinedIdx );
-
-                    localNodes.push_back( &node );
-                }
+              // Get halo information from cell.
+              // By this point, any global cell on this PE will have a
+              // non-null local cell pointer.
+              if (cell.localPtr) {
+                isGhost = true;
+                halo = std::min(halo, cell.localPtr->halo);
+              }
             }
-        }
+          }
+
+          if (isGhost) {
+
+            // Node is an ghost/halo.
+            localNodes.emplace_back();
+            LocalElem& localNode = localNodes.back();
+
+            localNode.type = ElemType::HALO;
+            localNode.halo = halo;
+            localNode.i = i;
+            localNode.j = j;
+            localNode.t = t;
+            localNode.globalPtr = &globalNode;
+
+          }
+
+        } // Finished with this node.
+      }
+    } // Finished with all nodes on tile.
+  } // Finished with all tiles.
+
+  // Partition by node type.
+  auto ghostBeginIt =
+    std::stable_partition(localNodes.begin(), localNodes.end(),
+    [](const LocalElem& node) -> bool {return node.type == ElemType::OWNER;});
+
+  // Sort by halo.
+  std::stable_sort(ghostBeginIt, localNodes.end(),
+    [](const LocalElem& nodeA, const LocalElem& nodeB) -> bool
+    {return nodeA.halo < nodeB.halo;});
+
+  // Associate global nodes with local nodes. Allows us to determine node
+  // local indices around a cell.
+  // Determine partition and remote index if we haven't done so already.
+  for (LocalElem& node : localNodes) {
+
+    node.globalPtr->localPtr = &node;
+
+    if (node.globalPtr->remoteIdx == undefinedIdx) {
+
+      const auto ijtGlobal =
+        jacobian.ijLocalToGlobal(PointIJ(node.i, node.j), node.t);
+
+      const idx_t i = ijtGlobal.first.iNode();
+      const idx_t j = ijtGlobal.first.jNode();
+      const idx_t t = ijtGlobal.second;
+
+      ATLAS_ASSERT(!exteriorNode(i, j));
+
+      const GlobalElem& ownerNode =
+        globalNodes[getNodeIdx(i, j, t)];
+
+      node.globalPtr->remoteIdx = ownerNode.remoteIdx;
+      node.globalPtr->part = ownerNode.part;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // 6. ASSIGN NODES TO MESH
+  //    In addition to the usual fields, we will add i, j and t to mesh.nodes().
+  // ---------------------------------------------------------------------------
+
+  // Resize nodes.
+  auto& nodes = mesh.nodes();
+  nodes.resize(static_cast<idx_t>(localNodes.size()));
+
+  // Add extra field.
+  Field ijtField =
+    nodes.add(Field("ijt", make_datatype<idx_t>(), make_shape(nodes.size(), 3)));
+  ijtField.set_variables(3);
+
+  // Get field views
+  auto nodesGlobalIdx = array::make_view<gidx_t, 1>(nodes.global_index());
+  auto nodesRemoteIdx = array::make_indexview<idx_t, 1>(nodes.remote_index());
+  auto nodesXy        = array::make_view<double, 2>(nodes.xy());
+  auto nodesLonLat    = array::make_view<double, 2>(nodes.lonlat());
+  auto nodesPart      = array::make_view<int, 1>(nodes.partition());
+  auto nodesGhost     = array::make_view<int, 1>(nodes.ghost());
+  auto nodesHalo      = array::make_view<int, 1>(nodes.halo());
+  auto nodesFlags     = array::make_view<int, 1>(nodes.flags());
+  auto nodesIjt       = array::make_view<idx_t, 2>(ijtField);
+
+  // Set fields.
+  idx_t nodeLocalIdx = 0;
+  for (const LocalElem& node : localNodes) {
+
+    // Set global index.
+    nodesGlobalIdx(nodeLocalIdx) = node.globalPtr->globalIdx;
+
+    // Set node remote index.
+    nodesRemoteIdx(nodeLocalIdx) = node.globalPtr->remoteIdx;
+
+    // Set node partition.
+    nodesPart(nodeLocalIdx) = node.globalPtr->part;
+
+    // Set xy.
+    const PointXY xyLocal = jacobian.xy(PointIJ(node.i, node.j), node.t);
+    const PointXY xyGlobal = interiorNode(node.i, node.j) ?
+      xyLocal : jacobian.xyLocalToGlobal(xyLocal, node.t).first;
+
+    nodesXy(nodeLocalIdx, XX) = xyLocal.x();
+    nodesXy(nodeLocalIdx, YY) = xyLocal.y();
+
+    // Set lon-lat.
+    const PointLonLat lonLat = csProjection->lonlat(xyGlobal);
+    nodesLonLat(nodeLocalIdx, LON) = lonLat.lon();
+    nodesLonLat(nodeLocalIdx, LAT) = lonLat.lat();
+
+    // Set tij.
+    nodesIjt(nodeLocalIdx, Coordinates::I) = node.i;
+    nodesIjt(nodeLocalIdx, Coordinates::J) = node.j;
+    nodesIjt(nodeLocalIdx, Coordinates::T) = node.t;
+
+    // Set halo.
+    nodesHalo(nodeLocalIdx) = node.halo;
+    ATLAS_ASSERT(node.halo != undefinedIdx);
+
+    // Set flags.
+    Topology::reset(nodesFlags(nodeLocalIdx));
+    switch(node.type) {
+
+      case ElemType::UNDEFINED : {
+        ATLAS_ASSERT(0);
+        break;
+      }
+      case ElemType::OWNER : {
+        nodesGhost(nodeLocalIdx) = 0;
+        // Vitally important that these two match!
+        ATLAS_ASSERT(nodeLocalIdx == node.globalPtr->remoteIdx);
+        break;
+      }
+      case ElemType::HALO : {
+        nodesGhost(nodeLocalIdx) = 1;
+        Topology::set(nodesFlags(nodeLocalIdx), Topology::GHOST);
+        break;
+      }
     }
 
-    // ---------------------------------------------------------------------------
-    // 5. ASSIGN NODES TO MESH
-    // ---------------------------------------------------------------------------
+    ++nodeLocalIdx;
+  }
 
-    // Resize nodes.
-    mesh.nodes().resize( nodeLocalIdxCount[thisPart] );
+  // ---------------------------------------------------------------------------
+  // 7. ASSIGN CELLS TO MESH
+  //    Again, we'll add i, j and t to mesh.cells(). We'll also add the xy and
+  //    lonlat coordinates of the cell centres.
+  // ---------------------------------------------------------------------------
 
-    // Get field views
-    auto nodesGlobalIdx = array::make_view<gidx_t, 1>( mesh.nodes().global_index() );
-    auto nodesRemoteIdx = array::make_indexview<idx_t, 1>( mesh.nodes().remote_index() );
-    auto nodesXy        = array::make_view<double, 2>( mesh.nodes().xy() );
-    auto nodesLonLat    = array::make_view<double, 2>( mesh.nodes().lonlat() );
-    auto nodesPart      = array::make_view<int, 1>( mesh.nodes().partition() );
-    auto nodesGhost     = array::make_view<int, 1>( mesh.nodes().ghost() );
-    auto nodesFlags     = array::make_view<int, 1>( mesh.nodes().flags() );
+  auto& cells = mesh.cells();
 
-    // Set fields.
-    for ( const auto* nodePtr : localNodes ) {
-        // Get local index.
-        const auto localIdx = nodePtr->localIdx;
+  // Resize cells.
+  cells.add(new mesh::temporary::Quadrilateral(), static_cast<idx_t>(localCells.size()));
 
-        // Set global index.
-        nodesGlobalIdx( localIdx ) = nodePtr->globalIdx;
+  // Add extra fields.
+  ijtField = cells.add(
+      Field("ijt", make_datatype<idx_t>(), make_shape(cells.size(), 3)));
+  ijtField.set_variables(3);
 
-        // Set node remote index.
-        nodesRemoteIdx( localIdx ) = nodePtr->remoteIdx;
+  Field xyField =
+   cells.add(Field("xy", make_datatype<double>(), make_shape(cells.size(), 2)));
+  xyField.set_variables(2);
 
-        // Set node partition.
-        nodesPart( localIdx ) = nodePtr->remotePart;
+  Field lonLatField =
+    cells.add(Field("lonlat", make_datatype<double>(), make_shape(cells.size(), 2)));
+  lonLatField.set_variables(2);
 
-        // Set xy.
-        nodesXy( localIdx, XX ) = nodePtr->localXy.x();
-        nodesXy( localIdx, YY ) = nodePtr->localXy.y();
+  // Set field views.
+  auto cellsGlobalIdx = array::make_view<gidx_t, 1>(cells.global_index());
+  auto cellsRemoteIdx = array::make_indexview<idx_t, 1>(cells.remote_index());
+  auto cellsPart      = array::make_view<int, 1>(cells.partition());
+  auto cellsHalo      = array::make_view<int, 1>(cells.halo());
+  auto cellsFlags     = array::make_view<int, 1>(cells.flags());
+  auto cellsIjt       = array::make_view<idx_t, 2>(ijtField);
+  auto cellsXy        = array::make_view<double, 2>(xyField);
+  auto cellsLonLat    = array::make_view<double, 2>(lonLatField);
 
-        // Set lon-lat.
-        const auto lonLat            = csProjection->lonlat( nodePtr->remoteXy );
-        nodesLonLat( localIdx, LON ) = lonLat.lon();
-        nodesLonLat( localIdx, LAT ) = lonLat.lat();
+  // Set local cells.
+  auto& nodeConnectivity = cells.node_connectivity();
+  const idx_t cellElemIdx0 = cells.elements(0).begin();
 
-        // Set ghost flag.
-        nodesGhost( localIdx ) = nodePtr->ghost;
+  // Set method to get node local index.
+  const auto getNodeLocalIdx = [&](idx_t i, idx_t j, idx_t t) -> idx_t {
 
-        // Set general flags.
-        Topology::reset( nodesFlags( localIdx ) );
-        if ( nodePtr->ghost )
-            Topology::set( nodesFlags( localIdx ), Topology::GHOST );
+    const GlobalElem& node = globalNodes[getNodeIdx(i, j, t)];
+
+    // Do some pointer arithmetic to get local index.
+    return static_cast<idx_t>(node.localPtr - localNodes.data());
+  };
+
+  idx_t cellLocalIdx = 0;
+  for (const LocalElem& cell : localCells) {
+
+    // Get local indices four surroundings nodes.
+    const auto quadNodeIdx = std::array<idx_t, 4> {
+      getNodeLocalIdx(cell.i    , cell.j    , cell.t),
+      getNodeLocalIdx(cell.i + 1, cell.j    , cell.t),
+      getNodeLocalIdx(cell.i + 1, cell.j + 1, cell.t),
+      getNodeLocalIdx(cell.i    , cell.j + 1, cell.t)};
+
+    // Set connectivity.
+    nodeConnectivity.set(cellLocalIdx + cellElemIdx0, quadNodeIdx.data());
+
+    // Set global index.
+    cellsGlobalIdx(cellLocalIdx) = cell.globalPtr->globalIdx;
+
+    // Set cell remote index.
+    cellsRemoteIdx(cellLocalIdx) = cell.globalPtr->remoteIdx;
+
+    // Set partition.
+    cellsPart(cellLocalIdx) = cell.globalPtr->part;
+
+    // Set xy.
+    const PointXY xyLocal = jacobian.xy(PointIJ(cell.i + 0.5, cell.j + 0.5), cell.t);
+    const PointXY xyGlobal = interiorCell(cell.i, cell.j) ?
+      xyLocal : jacobian.xyLocalToGlobal(xyLocal, cell.t).first;
+
+    cellsXy(cellLocalIdx, XX) = xyLocal.x();
+    cellsXy(cellLocalIdx, YY) = xyLocal.y();
+
+    // Set lon-lat.
+    const PointLonLat lonLat = csProjection->lonlat(xyGlobal);
+    cellsLonLat(cellLocalIdx, LON) = lonLat.lon();
+    cellsLonLat(cellLocalIdx, LAT) = lonLat.lat();
+
+    // Set ijt.
+    cellsIjt(cellLocalIdx, Coordinates::I) = cell.i;
+    cellsIjt(cellLocalIdx, Coordinates::J) = cell.j;
+    cellsIjt(cellLocalIdx, Coordinates::T) = cell.t;
+
+    // Set halo.
+    cellsHalo(cellLocalIdx) = cell.halo;
+
+    ATLAS_ASSERT(cell.halo != undefinedIdx);
+
+    // Set flags.
+    Topology::reset(cellsFlags(cellLocalIdx));
+    switch(cell.type) {
+
+      case ElemType::UNDEFINED : {
+        ATLAS_ASSERT(0);
+        break;
+      }
+      case ElemType::OWNER : {
+        // Vitally important that these two match!
+        ATLAS_ASSERT(cellLocalIdx == cell.globalPtr->remoteIdx);
+        break;
+      }
+      case ElemType::HALO : {
+        Topology::set(cellsFlags(cellLocalIdx), Topology::GHOST);
+        break;
+      }
     }
 
-    // ---------------------------------------------------------------------------
-    // 6. ASSIGN CELLS TO MESH
-    // ---------------------------------------------------------------------------
+    ++cellLocalIdx;
+  }
 
-    // Resize cells.
-    mesh.cells().add( new mesh::temporary::Quadrilateral(), cellIdxCount[thisPart] );
+  // ---------------------------------------------------------------------------
+  // 8. FINALISE
+  //    Done. That was rather a lot of bookkeeping!
+  // ---------------------------------------------------------------------------
 
-    // Set field views.
-    auto cellsGlobalIdx = array::make_view<gidx_t, 1>( mesh.cells().global_index() );
-    auto cellsPart      = array::make_view<int, 1>( mesh.cells().partition() );
+  mesh.metadata().set("halo", nHalo);
+  mesh.metadata().set("halo_locked", true);
 
-    // Set local cells.
-    auto& nodeConnectivity = mesh.cells().node_connectivity();
-    const auto idx0        = mesh.cells().elements( 0 ).begin();
+  mesh.nodes().metadata().set("parallel", true);
+  mesh.nodes().metadata().set("nb_owned", nodeLocalIdxCount[thisPart]);
 
-    for ( idx_t t = 0; t < nTiles; ++t ) {
-        // Use bounds from before.
-        const auto bounds = cellBounds[idx2st( t )];
+  mesh.cells().metadata().set("parallel", true);
+  mesh.cells().metadata().set("nb_owned", cellLocalIdxCount[thisPart]);
 
-        for ( idx_t j = bounds.jBegin; j < bounds.jEnd; ++j ) {
-            for ( idx_t i = bounds.iBegin; i < bounds.iEnd; ++i ) {
-                // Get cell.
-                const auto& cell = globalCells[getCellIdx( t, j, i )];
-
-                // Only add cells on this partition.
-                if ( cell.part == st2idx( thisPart ) ) {
-                    // Get local index.
-                    const auto localIdx = cell.localIdx + idx0;
-
-                    // Set quadrilateral.
-                    const auto& node0 = globalNodes[getNodeIdx( t, j, i )];
-                    const auto& node1 = globalNodes[getNodeIdx( t, j, i + 1 )];
-                    const auto& node2 = globalNodes[getNodeIdx( t, j + 1, i + 1 )];
-                    const auto& node3 = globalNodes[getNodeIdx( t, j + 1, i )];
-
-                    // Check nodes partitions match.
-                    ATLAS_ASSERT( node0.localPart == cell.part );
-                    ATLAS_ASSERT( node1.localPart == cell.part );
-                    ATLAS_ASSERT( node2.localPart == cell.part );
-                    ATLAS_ASSERT( node3.localPart == cell.part );
-
-                    const auto quadNodeIdx =
-                        std::array<idx_t, 4>{node0.localIdx, node1.localIdx, node2.localIdx, node3.localIdx};
-
-                    // Set connectivity.
-                    nodeConnectivity.set( localIdx, quadNodeIdx.data() );
-
-                    // Set global index.
-                    cellsGlobalIdx( localIdx ) = cell.globalIdx;
-
-                    // Set partition.
-                    cellsPart( localIdx ) = cell.part;
-                }
-            }
-        }
-    }
-
-    // ---------------------------------------------------------------------------
-    // 7. FINALISE
-    // ---------------------------------------------------------------------------
-
-    mesh.nodes().global_index().metadata().set( "human_readable", true );
-    mesh.nodes().global_index().metadata().set( "min", 1 );
-    mesh.nodes().global_index().metadata().set( "max", nNodesAll );
-    mesh.nodes().metadata().set( "parallel", true );
-
-    mesh.cells().global_index().metadata().set( "human_readable", true );
-    mesh.cells().global_index().metadata().set( "min", 1 );
-    mesh.cells().global_index().metadata().set( "max", nCells );
-    mesh.cells().metadata().set( "parallel", true );
-
-    return;
+  return;
 }
 
 // -----------------------------------------------------------------------------
 
-void CubedSphereMeshGenerator::hash( eckit::Hash& h ) const {
-    h.add( "CubedSphereMeshGenerator" );
-    options.hash( h );
+void CubedSphereMeshGenerator::hash(eckit::Hash& h) const {
+h.add("CubedSphereMeshGenerator");
+options.hash(h);
 }
 
 // -----------------------------------------------------------------------------
 
 namespace {
 static MeshGeneratorBuilder<CubedSphereMeshGenerator> CubedSphereMeshGenerator(
-    CubedSphereMeshGenerator::static_type() );
+CubedSphereMeshGenerator::static_type());
 }
 
 // -----------------------------------------------------------------------------

--- a/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
@@ -524,7 +524,7 @@ void CubedSphereMeshGenerator::generate_mesh( const CubedSphereGrid& csGrid, con
                 else {
                     // Cell is halo if there are nearby owners.
                     bool ownerFound = false;
-                    idx_t halo     = nHalo;
+                    idx_t halo      = nHalo;
                     for ( idx_t jHalo = j - nHalo; jHalo < j + nHalo + 1; ++jHalo ) {
                         for ( idx_t iHalo = i - nHalo; iHalo < i + nHalo + 1; ++iHalo ) {
                             if ( invalidCell( iHalo, jHalo ) || ( iHalo == i && jHalo == j ) )

--- a/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
@@ -522,8 +522,8 @@ void CubedSphereMeshGenerator::generate_mesh( const CubedSphereGrid& csGrid, con
                     localCell.globalPtr = &globalCell;
                 }
                 else {
-                    // Check if cell is halo.
-                    bool haloFound = false;
+                    // Cell is halo if there are nearby owners.
+                    bool ownerFound = false;
                     idx_t halo     = nHalo;
                     for ( idx_t jHalo = j - nHalo; jHalo < j + nHalo + 1; ++jHalo ) {
                         for ( idx_t iHalo = i - nHalo; iHalo < i + nHalo + 1; ++iHalo ) {
@@ -533,11 +533,11 @@ void CubedSphereMeshGenerator::generate_mesh( const CubedSphereGrid& csGrid, con
                             // Is there a nearby owner cell?
                             const GlobalElem& ownerCell = globalCells[getCellIdx( iHalo, jHalo, t )];
 
-                            const bool isHalo = ownerCell.part == static_cast<idx_t>( thisPart );
+                            const bool isOwner = ownerCell.part == static_cast<idx_t>( thisPart );
 
-                            haloFound = haloFound || isHalo;
+                            ownerFound = ownerFound || isOwner;
 
-                            if ( isHalo ) {
+                            if ( isOwner ) {
                                 // Determine halo level from cell distance (l-infinity norm).
                                 const idx_t dist = std::max( std::abs( iHalo - i ), std::abs( jHalo - j ) );
 
@@ -546,7 +546,7 @@ void CubedSphereMeshGenerator::generate_mesh( const CubedSphereGrid& csGrid, con
                         }
                     }
 
-                    if ( haloFound ) {
+                    if ( ownerFound ) {
                         // Cell is a halo.
                         localCells.emplace_back();
                         LocalElem& localCell = localCells.back();

--- a/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
@@ -44,947 +44,885 @@ namespace meshgenerator {
 
 // -----------------------------------------------------------------------------
 
-CubedSphereMeshGenerator::CubedSphereMeshGenerator(const eckit::Parametrisation& p) {
+CubedSphereMeshGenerator::CubedSphereMeshGenerator( const eckit::Parametrisation& p ) {
+    configure_defaults();
 
-  configure_defaults();
+    // Get number of partitions.
+    size_t nb_parts;
+    if ( p.get( "nb_parts", nb_parts ) )
+        options.set( "nb_parts", nb_parts );
 
-  // Get number of partitions.
-  size_t nb_parts;
-  if (p.get("nb_parts", nb_parts)) options.set("nb_parts", nb_parts);
+    // Get this partition.
+    size_t part;
+    if ( p.get( "part", part ) )
+        options.set( "part", part );
 
-  // Get this partition.
-  size_t part;
-  if (p.get("part", part)) options.set("part", part);
+    // Get halo size.
+    idx_t halo;
+    if ( p.get( "halo", halo ) )
+        options.set( "halo", halo );
 
-  // Get halo size.
-  idx_t halo;
-  if (p.get("halo", halo)) options.set("halo", halo);
-
-  // Get partitioner.
-  std::string partitioner;
-  if (p.get("partitioner", partitioner)) options.set("partitioner", partitioner);
-
+    // Get partitioner.
+    std::string partitioner;
+    if ( p.get( "partitioner", partitioner ) )
+        options.set( "partitioner", partitioner );
 }
 
 // -----------------------------------------------------------------------------
 
 
 void CubedSphereMeshGenerator::configure_defaults() {
+    // This option sets number of partitions.
+    options.set( "nb_parts", mpi::size() );
 
-  // This option sets number of partitions.
-  options.set( "nb_parts", mpi::size() );
+    // This option sets the part that will be generated.
+    options.set( "part", mpi::rank() );
 
-  // This option sets the part that will be generated.
-  options.set("part", mpi::rank());
+    // This options sets the number of halo elements around each partition.
+    options.set( "halo", idx_t{1} );
 
-  // This options sets the number of halo elements around each partition.
-  options.set("halo", idx_t{1});
-
-  // This options sets the default partitioner.
-  options.set<std::string>("partitioner", "cubedsphere");
+    // This options sets the default partitioner.
+    options.set<std::string>( "partitioner", "cubedsphere" );
 }
 
 // -----------------------------------------------------------------------------
 
-void CubedSphereMeshGenerator::generate(const Grid& grid, Mesh& mesh) const {
+void CubedSphereMeshGenerator::generate( const Grid& grid, Mesh& mesh ) const {
+    // Get partitioner type and number of partitions from config.
+    const auto nParts   = static_cast<idx_t>( options.get<size_t>( "nb_parts" ) );
+    const auto partType = options.get<std::string>( "partitioner" );
 
-  // Get partitioner type and number of partitions from config.
-  const auto nParts = static_cast<idx_t>(options.get<size_t>("nb_parts"));
-  const auto partType = options.get<std::string>("partitioner");
+    auto partConfig = util::Config{};
+    partConfig.set( "type", partType );
+    partConfig.set( "partitions", nParts );
 
-  auto partConfig = util::Config{};
-  partConfig.set("type", partType);
-  partConfig.set("partitions", nParts);
+    // Use lonlat instead of xy for equal_regions partitioner.
+    if ( partType == "equal_regions" )
+        partConfig.set( "coordinates", "lonlat" );
 
-  // Use lonlat instead of xy for equal_regions partitioner.
-  if (partType == "equal_regions") partConfig.set("coordinates", "lonlat");
+    // Set distribution.
+    const auto partitioner  = grid::Partitioner( partConfig );
+    const auto distribution = grid::Distribution( grid, partitioner );
 
-  // Set distribution.
-  const auto partitioner = grid::Partitioner(partConfig);
-  const auto distribution = grid::Distribution(grid, partitioner);
-
-  generate(grid, distribution, mesh);
-
+    generate( grid, distribution, mesh );
 }
 
 // -----------------------------------------------------------------------------
 
-void CubedSphereMeshGenerator::generate(const Grid& grid,
-  const grid::Distribution& distribution, Mesh& mesh) const {
-
-  // Check for correct grid and need for mesh
-  ATLAS_ASSERT(!mesh.generated());
-  if (!CubedSphereGrid(grid)) {
-    throw_Exception("CubedSphereMeshGenerator can only work "
-    "with a cubedsphere grid.", Here());
-  }
-
-  // Cast grid to cubed sphere grid.
-  const auto csGrid = CubedSphereGrid(grid);
-
-  // Clone some grid properties.
-  setGrid(mesh, csGrid, distribution);
-
-  generate_mesh(csGrid, distribution, mesh);
-}
-
-// -----------------------------------------------------------------------------
-
-void CubedSphereMeshGenerator::generate_mesh(const CubedSphereGrid& csGrid,
-  const grid::Distribution& distribution, Mesh& mesh) const {
-
-  ATLAS_TRACE("CubedSphereMeshGenerator::generate");
-
-  // ---------------------------------------------------------------------------
-  // CUBED SPHERE MESH GENERATOR
-  // ---------------------------------------------------------------------------
-  //
-  // Mesh generator creates a cubed sphere mesh by generating individual meshes
-  // for each cubed sphere tile and then working out the correspondence between
-  // overlapping nodes and cells.
-  //
-  // Meshgenerator places cell at each grid point on this partition. Halo
-  // cells are added to the mesh if options.get("halo") > 0. The halo cells may
-  // either be interior to the tile, || exterior. Interior halo cells share
-  // their xy coordinate and global ID with the corresponding cells on other
-  // partitions. Exterior halo cells have a unique global ID and their xy
-  // coordinates are extrapolated from the interior tile. The global IDs of non-
-  // halo cells match the global IDs of the cell-centre grid points.
-  //
-  // Nodes are added around cells. The nodes around interior cells are assigned
-  // an owner by the following rules:
-  //    * node (i > 0, j > 0) is owned by cell (i - 1, j - 1)
-  //    * node (i = 0, j > 0) is owned by cell (0    , j - 1)
-  //    * node (i > 0, j = 0) is owned by cell (i - 1, 0    )
-  //    * node (i = 0, j = 0) is owned by cell (0    , 0    )
-  //
-  // The partition of the owning cell determines the partition of the node.
-  // Ghost nodes are added to the mesh to complete cells at partition
-  // boundaries, cells exterior to the tiles, or on tile edges which do not
-  // own nodes.
-  //
-  // There are several stages to the mesh generator:
-  //    1. Preamble.
-  //    2. Define global cell distribution.
-  //    3. Define global node distribution.
-  //    4. Locate local cells.
-  //    5. Locate local nodes
-  //    6. Assign nodes to mesh.
-  //    7. Assign cells to mesh.
-  //    8. Finalise.
-
-  // ---------------------------------------------------------------------------
-  // 1. PREAMBLE
-  //    Setup some general parameters of the mesh, as well as define useful
-  //    lambda functions and structs.
-  // ---------------------------------------------------------------------------
-
-  using Topology = atlas::mesh::Nodes::Topology;
-  using atlas::array::make_datatype;
-  using atlas::array::make_shape;
-
-  using namespace detail::cubedsphere;
-
-  struct GlobalElem;
-  struct LocalElem;
-
-  // Define bad index values.
-  constexpr idx_t undefinedIdx       = -1;
-  constexpr idx_t undefinedGlobalIdx = -1;
-
-  // Define cell/node type.
-  enum class ElemType {
-    UNDEFINED,  // Not set. Writing this type to mesh is an error.
-    OWNER,      // Owner element on this partition.
-    HALO        // Ghost or halo element.
-  };
-
-  // Struct to store the information of globals cells/nodes.
-  // These must be generated for all cells/nodes on all partitions. Data is
-  // stored in (t, j, i) row-major order.
-  struct GlobalElem {
-    LocalElem* localPtr{};                    // Pointer to local element.
-    gidx_t     globalIdx{undefinedGlobalIdx}; // Global index.
-    idx_t      remoteIdx{undefinedIdx};       // Remote index.
-    idx_t      part{undefinedIdx};            // Partition.
-  };
-
-  // Struct to store additional information of local cells/nodes.
-  // These are only generated for nodes on this partition. Data is stored as a
-  // list which can be sorted.
-  struct LocalElem {
-    GlobalElem* globalPtr{};                  // Pointer to global element.
-    ElemType    type{ElemType::UNDEFINED};    // Cell/node Type.
-    idx_t       halo{undefinedIdx};           // Halo level.
-    idx_t       i{}, j{}, t{};                // i, j and t.
-  };
-
-  // Define ij bounding box for each face (this partition only).
-  struct BoundingBox {
-    idx_t iBegin{std::numeric_limits<idx_t>::max()};
-    idx_t iEnd{std::numeric_limits<idx_t>::min()};
-    idx_t jBegin{std::numeric_limits<idx_t>::max()};
-    idx_t jEnd{std::numeric_limits<idx_t>::min()};
-  };
-
-
-  // Check for correct grid stagger.
-  if (csGrid.stagger() != "C") {
-    throw_Exception("CubedSphereMeshGenerator will only work with a"
-    "cell-centroid grid. Try NodalCubedSphereMeshGenerator instead.", Here());
-  }
-
-  // Get dimensions of grid
-  const idx_t N = csGrid.N();
-
-  // Get size of halo.
-  idx_t nHalo = 0;
-  options.get("halo", nHalo);
-
-  // Unique non-halo nodes and cells.
-  const idx_t nNodesUnique = 6 * N * N + 2;
-  const idx_t nCellsUnique = 6 * N * N;
-
-  // Total array sizes (including invalid corner ijs).
-  const idx_t nNodesArray   = 6 * (N + 2 * nHalo + 1) * (N + 2 * nHalo + 1);
-  const idx_t nCellsArray   = 6 * (N + 2 * nHalo) * (N + 2 * nHalo);
-
-  // Total number of possible cells and nodes (including halos).
-  const idx_t nNodesTotal  = nNodesArray - 6 * 4 * nHalo * nHalo;
-  const idx_t nCellsTotal  = nCellsArray - 6 * 4 * nHalo * nHalo;
-
-  // Projection and jacobian.
-  const auto* const csProjection = castProjection(csGrid.projection().get());
-  const auto jacobian = NeighbourJacobian(csGrid);
-
-  // Get partition information.
-  const auto nParts = options.get<size_t>("nb_parts");
-  const auto thisPart = options.get<size_t>("part");
-
-  // Define an index counter.
-  const auto idxSum = [](const std::vector<idx_t>& idxCounts) -> idx_t {
-    return std::accumulate(idxCounts.begin(), idxCounts.end(), 0);};
-
-  // Helper functions to get node vector idx from (i, j, t).
-  const auto getNodeIdx = [&](idx_t i, idx_t j, idx_t t) -> size_t {
-
-    const idx_t rowSize = (N + 2 * nHalo + 1);
-    const idx_t tileSize = rowSize * rowSize;
-
-    return static_cast<size_t>(t * tileSize + (j + nHalo) * rowSize + i + nHalo);
-  };
-
-  // Helper functions to get cell vector idx from (i, j, t).
-  const auto getCellIdx = [&](idx_t i, idx_t j, idx_t t) -> size_t {
-
-    const idx_t rowSize = (N + 2 * nHalo);
-    const idx_t tileSize = rowSize * rowSize;
-
-    return static_cast<size_t>(t * tileSize + (j + nHalo) * rowSize + i + nHalo);
-
-  };
-
-  // Return true for nodes interior to tile (excluding edge).
-  const auto interiorNode = [&](idx_t i, idx_t j) -> bool {
-    return i > 0 && i < N && j > 0 && j < N;
-  };
-
-  // return true for nodes exterior to tile (excluding edge).
-  const auto exteriorNode = [&](idx_t i, idx_t j) -> bool {
-    return i < 0 || i > N || j < 0 || j > N;
-  };
-
-  // Return true for cells interior to tile.
-  const auto interiorCell = [&](idx_t i, idx_t j) -> bool {
-    return i >= 0 && i < N && j >= 0 && j < N;
-  };
-
-  // Return true for impossible node (i, j) combinations.
-  const auto invalidNode = [&](idx_t i, idx_t j) -> bool {
-
-    const bool inCorner = (i < 0 && j < 0) ||  // Bottom-left corner.
-                          (i > N && j < 0) ||  // Bottom-right corner.
-                          (i > N && j > N) ||  // Top-right corner.
-                          (i < 0 && j > N);    // Top-left corner.
-
-    if (inCorner) return true;
-
-    const bool outOfBounds = i < -nHalo || i > N + nHalo ||
-                             j < -nHalo || j > N + nHalo;
-
-    if (outOfBounds) return true;
-
-    return false;
-  };
-
-  // Return true for impossible cell (i, j) combinations.
-  const auto invalidCell = [&](idx_t i, idx_t j) -> bool {
-
-    const bool inCorner = (i < 0     && j < 0    ) ||  // Bottom-left corner.
-                          (i > N - 1 && j < 0    ) ||  // Bottom-right corner.
-                          (i > N - 1 && j > N - 1) ||  // Top-right corner.
-                          (i < 0     && j > N - 1);    // Top-left corner.
-
-    if (inCorner) return true;
-
-    const bool outOfBounds = i < -nHalo || i > N + nHalo - 1 ||
-                             j < -nHalo || j > N + nHalo - 1;
-
-    if (outOfBounds) return true;
-
-    return false;
-  };
-
-  // Return the (i, j) of cell that owns node (i, j).
-  // It's possible that this may need to be user-defined in the future.
-  const auto nodeOwnerCell =
-    [](idx_t iNode, idx_t jNode) -> std::pair<idx_t, idx_t> {
-    return std::make_pair(iNode > 0 ? iNode - 1 : iNode,
-                          jNode > 0 ? jNode - 1 : jNode);
-  };
-
-  // ---------------------------------------------------------------------------
-  // 2. GLOBAL CELL DISTRIBUTION
-  //    Need to construct a lightweight global mesh. This will help us pair up
-  //    local and remote indices on different partitions.
-  // ---------------------------------------------------------------------------
-
-  // Make vector of all possible cells.
-  auto globalCells = std::vector<GlobalElem>(static_cast<size_t>(nCellsArray));
-
-  // Initialise bounding box.
-  auto cellBounds = std::vector<BoundingBox>(static_cast<size_t>(6));
-
-  // Set tji grid iterator.
-  auto ijtIt = csGrid.tij().begin();
-
-  for (gidx_t gridIdx = 0; gridIdx < csGrid.size(); ++gridIdx) {
-
-    // It's more than likely that the grid order follows the same (t, j, i) row-
-    // major order of the mesh. However, we shouldn't assume this is true.
-
-    // Get cell index.
-    const idx_t i = (*ijtIt).i();
-    const idx_t j = (*ijtIt).j();
-    const idx_t t = (*ijtIt).t();
-    const size_t cellIdx = getCellIdx(i, j, t);
-    GlobalElem& globalCell = globalCells[cellIdx];
-
-    // Set global index.
-    globalCell.globalIdx = gridIdx + 1;
-
-    // Set partition.
-    globalCell.part = distribution.partition(gridIdx);
-
-    if (globalCell.part == static_cast<idx_t>(thisPart)) {
-
-      // Keep track of local (t, j, i) bounds.
-      BoundingBox& bounds = cellBounds[static_cast<size_t>(t)];
-      bounds.iBegin = std::min(bounds.iBegin, i - nHalo    );
-      bounds.iEnd   = std::max(bounds.iEnd  , i + nHalo + 1);
-      bounds.jBegin = std::min(bounds.jBegin, j - nHalo    );
-      bounds.jEnd   = std::max(bounds.jEnd  , j + nHalo + 1);
-
+void CubedSphereMeshGenerator::generate( const Grid& grid, const grid::Distribution& distribution, Mesh& mesh ) const {
+    // Check for correct grid and need for mesh
+    ATLAS_ASSERT( !mesh.generated() );
+    if ( !CubedSphereGrid( grid ) ) {
+        throw_Exception(
+            "CubedSphereMeshGenerator can only work "
+            "with a cubedsphere grid.",
+            Here() );
     }
-    // Increment iterators.
-    ++ijtIt;
-  }
 
-  // Set counters for cell local indices.
-  auto cellLocalIdxCount = std::vector<idx_t>(nParts, 0);
+    // Cast grid to cubed sphere grid.
+    const auto csGrid = CubedSphereGrid( grid );
 
-  // Give possible edge-halo cells a unique global ID.
-  gidx_t cellGlobalIdxCount = nCellsUnique + 1;
+    // Clone some grid properties.
+    setGrid( mesh, csGrid, distribution );
 
-  for (idx_t t = 0; t < 6; ++t) {
-    for (idx_t j = -nHalo; j < N + nHalo; ++j) {
-      for (idx_t i = -nHalo; i < N + nHalo; ++i) {
+    generate_mesh( csGrid, distribution, mesh );
+}
 
-        // Skip invalid cell.
-        if (invalidCell(i, j)) continue;
+// -----------------------------------------------------------------------------
 
-        // Get cell.
-        GlobalElem& globalCell = globalCells[getCellIdx(i, j, t)];
+void CubedSphereMeshGenerator::generate_mesh( const CubedSphereGrid& csGrid, const grid::Distribution& distribution,
+                                              Mesh& mesh ) const {
+    ATLAS_TRACE( "CubedSphereMeshGenerator::generate" );
 
-        // Set cell remote index if interior cell.
-        if (interiorCell(i, j)) {
+    // ---------------------------------------------------------------------------
+    // CUBED SPHERE MESH GENERATOR
+    // ---------------------------------------------------------------------------
+    //
+    // Mesh generator creates a cubed sphere mesh by generating individual meshes
+    // for each cubed sphere tile and then working out the correspondence between
+    // overlapping nodes and cells.
+    //
+    // Meshgenerator places cell at each grid point on this partition. Halo
+    // cells are added to the mesh if options.get("halo") > 0. The halo cells may
+    // either be interior to the tile, || exterior. Interior halo cells share
+    // their xy coordinate and global ID with the corresponding cells on other
+    // partitions. Exterior halo cells have a unique global ID and their xy
+    // coordinates are extrapolated from the interior tile. The global IDs of non-
+    // halo cells match the global IDs of the cell-centre grid points.
+    //
+    // Nodes are added around cells. The nodes around interior cells are assigned
+    // an owner by the following rules:
+    //    * node (i > 0, j > 0) is owned by cell (i - 1, j - 1)
+    //    * node (i = 0, j > 0) is owned by cell (0    , j - 1)
+    //    * node (i > 0, j = 0) is owned by cell (i - 1, 0    )
+    //    * node (i = 0, j = 0) is owned by cell (0    , 0    )
+    //
+    // The partition of the owning cell determines the partition of the node.
+    // Ghost nodes are added to the mesh to complete cells at partition
+    // boundaries, cells exterior to the tiles, or on tile edges which do not
+    // own nodes.
+    //
+    // There are several stages to the mesh generator:
+    //    1. Preamble.
+    //    2. Define global cell distribution.
+    //    3. Define global node distribution.
+    //    4. Locate local cells.
+    //    5. Locate local nodes
+    //    6. Assign nodes to mesh.
+    //    7. Assign cells to mesh.
+    //    8. Finalise.
 
-          // Set remote index.
-          globalCell.remoteIdx =
-            cellLocalIdxCount[static_cast<size_t>(globalCell.part)]++;
+    // ---------------------------------------------------------------------------
+    // 1. PREAMBLE
+    //    Setup some general parameters of the mesh, as well as define useful
+    //    lambda functions and structs.
+    // ---------------------------------------------------------------------------
 
-        } else {
+    using Topology = atlas::mesh::Nodes::Topology;
+    using atlas::array::make_datatype;
+    using atlas::array::make_shape;
 
-          // Set global index.
-          globalCell.globalIdx = cellGlobalIdxCount++;
-          // Leave remote index and part undefined.
+    using namespace detail::cubedsphere;
+
+    struct GlobalElem;
+    struct LocalElem;
+
+    // Define bad index values.
+    constexpr idx_t undefinedIdx       = -1;
+    constexpr idx_t undefinedGlobalIdx = -1;
+
+    // Define cell/node type.
+    enum class ElemType
+    {
+        UNDEFINED,  // Not set. Writing this type to mesh is an error.
+        OWNER,      // Owner element on this partition.
+        HALO        // Ghost or halo element.
+    };
+
+    // Struct to store the information of globals cells/nodes.
+    // These must be generated for all cells/nodes on all partitions. Data is
+    // stored in (t, j, i) row-major order.
+    struct GlobalElem {
+        LocalElem* localPtr{};                 // Pointer to local element.
+        gidx_t globalIdx{undefinedGlobalIdx};  // Global index.
+        idx_t remoteIdx{undefinedIdx};         // Remote index.
+        idx_t part{undefinedIdx};              // Partition.
+    };
+
+    // Struct to store additional information of local cells/nodes.
+    // These are only generated for nodes on this partition. Data is stored as a
+    // list which can be sorted.
+    struct LocalElem {
+        GlobalElem* globalPtr{};             // Pointer to global element.
+        ElemType type{ElemType::UNDEFINED};  // Cell/node Type.
+        idx_t halo{undefinedIdx};            // Halo level.
+        idx_t i{}, j{}, t{};                 // i, j and t.
+    };
+
+    // Define ij bounding box for each face (this partition only).
+    struct BoundingBox {
+        idx_t iBegin{std::numeric_limits<idx_t>::max()};
+        idx_t iEnd{std::numeric_limits<idx_t>::min()};
+        idx_t jBegin{std::numeric_limits<idx_t>::max()};
+        idx_t jEnd{std::numeric_limits<idx_t>::min()};
+    };
+
+
+    // Check for correct grid stagger.
+    if ( csGrid.stagger() != "C" ) {
+        throw_Exception(
+            "CubedSphereMeshGenerator will only work with a"
+            "cell-centroid grid. Try NodalCubedSphereMeshGenerator instead.",
+            Here() );
+    }
+
+    // Get dimensions of grid
+    const idx_t N = csGrid.N();
+
+    // Get size of halo.
+    idx_t nHalo = 0;
+    options.get( "halo", nHalo );
+
+    // Unique non-halo nodes and cells.
+    const idx_t nNodesUnique = 6 * N * N + 2;
+    const idx_t nCellsUnique = 6 * N * N;
+
+    // Total array sizes (including invalid corner ijs).
+    const idx_t nNodesArray = 6 * ( N + 2 * nHalo + 1 ) * ( N + 2 * nHalo + 1 );
+    const idx_t nCellsArray = 6 * ( N + 2 * nHalo ) * ( N + 2 * nHalo );
+
+    // Total number of possible cells and nodes (including halos).
+    const idx_t nNodesTotal = nNodesArray - 6 * 4 * nHalo * nHalo;
+    const idx_t nCellsTotal = nCellsArray - 6 * 4 * nHalo * nHalo;
+
+    // Projection and jacobian.
+    const auto* const csProjection = castProjection( csGrid.projection().get() );
+    const auto jacobian            = NeighbourJacobian( csGrid );
+
+    // Get partition information.
+    const auto nParts   = options.get<size_t>( "nb_parts" );
+    const auto thisPart = options.get<size_t>( "part" );
+
+    // Define an index counter.
+    const auto idxSum = []( const std::vector<idx_t>& idxCounts ) -> idx_t {
+        return std::accumulate( idxCounts.begin(), idxCounts.end(), 0 );
+    };
+
+    // Helper functions to get node vector idx from (i, j, t).
+    const auto getNodeIdx = [&]( idx_t i, idx_t j, idx_t t ) -> size_t {
+        const idx_t rowSize  = ( N + 2 * nHalo + 1 );
+        const idx_t tileSize = rowSize * rowSize;
+
+        return static_cast<size_t>( t * tileSize + ( j + nHalo ) * rowSize + i + nHalo );
+    };
+
+    // Helper functions to get cell vector idx from (i, j, t).
+    const auto getCellIdx = [&]( idx_t i, idx_t j, idx_t t ) -> size_t {
+        const idx_t rowSize  = ( N + 2 * nHalo );
+        const idx_t tileSize = rowSize * rowSize;
+
+        return static_cast<size_t>( t * tileSize + ( j + nHalo ) * rowSize + i + nHalo );
+    };
+
+    // Return true for nodes interior to tile (excluding edge).
+    const auto interiorNode = [&]( idx_t i, idx_t j ) -> bool { return i > 0 && i < N && j > 0 && j < N; };
+
+    // return true for nodes exterior to tile (excluding edge).
+    const auto exteriorNode = [&]( idx_t i, idx_t j ) -> bool { return i < 0 || i > N || j < 0 || j > N; };
+
+    // Return true for cells interior to tile.
+    const auto interiorCell = [&]( idx_t i, idx_t j ) -> bool { return i >= 0 && i < N && j >= 0 && j < N; };
+
+    // Return true for impossible node (i, j) combinations.
+    const auto invalidNode = [&]( idx_t i, idx_t j ) -> bool {
+        const bool inCorner = ( i < 0 && j < 0 ) ||  // Bottom-left corner.
+                              ( i > N && j < 0 ) ||  // Bottom-right corner.
+                              ( i > N && j > N ) ||  // Top-right corner.
+                              ( i < 0 && j > N );    // Top-left corner.
+
+        if ( inCorner )
+            return true;
+
+        const bool outOfBounds = i < -nHalo || i > N + nHalo || j < -nHalo || j > N + nHalo;
+
+        if ( outOfBounds )
+            return true;
+
+        return false;
+    };
+
+    // Return true for impossible cell (i, j) combinations.
+    const auto invalidCell = [&]( idx_t i, idx_t j ) -> bool {
+        const bool inCorner = ( i < 0 && j < 0 ) ||          // Bottom-left corner.
+                              ( i > N - 1 && j < 0 ) ||      // Bottom-right corner.
+                              ( i > N - 1 && j > N - 1 ) ||  // Top-right corner.
+                              ( i < 0 && j > N - 1 );        // Top-left corner.
+
+        if ( inCorner )
+            return true;
+
+        const bool outOfBounds = i < -nHalo || i > N + nHalo - 1 || j < -nHalo || j > N + nHalo - 1;
+
+        if ( outOfBounds )
+            return true;
+
+        return false;
+    };
+
+    // Return the (i, j) of cell that owns node (i, j).
+    // It's possible that this may need to be user-defined in the future.
+    const auto nodeOwnerCell = []( idx_t iNode, idx_t jNode ) -> std::pair<idx_t, idx_t> {
+        return std::make_pair( iNode > 0 ? iNode - 1 : iNode, jNode > 0 ? jNode - 1 : jNode );
+    };
+
+    // ---------------------------------------------------------------------------
+    // 2. GLOBAL CELL DISTRIBUTION
+    //    Need to construct a lightweight global mesh. This will help us pair up
+    //    local and remote indices on different partitions.
+    // ---------------------------------------------------------------------------
+
+    // Make vector of all possible cells.
+    auto globalCells = std::vector<GlobalElem>( static_cast<size_t>( nCellsArray ) );
+
+    // Initialise bounding box.
+    auto cellBounds = std::vector<BoundingBox>( static_cast<size_t>( 6 ) );
+
+    // Set tji grid iterator.
+    auto ijtIt = csGrid.tij().begin();
+
+    for ( gidx_t gridIdx = 0; gridIdx < csGrid.size(); ++gridIdx ) {
+        // It's more than likely that the grid order follows the same (t, j, i) row-
+        // major order of the mesh. However, we shouldn't assume this is true.
+
+        // Get cell index.
+        const idx_t i          = ( *ijtIt ).i();
+        const idx_t j          = ( *ijtIt ).j();
+        const idx_t t          = ( *ijtIt ).t();
+        const size_t cellIdx   = getCellIdx( i, j, t );
+        GlobalElem& globalCell = globalCells[cellIdx];
+
+        // Set global index.
+        globalCell.globalIdx = gridIdx + 1;
+
+        // Set partition.
+        globalCell.part = distribution.partition( gridIdx );
+
+        if ( globalCell.part == static_cast<idx_t>( thisPart ) ) {
+            // Keep track of local (t, j, i) bounds.
+            BoundingBox& bounds = cellBounds[static_cast<size_t>( t )];
+            bounds.iBegin       = std::min( bounds.iBegin, i - nHalo );
+            bounds.iEnd         = std::max( bounds.iEnd, i + nHalo + 1 );
+            bounds.jBegin       = std::min( bounds.jBegin, j - nHalo );
+            bounds.jEnd         = std::max( bounds.jEnd, j + nHalo + 1 );
         }
-      }
+        // Increment iterators.
+        ++ijtIt;
     }
-  }
 
-  ATLAS_ASSERT(idxSum(cellLocalIdxCount) == nCellsUnique);
-  ATLAS_ASSERT(cellGlobalIdxCount == nCellsTotal + 1);
+    // Set counters for cell local indices.
+    auto cellLocalIdxCount = std::vector<idx_t>( nParts, 0 );
 
-  // ---------------------------------------------------------------------------
-  // 3. GLOBAL NODE DISTRIBUTION
-  //    Construct a lightweight global distribution of nodes. Again, this will
-  //    help us match up local and remote indices accross partitions.
-  // ---------------------------------------------------------------------------
+    // Give possible edge-halo cells a unique global ID.
+    gidx_t cellGlobalIdxCount = nCellsUnique + 1;
 
-  // Make list of all nodes.
-  auto globalNodes = std::vector<GlobalElem>(static_cast<size_t>(nNodesArray));
+    for ( idx_t t = 0; t < 6; ++t ) {
+        for ( idx_t j = -nHalo; j < N + nHalo; ++j ) {
+            for ( idx_t i = -nHalo; i < N + nHalo; ++i ) {
+                // Skip invalid cell.
+                if ( invalidCell( i, j ) )
+                    continue;
 
-  // Set counters for local node indices.
-  auto nodeLocalIdxCount = std::vector<idx_t>(nParts, 0);
+                // Get cell.
+                GlobalElem& globalCell = globalCells[getCellIdx( i, j, t )];
 
-  // Set counter for global indices.
-  gidx_t nodeGlobalOwnedIdxCount = 1;
-  idx_t nodeGlobalGhostIdxCount = nNodesUnique + 1;
-
-  for (idx_t t = 0; t < 6; ++t) {
-    for (idx_t j = -nHalo; j < N + nHalo + 1; ++j) {
-      for (idx_t i = -nHalo; i < N + nHalo + 1; ++i) {
-
-        // Skip if not a valid node.
-        if (invalidNode(i, j)) continue;
-
-        // Get this node.
-        GlobalElem& globalNode = globalNodes[getNodeIdx(i, j, t)];
-
-        // Get owner cell.
-        idx_t iCell, jCell;
-        std::tie(iCell, jCell) = nodeOwnerCell(i, j);
-        const GlobalElem& ownerCell = globalCells[getCellIdx(iCell, jCell, t)];
-
-        if (interiorNode(i, j)) {
-
-          // Node is definitely an owner.
-          globalNode.globalIdx = nodeGlobalOwnedIdxCount++;
-          globalNode.part = ownerCell.part;
-          globalNode.remoteIdx =
-            nodeLocalIdxCount[static_cast<size_t>(globalNode.part)]++;
-
-        } else if (exteriorNode(i, j)) {
-
-          // Node is definitely a ghost.
-          globalNode.globalIdx = nodeGlobalGhostIdxCount++;
-          // Leave remote index and partition undefined.
-
-        } else {
-
-          // We're not sure (i.e., node is on a tile edge).
-
-          // Check that xy is on this tile.
-          PointXY xy = jacobian.xy(PointIJ(i, j) ,t);
-          xy = jacobian.snapToEdge(xy, t);
-
-          // This will only determine if tGlobal does not match t.
-          // This is cheaper than determining the correct tGlobal.
-          idx_t tGlobal =
-            csProjection->getCubedSphereTiles().indexFromXY(xy.data());
-
-          if (tGlobal == t) {
-
-            // Node is an owner.
-            globalNode.globalIdx = nodeGlobalOwnedIdxCount++;
-            globalNode.part = ownerCell.part;
-            globalNode.remoteIdx =
-              nodeLocalIdxCount[static_cast<size_t>(globalNode.part)]++;
-
-          } else {
-
-            // Node is a ghost.
-            globalNode.globalIdx = nodeGlobalGhostIdxCount++;
-
-          }
-        } // Finished with this node.
-      }
-    } // Finished with all nodes on tile.
-  } // Finished with all tiles.
-
-  ATLAS_ASSERT(nodeGlobalOwnedIdxCount == nNodesUnique + 1);
-  ATLAS_ASSERT(nodeGlobalGhostIdxCount == nNodesTotal + 1);
-  ATLAS_ASSERT(idxSum(nodeLocalIdxCount) == nNodesUnique);
-
-  // ---------------------------------------------------------------------------
-  // 4. LOCATE LOCAL CELLS.
-  //    Now that we know where all the nodes and cells are, we can make a list
-  //    of local cells to add the the mesh. "Owner" cells correspond to grid
-  //    points on this parition. "Halo" cells are at most nHalo grid points
-  //    away from an owner cell.
-  // ---------------------------------------------------------------------------
-
-  // Make vector of local cells.
-  auto localCells = std::vector<LocalElem>{};
-
-  // Loop over all possible local cells.
-  for (idx_t t = 0; t < 6; ++t) {
-
-    // Limit range to bounds recorded earlier.
-    const BoundingBox& bounds = cellBounds[static_cast<size_t>(t)];
-
-    for (idx_t j = bounds.jBegin; j < bounds.jEnd; ++j) {
-      for (idx_t i = bounds.iBegin; i < bounds.iEnd; ++i) {
-
-        if (invalidCell(i, j)) continue;
-
-        // Get cell
-        GlobalElem& globalCell = globalCells[getCellIdx(i, j, t)];
-
-        // Check if cell is an owner.
-        if (globalCell.part == static_cast<idx_t>(thisPart)) {
-
-          // Cell is an owner.
-          localCells.emplace_back();
-          LocalElem& localCell = localCells.back();
-
-          localCell.type = ElemType::OWNER;
-          localCell.halo = 0;
-          localCell.i = i;
-          localCell.j = j;
-          localCell.t = t;
-          localCell.globalPtr = &globalCell;
-
-        } else {
-
-          // Check if cell is halo.
-          bool haloFound = false;
-          idx_t halo = nHalo;
-          for (idx_t jHalo = j - nHalo; jHalo < j + nHalo + 1; ++jHalo) {
-            for (idx_t iHalo = i - nHalo; iHalo < i + nHalo + 1; ++iHalo) {
-
-              if (invalidCell(iHalo, jHalo) ||
-                 (iHalo == i && jHalo == j)) continue;
-
-              // Is there a nearby owner cell?
-              const GlobalElem& ownerCell =
-                globalCells[getCellIdx(iHalo, jHalo, t)];
-
-              const bool isHalo =
-                ownerCell.part == static_cast<idx_t>(thisPart);
-
-              haloFound = haloFound || isHalo;
-
-              if (isHalo) {
-
-                // Determine halo level from cell distance (l-infinity norm).
-                const idx_t dist =
-                  std::max(std::abs(iHalo - i), std::abs(jHalo - j));
-
-                halo = std::min(dist, halo);
-              }
+                // Set cell remote index if interior cell.
+                if ( interiorCell( i, j ) ) {
+                    // Set remote index.
+                    globalCell.remoteIdx = cellLocalIdxCount[static_cast<size_t>( globalCell.part )]++;
+                }
+                else {
+                    // Set global index.
+                    globalCell.globalIdx = cellGlobalIdxCount++;
+                    // Leave remote index and part undefined.
+                }
             }
-          }
-
-          if (haloFound) {
-
-            // Cell is a halo.
-            localCells.emplace_back();
-            LocalElem& localCell = localCells.back();
-
-            localCell.type = ElemType::HALO;
-            localCell.halo = halo;
-            localCell.i = i;
-            localCell.j = j;
-            localCell.t = t;
-            localCell.globalPtr = &globalCell;
-
-          } // Finished with halo search.
-        } // Finished with cell.
-      }
-    } // Finished with all cells on tile.
-  } // Finished with all tiles.
-
-  // Partition by cell type.
-  auto haloBeginIt =
-    std::stable_partition(localCells.begin(), localCells.end(),
-    [](const LocalElem& localCell) -> bool {
-      return localCell.type == ElemType::OWNER;
-    });
-
-  // Sort by halo.
-  std::stable_sort(haloBeginIt, localCells.end(),
-    [](const LocalElem& cellA, const LocalElem& cellB) -> bool
-    {return cellA.halo < cellB.halo;});
-
-  // Point global cell to local cell. This is needed to determine node halos.
-  // Need to determine remote index and partition if we haven't done so already.
-  for (LocalElem& localCell : localCells) {
-
-    localCell.globalPtr->localPtr = &localCell;
-
-    if (localCell.globalPtr->remoteIdx == undefinedIdx) {
-
-      const auto ijtGlobal =
-        jacobian.ijLocalToGlobal(
-          PointIJ(localCell.i + 0.5, localCell.j + 0.5), localCell.t);
-
-      const idx_t i = ijtGlobal.first.iCell();
-      const idx_t j = ijtGlobal.first.jCell();
-      const idx_t t = ijtGlobal.second;
-
-      ATLAS_ASSERT(interiorCell(i, j));
-
-      const GlobalElem& ownerCell = globalCells[getCellIdx(i, j, t)];
-
-      localCell.globalPtr->remoteIdx = ownerCell.remoteIdx;
-      localCell.globalPtr->part = ownerCell.part;
+        }
     }
-  }
 
-  // ---------------------------------------------------------------------------
-  // 5. LOCATE LOCAL NODES.
-  //    We can now locate the nodes surrounding the owner and halo cells on the
-  //    mesh.
-  // ---------------------------------------------------------------------------
+    ATLAS_ASSERT( idxSum( cellLocalIdxCount ) == nCellsUnique );
+    ATLAS_ASSERT( cellGlobalIdxCount == nCellsTotal + 1 );
 
-  // Make vector of local nodes.
-  auto localNodes = std::vector<LocalElem>{};
+    // ---------------------------------------------------------------------------
+    // 3. GLOBAL NODE DISTRIBUTION
+    //    Construct a lightweight global distribution of nodes. Again, this will
+    //    help us match up local and remote indices accross partitions.
+    // ---------------------------------------------------------------------------
 
-  // Loop over all possible local nodes.
-  for (idx_t t = 0; t < 6; ++t) {
+    // Make list of all nodes.
+    auto globalNodes = std::vector<GlobalElem>( static_cast<size_t>( nNodesArray ) );
 
-    // Limit range to bounds recorded earlier.
-    const BoundingBox& bounds = cellBounds[static_cast<size_t>(t)];
+    // Set counters for local node indices.
+    auto nodeLocalIdxCount = std::vector<idx_t>( nParts, 0 );
 
-    for (idx_t j = bounds.jBegin; j < bounds.jEnd + 1; ++j) {
-      for (idx_t i = bounds.iBegin; i < bounds.iEnd + 1; ++i) {
+    // Set counter for global indices.
+    gidx_t nodeGlobalOwnedIdxCount = 1;
+    idx_t nodeGlobalGhostIdxCount  = nNodesUnique + 1;
 
-        if (invalidNode(i, j)) continue;
+    for ( idx_t t = 0; t < 6; ++t ) {
+        for ( idx_t j = -nHalo; j < N + nHalo + 1; ++j ) {
+            for ( idx_t i = -nHalo; i < N + nHalo + 1; ++i ) {
+                // Skip if not a valid node.
+                if ( invalidNode( i, j ) )
+                    continue;
 
-        // Get node.
-        GlobalElem& globalNode = globalNodes[getNodeIdx(i, j, t)];
+                // Get this node.
+                GlobalElem& globalNode = globalNodes[getNodeIdx( i, j, t )];
 
-        // Check if node is an owner.
-        if (globalNode.part == static_cast<idx_t>(thisPart)) {
+                // Get owner cell.
+                idx_t iCell, jCell;
+                std::tie( iCell, jCell )    = nodeOwnerCell( i, j );
+                const GlobalElem& ownerCell = globalCells[getCellIdx( iCell, jCell, t )];
 
-          // Node is an owner.
-          localNodes.emplace_back();
-          LocalElem& localNode = localNodes.back();
+                if ( interiorNode( i, j ) ) {
+                    // Node is definitely an owner.
+                    globalNode.globalIdx = nodeGlobalOwnedIdxCount++;
+                    globalNode.part      = ownerCell.part;
+                    globalNode.remoteIdx = nodeLocalIdxCount[static_cast<size_t>( globalNode.part )]++;
+                }
+                else if ( exteriorNode( i, j ) ) {
+                    // Node is definitely a ghost.
+                    globalNode.globalIdx = nodeGlobalGhostIdxCount++;
+                    // Leave remote index and partition undefined.
+                }
+                else {
+                    // We're not sure (i.e., node is on a tile edge).
 
-          localNode.type = ElemType::OWNER;
-          localNode.halo = 0;
-          localNode.i = i;
-          localNode.j = j;
-          localNode.t = t;
-          localNode.globalPtr = &globalNode;
+                    // Check that xy is on this tile.
+                    PointXY xy = jacobian.xy( PointIJ( i, j ), t );
+                    xy         = jacobian.snapToEdge( xy, t );
 
-        } else {
+                    // This will only determine if tGlobal does not match t.
+                    // This is cheaper than determining the correct tGlobal.
+                    idx_t tGlobal = csProjection->getCubedSphereTiles().indexFromXY( xy.data() );
 
-          // Node is possibly a ghost or halo.
-
-          // Search four neighbouring cells of node.
-          bool isGhost = false;
-          idx_t halo = nHalo;
-
-          // A double-loop with no more than four iterations!
-          for (idx_t iCell = i - 1; iCell < i + 1; ++iCell) {
-            for (idx_t jCell = j - 1; jCell < j + 1; ++jCell) {
-
-              if (invalidCell(iCell, jCell)) continue;
-
-              const GlobalElem& globalCell =
-                globalCells[getCellIdx(iCell, jCell, t)];
-
-              // Get halo information from cell.
-              // By this point, any global cell on this PE will have a
-              // non-null local cell pointer.
-              if (globalCell.localPtr) {
-                isGhost = true;
-                halo = std::min(halo, globalCell.localPtr->halo);
-              }
+                    if ( tGlobal == t ) {
+                        // Node is an owner.
+                        globalNode.globalIdx = nodeGlobalOwnedIdxCount++;
+                        globalNode.part      = ownerCell.part;
+                        globalNode.remoteIdx = nodeLocalIdxCount[static_cast<size_t>( globalNode.part )]++;
+                    }
+                    else {
+                        // Node is a ghost.
+                        globalNode.globalIdx = nodeGlobalGhostIdxCount++;
+                    }
+                }  // Finished with this node.
             }
-          }
+        }  // Finished with all nodes on tile.
+    }      // Finished with all tiles.
 
-          if (isGhost) {
+    ATLAS_ASSERT( nodeGlobalOwnedIdxCount == nNodesUnique + 1 );
+    ATLAS_ASSERT( nodeGlobalGhostIdxCount == nNodesTotal + 1 );
+    ATLAS_ASSERT( idxSum( nodeLocalIdxCount ) == nNodesUnique );
 
-            // Node is an ghost/halo.
-            localNodes.emplace_back();
-            LocalElem& localNode = localNodes.back();
+    // ---------------------------------------------------------------------------
+    // 4. LOCATE LOCAL CELLS.
+    //    Now that we know where all the nodes and cells are, we can make a list
+    //    of local cells to add the the mesh. "Owner" cells correspond to grid
+    //    points on this parition. "Halo" cells are at most nHalo grid points
+    //    away from an owner cell.
+    // ---------------------------------------------------------------------------
 
-            localNode.type = ElemType::HALO;
-            localNode.halo = halo;
-            localNode.i = i;
-            localNode.j = j;
-            localNode.t = t;
-            localNode.globalPtr = &globalNode;
+    // Make vector of local cells.
+    auto localCells = std::vector<LocalElem>{};
 
-          }
+    // Loop over all possible local cells.
+    for ( idx_t t = 0; t < 6; ++t ) {
+        // Limit range to bounds recorded earlier.
+        const BoundingBox& bounds = cellBounds[static_cast<size_t>( t )];
 
-        } // Finished with this node.
-      }
-    } // Finished with all nodes on tile.
-  } // Finished with all tiles.
+        for ( idx_t j = bounds.jBegin; j < bounds.jEnd; ++j ) {
+            for ( idx_t i = bounds.iBegin; i < bounds.iEnd; ++i ) {
+                if ( invalidCell( i, j ) )
+                    continue;
 
-  // Partition by node type.
-  auto ghostBeginIt =
-    std::stable_partition(localNodes.begin(), localNodes.end(),
-    [](const LocalElem& localNode) -> bool {
-      return localNode.type == ElemType::OWNER;
-    });
+                // Get cell
+                GlobalElem& globalCell = globalCells[getCellIdx( i, j, t )];
 
-  // Sort by halo.
-  std::stable_sort(ghostBeginIt, localNodes.end(),
-    [](const LocalElem& nodeA, const LocalElem& nodeB) -> bool
-    {return nodeA.halo < nodeB.halo;});
+                // Check if cell is an owner.
+                if ( globalCell.part == static_cast<idx_t>( thisPart ) ) {
+                    // Cell is an owner.
+                    localCells.emplace_back();
+                    LocalElem& localCell = localCells.back();
 
-  // Associate global nodes with local nodes. Allows us to determine node
-  // local indices around a cell.
-  // Determine partition and remote index if we haven't done so already.
-  for (LocalElem& localNode : localNodes) {
+                    localCell.type      = ElemType::OWNER;
+                    localCell.halo      = 0;
+                    localCell.i         = i;
+                    localCell.j         = j;
+                    localCell.t         = t;
+                    localCell.globalPtr = &globalCell;
+                }
+                else {
+                    // Check if cell is halo.
+                    bool haloFound = false;
+                    idx_t halo     = nHalo;
+                    for ( idx_t jHalo = j - nHalo; jHalo < j + nHalo + 1; ++jHalo ) {
+                        for ( idx_t iHalo = i - nHalo; iHalo < i + nHalo + 1; ++iHalo ) {
+                            if ( invalidCell( iHalo, jHalo ) || ( iHalo == i && jHalo == j ) )
+                                continue;
 
-    localNode.globalPtr->localPtr = &localNode;
+                            // Is there a nearby owner cell?
+                            const GlobalElem& ownerCell = globalCells[getCellIdx( iHalo, jHalo, t )];
 
-    if (localNode.globalPtr->remoteIdx == undefinedIdx) {
+                            const bool isHalo = ownerCell.part == static_cast<idx_t>( thisPart );
 
-      const auto ijtGlobal =
-        jacobian.ijLocalToGlobal(PointIJ(localNode.i, localNode.j), localNode.t);
+                            haloFound = haloFound || isHalo;
 
-      const idx_t i = ijtGlobal.first.iNode();
-      const idx_t j = ijtGlobal.first.jNode();
-      const idx_t t = ijtGlobal.second;
+                            if ( isHalo ) {
+                                // Determine halo level from cell distance (l-infinity norm).
+                                const idx_t dist = std::max( std::abs( iHalo - i ), std::abs( jHalo - j ) );
 
-      ATLAS_ASSERT(!exteriorNode(i, j));
+                                halo = std::min( dist, halo );
+                            }
+                        }
+                    }
 
-      const GlobalElem& ownerNode =
-        globalNodes[getNodeIdx(i, j, t)];
+                    if ( haloFound ) {
+                        // Cell is a halo.
+                        localCells.emplace_back();
+                        LocalElem& localCell = localCells.back();
 
-      localNode.globalPtr->remoteIdx = ownerNode.remoteIdx;
-      localNode.globalPtr->part = ownerNode.part;
-    }
-  }
+                        localCell.type      = ElemType::HALO;
+                        localCell.halo      = halo;
+                        localCell.i         = i;
+                        localCell.j         = j;
+                        localCell.t         = t;
+                        localCell.globalPtr = &globalCell;
 
-  // ---------------------------------------------------------------------------
-  // 6. ASSIGN NODES TO MESH
-  //    In addition to the usual fields, we will add i, j and t to mesh.nodes().
-  // ---------------------------------------------------------------------------
+                    }  // Finished with halo search.
+                }      // Finished with cell.
+            }
+        }  // Finished with all cells on tile.
+    }      // Finished with all tiles.
 
-  // Resize nodes.
-  auto& nodes = mesh.nodes();
-  nodes.resize(static_cast<idx_t>(localNodes.size()));
+    // Partition by cell type.
+    auto haloBeginIt =
+        std::stable_partition( localCells.begin(), localCells.end(),
+                               []( const LocalElem& localCell ) -> bool { return localCell.type == ElemType::OWNER; } );
 
-  // Add extra field.
-  Field ijtField =
-    nodes.add(Field("ijt", make_datatype<idx_t>(), make_shape(nodes.size(), 3)));
-  ijtField.set_variables(3);
+    // Sort by halo.
+    std::stable_sort( haloBeginIt, localCells.end(), []( const LocalElem& cellA, const LocalElem& cellB ) -> bool {
+        return cellA.halo < cellB.halo;
+    } );
 
-  // Get field views
-  auto nodesGlobalIdx = array::make_view<gidx_t, 1>(nodes.global_index());
-  auto nodesRemoteIdx = array::make_indexview<idx_t, 1>(nodes.remote_index());
-  auto nodesXy        = array::make_view<double, 2>(nodes.xy());
-  auto nodesLonLat    = array::make_view<double, 2>(nodes.lonlat());
-  auto nodesPart      = array::make_view<int, 1>(nodes.partition());
-  auto nodesGhost     = array::make_view<int, 1>(nodes.ghost());
-  auto nodesHalo      = array::make_view<int, 1>(nodes.halo());
-  auto nodesFlags     = array::make_view<int, 1>(nodes.flags());
-  auto nodesIjt       = array::make_view<idx_t, 2>(ijtField);
+    // Point global cell to local cell. This is needed to determine node halos.
+    // Need to determine remote index and partition if we haven't done so already.
+    for ( LocalElem& localCell : localCells ) {
+        localCell.globalPtr->localPtr = &localCell;
 
-  // Set fields.
-  idx_t nodeLocalIdx = 0;
-  for (const LocalElem& localNode : localNodes) {
+        if ( localCell.globalPtr->remoteIdx == undefinedIdx ) {
+            const auto ijtGlobal =
+                jacobian.ijLocalToGlobal( PointIJ( localCell.i + 0.5, localCell.j + 0.5 ), localCell.t );
 
-    // Set global index.
-    nodesGlobalIdx(nodeLocalIdx) = localNode.globalPtr->globalIdx;
+            const idx_t i = ijtGlobal.first.iCell();
+            const idx_t j = ijtGlobal.first.jCell();
+            const idx_t t = ijtGlobal.second;
 
-    // Set node remote index.
-    nodesRemoteIdx(nodeLocalIdx) = localNode.globalPtr->remoteIdx;
+            ATLAS_ASSERT( interiorCell( i, j ) );
 
-    // Set node partition.
-    nodesPart(nodeLocalIdx) = localNode.globalPtr->part;
+            const GlobalElem& ownerCell = globalCells[getCellIdx( i, j, t )];
 
-    // Set xy.
-    const PointXY xyLocal =
-      jacobian.xy(PointIJ(localNode.i, localNode.j), localNode.t);
-    const PointXY xyGlobal = interiorNode(localNode.i, localNode.j) ?
-      xyLocal : jacobian.xyLocalToGlobal(xyLocal, localNode.t).first;
-
-    nodesXy(nodeLocalIdx, XX) = xyLocal.x();
-    nodesXy(nodeLocalIdx, YY) = xyLocal.y();
-
-    // Set lon-lat.
-    const PointLonLat lonLat = csProjection->lonlat(xyGlobal);
-    nodesLonLat(nodeLocalIdx, LON) = lonLat.lon();
-    nodesLonLat(nodeLocalIdx, LAT) = lonLat.lat();
-
-    // Set tij.
-    nodesIjt(nodeLocalIdx, Coordinates::I) = localNode.i;
-    nodesIjt(nodeLocalIdx, Coordinates::J) = localNode.j;
-    nodesIjt(nodeLocalIdx, Coordinates::T) = localNode.t;
-
-    // Set halo.
-    nodesHalo(nodeLocalIdx) = localNode.halo;
-    ATLAS_ASSERT(localNode.halo != undefinedIdx);
-
-    // Set flags.
-    Topology::reset(nodesFlags(nodeLocalIdx));
-    switch(localNode.type) {
-
-      case ElemType::UNDEFINED : {
-        ATLAS_ASSERT(0);
-        break;
-      }
-      case ElemType::OWNER : {
-        nodesGhost(nodeLocalIdx) = 0;
-        // Vitally important that these two match!
-        ATLAS_ASSERT(nodeLocalIdx == localNode.globalPtr->remoteIdx);
-        break;
-      }
-      case ElemType::HALO : {
-        nodesGhost(nodeLocalIdx) = 1;
-        Topology::set(nodesFlags(nodeLocalIdx), Topology::GHOST);
-        break;
-      }
+            localCell.globalPtr->remoteIdx = ownerCell.remoteIdx;
+            localCell.globalPtr->part      = ownerCell.part;
+        }
     }
 
-    ++nodeLocalIdx;
-  }
+    // ---------------------------------------------------------------------------
+    // 5. LOCATE LOCAL NODES.
+    //    We can now locate the nodes surrounding the owner and halo cells on the
+    //    mesh.
+    // ---------------------------------------------------------------------------
 
-  // ---------------------------------------------------------------------------
-  // 7. ASSIGN CELLS TO MESH
-  //    Again, we'll add i, j and t to mesh.cells(). We'll also add the xy and
-  //    lonlat coordinates of the cell centres.
-  // ---------------------------------------------------------------------------
+    // Make vector of local nodes.
+    auto localNodes = std::vector<LocalElem>{};
 
-  auto& cells = mesh.cells();
+    // Loop over all possible local nodes.
+    for ( idx_t t = 0; t < 6; ++t ) {
+        // Limit range to bounds recorded earlier.
+        const BoundingBox& bounds = cellBounds[static_cast<size_t>( t )];
 
-  // Resize cells.
-  cells.add(new mesh::temporary::Quadrilateral(),
-            static_cast<idx_t>(localCells.size()));
+        for ( idx_t j = bounds.jBegin; j < bounds.jEnd + 1; ++j ) {
+            for ( idx_t i = bounds.iBegin; i < bounds.iEnd + 1; ++i ) {
+                if ( invalidNode( i, j ) )
+                    continue;
 
-  // Add extra fields.
-  ijtField = cells.add(
-      Field("ijt", make_datatype<idx_t>(), make_shape(cells.size(), 3)));
-  ijtField.set_variables(3);
+                // Get node.
+                GlobalElem& globalNode = globalNodes[getNodeIdx( i, j, t )];
 
-  Field xyField =
-   cells.add(Field("xy", make_datatype<double>(), make_shape(cells.size(), 2)));
-  xyField.set_variables(2);
+                // Check if node is an owner.
+                if ( globalNode.part == static_cast<idx_t>( thisPart ) ) {
+                    // Node is an owner.
+                    localNodes.emplace_back();
+                    LocalElem& localNode = localNodes.back();
 
-  Field lonLatField =
-    cells.add(Field("lonlat", make_datatype<double>(), make_shape(cells.size(), 2)));
-  lonLatField.set_variables(2);
+                    localNode.type      = ElemType::OWNER;
+                    localNode.halo      = 0;
+                    localNode.i         = i;
+                    localNode.j         = j;
+                    localNode.t         = t;
+                    localNode.globalPtr = &globalNode;
+                }
+                else {
+                    // Node is possibly a ghost or halo.
 
-  // Set field views.
-  auto cellsGlobalIdx = array::make_view<gidx_t, 1>(cells.global_index());
-  auto cellsRemoteIdx = array::make_indexview<idx_t, 1>(cells.remote_index());
-  auto cellsPart      = array::make_view<int, 1>(cells.partition());
-  auto cellsHalo      = array::make_view<int, 1>(cells.halo());
-  auto cellsFlags     = array::make_view<int, 1>(cells.flags());
-  auto cellsIjt       = array::make_view<idx_t, 2>(ijtField);
-  auto cellsXy        = array::make_view<double, 2>(xyField);
-  auto cellsLonLat    = array::make_view<double, 2>(lonLatField);
+                    // Search four neighbouring cells of node.
+                    bool isGhost = false;
+                    idx_t halo   = nHalo;
 
-  // Set local cells.
-  auto& nodeConnectivity = cells.node_connectivity();
-  const idx_t cellElemIdx0 = cells.elements(0).begin();
+                    // A double-loop with no more than four iterations!
+                    for ( idx_t iCell = i - 1; iCell < i + 1; ++iCell ) {
+                        for ( idx_t jCell = j - 1; jCell < j + 1; ++jCell ) {
+                            if ( invalidCell( iCell, jCell ) )
+                                continue;
 
-  // Set method to get node local index.
-  const auto getNodeLocalIdx = [&](idx_t i, idx_t j, idx_t t) -> idx_t {
+                            const GlobalElem& globalCell = globalCells[getCellIdx( iCell, jCell, t )];
 
-    const GlobalElem& globalNode = globalNodes[getNodeIdx(i, j, t)];
+                            // Get halo information from cell.
+                            // By this point, any global cell on this PE will have a
+                            // non-null local cell pointer.
+                            if ( globalCell.localPtr ) {
+                                isGhost = true;
+                                halo    = std::min( halo, globalCell.localPtr->halo );
+                            }
+                        }
+                    }
 
-    // Do some pointer arithmetic to get local index.
-    return static_cast<idx_t>(globalNode.localPtr - localNodes.data());
-  };
+                    if ( isGhost ) {
+                        // Node is an ghost/halo.
+                        localNodes.emplace_back();
+                        LocalElem& localNode = localNodes.back();
 
-  idx_t cellLocalIdx = 0;
-  for (const LocalElem& localCell : localCells) {
+                        localNode.type      = ElemType::HALO;
+                        localNode.halo      = halo;
+                        localNode.i         = i;
+                        localNode.j         = j;
+                        localNode.t         = t;
+                        localNode.globalPtr = &globalNode;
+                    }
 
-    // Get local indices four surroundings nodes.
-    const auto quadNodeIdx = std::array<idx_t, 4> {
-      getNodeLocalIdx(localCell.i    , localCell.j    , localCell.t),
-      getNodeLocalIdx(localCell.i + 1, localCell.j    , localCell.t),
-      getNodeLocalIdx(localCell.i + 1, localCell.j + 1, localCell.t),
-      getNodeLocalIdx(localCell.i    , localCell.j + 1, localCell.t)};
+                }  // Finished with this node.
+            }
+        }  // Finished with all nodes on tile.
+    }      // Finished with all tiles.
 
-    // Set connectivity.
-    nodeConnectivity.set(cellLocalIdx + cellElemIdx0, quadNodeIdx.data());
+    // Partition by node type.
+    auto ghostBeginIt =
+        std::stable_partition( localNodes.begin(), localNodes.end(),
+                               []( const LocalElem& localNode ) -> bool { return localNode.type == ElemType::OWNER; } );
 
-    // Set global index.
-    cellsGlobalIdx(cellLocalIdx) = localCell.globalPtr->globalIdx;
+    // Sort by halo.
+    std::stable_sort( ghostBeginIt, localNodes.end(), []( const LocalElem& nodeA, const LocalElem& nodeB ) -> bool {
+        return nodeA.halo < nodeB.halo;
+    } );
 
-    // Set cell remote index.
-    cellsRemoteIdx(cellLocalIdx) = localCell.globalPtr->remoteIdx;
+    // Associate global nodes with local nodes. Allows us to determine node
+    // local indices around a cell.
+    // Determine partition and remote index if we haven't done so already.
+    for ( LocalElem& localNode : localNodes ) {
+        localNode.globalPtr->localPtr = &localNode;
 
-    // Set partition.
-    cellsPart(cellLocalIdx) = localCell.globalPtr->part;
+        if ( localNode.globalPtr->remoteIdx == undefinedIdx ) {
+            const auto ijtGlobal = jacobian.ijLocalToGlobal( PointIJ( localNode.i, localNode.j ), localNode.t );
 
-    // Set xy.
-    const PointXY xyLocal =
-      jacobian.xy(PointIJ(localCell.i + 0.5, localCell.j + 0.5), localCell.t);
-    const PointXY xyGlobal = interiorCell(localCell.i, localCell.j) ?
-      xyLocal : jacobian.xyLocalToGlobal(xyLocal, localCell.t).first;
+            const idx_t i = ijtGlobal.first.iNode();
+            const idx_t j = ijtGlobal.first.jNode();
+            const idx_t t = ijtGlobal.second;
 
-    cellsXy(cellLocalIdx, XX) = xyLocal.x();
-    cellsXy(cellLocalIdx, YY) = xyLocal.y();
+            ATLAS_ASSERT( !exteriorNode( i, j ) );
 
-    // Set lon-lat.
-    const PointLonLat lonLat = csProjection->lonlat(xyGlobal);
-    cellsLonLat(cellLocalIdx, LON) = lonLat.lon();
-    cellsLonLat(cellLocalIdx, LAT) = lonLat.lat();
+            const GlobalElem& ownerNode = globalNodes[getNodeIdx( i, j, t )];
 
-    // Set ijt.
-    cellsIjt(cellLocalIdx, Coordinates::I) = localCell.i;
-    cellsIjt(cellLocalIdx, Coordinates::J) = localCell.j;
-    cellsIjt(cellLocalIdx, Coordinates::T) = localCell.t;
-
-    // Set halo.
-    cellsHalo(cellLocalIdx) = localCell.halo;
-
-    ATLAS_ASSERT(localCell.halo != undefinedIdx);
-
-    // Set flags.
-    Topology::reset(cellsFlags(cellLocalIdx));
-    switch(localCell.type) {
-
-      case ElemType::UNDEFINED : {
-        ATLAS_ASSERT(0);
-        break;
-      }
-      case ElemType::OWNER : {
-        // Vitally important that these two match!
-        ATLAS_ASSERT(cellLocalIdx == localCell.globalPtr->remoteIdx);
-        break;
-      }
-      case ElemType::HALO : {
-        Topology::set(cellsFlags(cellLocalIdx), Topology::GHOST);
-        break;
-      }
+            localNode.globalPtr->remoteIdx = ownerNode.remoteIdx;
+            localNode.globalPtr->part      = ownerNode.part;
+        }
     }
 
-    ++cellLocalIdx;
-  }
+    // ---------------------------------------------------------------------------
+    // 6. ASSIGN NODES TO MESH
+    //    In addition to the usual fields, we will add i, j and t to mesh.nodes().
+    // ---------------------------------------------------------------------------
 
-  // ---------------------------------------------------------------------------
-  // 8. FINALISE
-  //    Done. That was rather a lot of bookkeeping!
-  // ---------------------------------------------------------------------------
+    // Resize nodes.
+    auto& nodes = mesh.nodes();
+    nodes.resize( static_cast<idx_t>( localNodes.size() ) );
 
-  mesh.metadata().set("halo", nHalo);
-  mesh.metadata().set("halo_locked", true);
+    // Add extra field.
+    Field ijtField = nodes.add( Field( "ijt", make_datatype<idx_t>(), make_shape( nodes.size(), 3 ) ) );
+    ijtField.set_variables( 3 );
 
-  mesh.nodes().metadata().set("parallel", true);
-  mesh.nodes().metadata().set("nb_owned", nodeLocalIdxCount[thisPart]);
+    // Get field views
+    auto nodesGlobalIdx = array::make_view<gidx_t, 1>( nodes.global_index() );
+    auto nodesRemoteIdx = array::make_indexview<idx_t, 1>( nodes.remote_index() );
+    auto nodesXy        = array::make_view<double, 2>( nodes.xy() );
+    auto nodesLonLat    = array::make_view<double, 2>( nodes.lonlat() );
+    auto nodesPart      = array::make_view<int, 1>( nodes.partition() );
+    auto nodesGhost     = array::make_view<int, 1>( nodes.ghost() );
+    auto nodesHalo      = array::make_view<int, 1>( nodes.halo() );
+    auto nodesFlags     = array::make_view<int, 1>( nodes.flags() );
+    auto nodesIjt       = array::make_view<idx_t, 2>( ijtField );
 
-  mesh.cells().metadata().set("parallel", true);
-  mesh.cells().metadata().set("nb_owned", cellLocalIdxCount[thisPart]);
+    // Set fields.
+    idx_t nodeLocalIdx = 0;
+    for ( const LocalElem& localNode : localNodes ) {
+        // Set global index.
+        nodesGlobalIdx( nodeLocalIdx ) = localNode.globalPtr->globalIdx;
 
-  return;
+        // Set node remote index.
+        nodesRemoteIdx( nodeLocalIdx ) = localNode.globalPtr->remoteIdx;
+
+        // Set node partition.
+        nodesPart( nodeLocalIdx ) = localNode.globalPtr->part;
+
+        // Set xy.
+        const PointXY xyLocal = jacobian.xy( PointIJ( localNode.i, localNode.j ), localNode.t );
+        const PointXY xyGlobal =
+            interiorNode( localNode.i, localNode.j ) ? xyLocal : jacobian.xyLocalToGlobal( xyLocal, localNode.t ).first;
+
+        nodesXy( nodeLocalIdx, XX ) = xyLocal.x();
+        nodesXy( nodeLocalIdx, YY ) = xyLocal.y();
+
+        // Set lon-lat.
+        const PointLonLat lonLat         = csProjection->lonlat( xyGlobal );
+        nodesLonLat( nodeLocalIdx, LON ) = lonLat.lon();
+        nodesLonLat( nodeLocalIdx, LAT ) = lonLat.lat();
+
+        // Set tij.
+        nodesIjt( nodeLocalIdx, Coordinates::I ) = localNode.i;
+        nodesIjt( nodeLocalIdx, Coordinates::J ) = localNode.j;
+        nodesIjt( nodeLocalIdx, Coordinates::T ) = localNode.t;
+
+        // Set halo.
+        nodesHalo( nodeLocalIdx ) = localNode.halo;
+        ATLAS_ASSERT( localNode.halo != undefinedIdx );
+
+        // Set flags.
+        Topology::reset( nodesFlags( nodeLocalIdx ) );
+        switch ( localNode.type ) {
+            case ElemType::UNDEFINED: {
+                ATLAS_ASSERT( 0 );
+                break;
+            }
+            case ElemType::OWNER: {
+                nodesGhost( nodeLocalIdx ) = 0;
+                // Vitally important that these two match!
+                ATLAS_ASSERT( nodeLocalIdx == localNode.globalPtr->remoteIdx );
+                break;
+            }
+            case ElemType::HALO: {
+                nodesGhost( nodeLocalIdx ) = 1;
+                Topology::set( nodesFlags( nodeLocalIdx ), Topology::GHOST );
+                break;
+            }
+        }
+
+        ++nodeLocalIdx;
+    }
+
+    // ---------------------------------------------------------------------------
+    // 7. ASSIGN CELLS TO MESH
+    //    Again, we'll add i, j and t to mesh.cells(). We'll also add the xy and
+    //    lonlat coordinates of the cell centres.
+    // ---------------------------------------------------------------------------
+
+    auto& cells = mesh.cells();
+
+    // Resize cells.
+    cells.add( new mesh::temporary::Quadrilateral(), static_cast<idx_t>( localCells.size() ) );
+
+    // Add extra fields.
+    ijtField = cells.add( Field( "ijt", make_datatype<idx_t>(), make_shape( cells.size(), 3 ) ) );
+    ijtField.set_variables( 3 );
+
+    Field xyField = cells.add( Field( "xy", make_datatype<double>(), make_shape( cells.size(), 2 ) ) );
+    xyField.set_variables( 2 );
+
+    Field lonLatField = cells.add( Field( "lonlat", make_datatype<double>(), make_shape( cells.size(), 2 ) ) );
+    lonLatField.set_variables( 2 );
+
+    // Set field views.
+    auto cellsGlobalIdx = array::make_view<gidx_t, 1>( cells.global_index() );
+    auto cellsRemoteIdx = array::make_indexview<idx_t, 1>( cells.remote_index() );
+    auto cellsPart      = array::make_view<int, 1>( cells.partition() );
+    auto cellsHalo      = array::make_view<int, 1>( cells.halo() );
+    auto cellsFlags     = array::make_view<int, 1>( cells.flags() );
+    auto cellsIjt       = array::make_view<idx_t, 2>( ijtField );
+    auto cellsXy        = array::make_view<double, 2>( xyField );
+    auto cellsLonLat    = array::make_view<double, 2>( lonLatField );
+
+    // Set local cells.
+    auto& nodeConnectivity   = cells.node_connectivity();
+    const idx_t cellElemIdx0 = cells.elements( 0 ).begin();
+
+    // Set method to get node local index.
+    const auto getNodeLocalIdx = [&]( idx_t i, idx_t j, idx_t t ) -> idx_t {
+        const GlobalElem& globalNode = globalNodes[getNodeIdx( i, j, t )];
+
+        // Do some pointer arithmetic to get local index.
+        return static_cast<idx_t>( globalNode.localPtr - localNodes.data() );
+    };
+
+    idx_t cellLocalIdx = 0;
+    for ( const LocalElem& localCell : localCells ) {
+        // Get local indices four surroundings nodes.
+        const auto quadNodeIdx = std::array<idx_t, 4>{getNodeLocalIdx( localCell.i, localCell.j, localCell.t ),
+                                                      getNodeLocalIdx( localCell.i + 1, localCell.j, localCell.t ),
+                                                      getNodeLocalIdx( localCell.i + 1, localCell.j + 1, localCell.t ),
+                                                      getNodeLocalIdx( localCell.i, localCell.j + 1, localCell.t )};
+
+        // Set connectivity.
+        nodeConnectivity.set( cellLocalIdx + cellElemIdx0, quadNodeIdx.data() );
+
+        // Set global index.
+        cellsGlobalIdx( cellLocalIdx ) = localCell.globalPtr->globalIdx;
+
+        // Set cell remote index.
+        cellsRemoteIdx( cellLocalIdx ) = localCell.globalPtr->remoteIdx;
+
+        // Set partition.
+        cellsPart( cellLocalIdx ) = localCell.globalPtr->part;
+
+        // Set xy.
+        const PointXY xyLocal = jacobian.xy( PointIJ( localCell.i + 0.5, localCell.j + 0.5 ), localCell.t );
+        const PointXY xyGlobal =
+            interiorCell( localCell.i, localCell.j ) ? xyLocal : jacobian.xyLocalToGlobal( xyLocal, localCell.t ).first;
+
+        cellsXy( cellLocalIdx, XX ) = xyLocal.x();
+        cellsXy( cellLocalIdx, YY ) = xyLocal.y();
+
+        // Set lon-lat.
+        const PointLonLat lonLat         = csProjection->lonlat( xyGlobal );
+        cellsLonLat( cellLocalIdx, LON ) = lonLat.lon();
+        cellsLonLat( cellLocalIdx, LAT ) = lonLat.lat();
+
+        // Set ijt.
+        cellsIjt( cellLocalIdx, Coordinates::I ) = localCell.i;
+        cellsIjt( cellLocalIdx, Coordinates::J ) = localCell.j;
+        cellsIjt( cellLocalIdx, Coordinates::T ) = localCell.t;
+
+        // Set halo.
+        cellsHalo( cellLocalIdx ) = localCell.halo;
+
+        ATLAS_ASSERT( localCell.halo != undefinedIdx );
+
+        // Set flags.
+        Topology::reset( cellsFlags( cellLocalIdx ) );
+        switch ( localCell.type ) {
+            case ElemType::UNDEFINED: {
+                ATLAS_ASSERT( 0 );
+                break;
+            }
+            case ElemType::OWNER: {
+                // Vitally important that these two match!
+                ATLAS_ASSERT( cellLocalIdx == localCell.globalPtr->remoteIdx );
+                break;
+            }
+            case ElemType::HALO: {
+                Topology::set( cellsFlags( cellLocalIdx ), Topology::GHOST );
+                break;
+            }
+        }
+
+        ++cellLocalIdx;
+    }
+
+    // ---------------------------------------------------------------------------
+    // 8. FINALISE
+    //    Done. That was rather a lot of bookkeeping!
+    // ---------------------------------------------------------------------------
+
+    mesh.metadata().set( "halo", nHalo );
+    mesh.metadata().set( "halo_locked", true );
+
+    mesh.nodes().metadata().set( "parallel", true );
+    mesh.nodes().metadata().set( "nb_owned", nodeLocalIdxCount[thisPart] );
+
+    mesh.cells().metadata().set( "parallel", true );
+    mesh.cells().metadata().set( "nb_owned", cellLocalIdxCount[thisPart] );
+
+    return;
 }
 
 // -----------------------------------------------------------------------------
 
-void CubedSphereMeshGenerator::hash(eckit::Hash& h) const {
-h.add("CubedSphereMeshGenerator");
-options.hash(h);
+void CubedSphereMeshGenerator::hash( eckit::Hash& h ) const {
+    h.add( "CubedSphereMeshGenerator" );
+    options.hash( h );
 }
 
 // -----------------------------------------------------------------------------
 
 namespace {
 static MeshGeneratorBuilder<CubedSphereMeshGenerator> CubedSphereMeshGenerator(
-CubedSphereMeshGenerator::static_type());
+    CubedSphereMeshGenerator::static_type() );
 }
 
 // -----------------------------------------------------------------------------

--- a/src/atlas/meshgenerator/detail/NodalCubedSphereMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/NodalCubedSphereMeshGenerator.cc
@@ -85,19 +85,22 @@ void NodalCubedSphereMeshGenerator::generate( const Grid& grid, const grid::Dist
     const int nTiles = csgrid.tiles().size();
 
     // N must be greater than 1.
-    if (N < 2) throw_Exception("N must be greater than 1 for NodalCubedSphereMeshGenerator", Here());
+    if ( N < 2 )
+        throw_Exception( "N must be greater than 1 for NodalCubedSphereMeshGenerator", Here() );
 
     // grid must have node staggering.
-    if (csgrid.stagger() != "L") {
-      throw_Exception("NodalCubedSphereMeshGenerator will only work with a"
-      "nodal grid. Try CubedSphereMeshGenerator instead.", Here());
+    if ( csgrid.stagger() != "L" ) {
+        throw_Exception(
+            "NodalCubedSphereMeshGenerator will only work with a"
+            "nodal grid. Try CubedSphereMeshGenerator instead.",
+            Here() );
     }
 
     // Get tiles
-    auto csprojection = castProjection(csgrid.projection().get());
+    auto csprojection = castProjection( csgrid.projection().get() );
     // grid must use FV3Tiles class.
-    if (csprojection->getCubedSphereTiles().type() != "cubedsphere_fv3") {
-      throw_Exception("NodalCubedSphereMeshGenerator only works with FV3 tiles", Here());
+    if ( csprojection->getCubedSphereTiles().type() != "cubedsphere_fv3" ) {
+        throw_Exception( "NodalCubedSphereMeshGenerator only works with FV3 tiles", Here() );
     }
 
     // Make a list linking ghost (t, i, j) values to known (t, i, j)

--- a/src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.cc
+++ b/src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.cc
@@ -1,0 +1,400 @@
+/*
+ * (C) Crown Copyright 2021 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include "atlas/grid/CubedSphereGrid.h"
+#include "atlas/grid/Iterator.h"
+#include "atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h"
+#include "atlas/projection/detail/CubedSphereProjectionBase.h"
+
+namespace atlas {
+namespace meshgenerator {
+namespace detail {
+namespace cubedsphere {
+
+
+// -----------------------------------------------------------------------------
+// Projection cast
+// -----------------------------------------------------------------------------
+
+const CubedSphereProjectionBase* castProjection(
+  const ProjectionImpl* projectionPtr) {
+
+  const auto* const csProjectionPtr =
+    dynamic_cast<const CubedSphereProjectionBase*>(projectionPtr);
+
+  if (!csProjectionPtr) {
+    throw_Exception("Cannot cast " + projectionPtr->type()
+      + " to CubedSphereProjectionBase*.", Here());
+  }
+  return csProjectionPtr;
+}
+
+// -----------------------------------------------------------------------------
+// Jacobian2 class
+// -----------------------------------------------------------------------------
+
+Jacobian2::Jacobian2(
+  double df0_by_dx0, double df0_by_dx1, double df1_by_dx0, double df1_by_dx1) {
+  data_ << df0_by_dx0, df0_by_dx1, df1_by_dx0, df1_by_dx1;
+}
+
+Jacobian2::Jacobian2(const Point2& f00, const Point2& f10, const Point2& f01,
+  double dx0, double dx1) : Jacobian2(
+    (f10[0] - f00[0]) / dx0, (f01[0] - f00[0]) / dx1,
+    (f10[1] - f00[1]) / dx0, (f01[1] - f00[1]) / dx1) {}
+
+Jacobian2::Jacobian2(const Point2& f00, const Point2& f10, const Point2& f01) :
+  Jacobian2(f00, f10, f01, 1., 1.) {}
+
+Jacobian2::Jacobian2(const Eigen::Matrix2d& data) : data_(data) {}
+
+Jacobian2 Jacobian2::operator*(double a) const {
+  return Jacobian2(data_ * a);
+}
+
+Point2 Jacobian2::operator*(const Point2& dx) const {
+
+  // Declare result.
+  Point2 df;
+
+  // Compute product using Eigen maps.
+  Eigen::Map<Eigen::Vector2d>(df.data()) =
+    data_ * Eigen::Map<const Eigen::Vector2d>(dx.data());
+
+  return df;
+}
+
+Jacobian2 Jacobian2::operator*(const Jacobian2& Jb) const {
+  return Jacobian2(data_ * Jb.data_);
+}
+
+Jacobian2 Jacobian2::inverse() const {
+  return Jacobian2(data_.inverse());
+}
+
+Jacobian2 Jacobian2::sign() const {
+  return Jacobian2(data_.array().sign().matrix());
+}
+
+
+// -----------------------------------------------------------------------------
+// NeighbourJacobian class
+// -----------------------------------------------------------------------------
+
+NeighbourJacobian::NeighbourJacobian(const CubedSphereGrid& csGrid) {
+
+  // N must be greater than 2.
+  if (csGrid.N() < 2) {
+    throw_Exception("Jacobians can only be calculated for N > 1 .", Here());
+  }
+
+  // Assumes cell centre staggering.
+  if (csGrid.stagger() != "C") {
+    throw_Exception(
+      "NeighbourJacobian class only works for cell-centre grid", Here());
+  }
+
+  // Get projection.
+  csProjection_ = castProjection(csGrid.projection().get());
+
+  // Get tiles.
+  const auto& csTiles = csProjection_->getCubedSphereTiles();
+
+  // Get grid size.
+  N_ = csGrid.N();
+
+
+  // Get cell width.
+  const double cellWidth = 90. / N_;
+
+  // Get xy of points (i = 0, j = 0), (i = 1, j = 0) and (i = 0, j = 1) on tiles.
+  std::array<PointXY, 6> xy00;
+  std::array<PointXY, 6> xy10;
+  std::array<PointXY, 6> xy01;
+
+  // Loop over grid points.
+  auto ijtIt = csGrid.tij().begin();
+  for (const PointXY& xy : csGrid.xy()) {
+
+    const idx_t i = (*ijtIt).i();
+    const idx_t j = (*ijtIt).j();
+    const auto t = static_cast<size_t>((*ijtIt).t());
+
+    if      (i == 0  && j == 0) xy00[t] = xy;
+    else if (i == 1  && j == 0) xy10[t] = xy;
+    else if (i == 0  && j == 1) xy01[t] = xy;
+
+    ++ijtIt;
+  }
+
+  for (size_t t = 0; t < 6; ++t) {
+
+    // Calculate tile Jacobians.
+    dxy_by_dij_[t] = Jacobian2(xy00[t], xy10[t], xy01[t]);
+
+    // Rescale by cell width (gains an extra couple of decimal places of precision).
+    dxy_by_dij_[t] = dxy_by_dij_[t].sign() * cellWidth;
+
+    // Get inverse.
+    dij_by_dxy_[t] = dxy_by_dij_[t].inverse();
+
+    // Set xy00. Grid point needs moving to (i = 0, j = 0).
+    xy00_[t] = xy00[t] + dxy_by_dij_[t] * PointIJ(-0.5, -0.5);
+
+    // Get other three corners so we can work out xy min/max.
+    const PointXY xyN0 = xy00_[t] + dxy_by_dij_[t] * PointIJ(N_, 0 );
+    const PointXY xyNN = xy00_[t] + dxy_by_dij_[t] * PointIJ(N_, N_);
+    const PointXY xy0N = xy00_[t] + dxy_by_dij_[t] * PointIJ(0 , N_);
+
+    // Get xy min/max.
+    std::tie(xyMin_[t].x(), xyMax_[t].x()) =
+      std::minmax({xy00_[t].x(), xyN0.x(), xyNN.x(), xy0N.x()});
+    std::tie(xyMin_[t].y(), xyMax_[t].y()) =
+      std::minmax({xy00_[t].y(), xyN0.y(), xyNN.y(), xy0N.y()});
+
+    // Round to nearest degree.
+    xyMin_[t].x() = std::round(xyMin_[t].x());
+    xyMax_[t].x() = std::round(xyMax_[t].x());
+    xyMin_[t].y() = std::round(xyMin_[t].y());
+    xyMax_[t].y() = std::round(xyMax_[t].y());
+
+    // Neighbour assignment lambda.
+    const auto neighbourAssignment = [&](TileEdge::k k) -> void {
+
+      // Shift points in to neighbouring tiles.
+      PointIJ ijDisplacement;
+      switch (k) {
+        case TileEdge::LEFT : {
+          ijDisplacement = PointIJ(-2, 0);
+          break;
+          }
+        case TileEdge::BOTTOM : {
+          ijDisplacement = PointIJ(0, -2);
+          break;
+        }
+        case TileEdge::RIGHT : {
+          ijDisplacement = PointIJ(N_, 0);
+          break;
+        }
+        case TileEdge::TOP : {
+          ijDisplacement = PointIJ(0, N_);
+          break;
+        }
+        case TileEdge::UNDEFINED : {
+        throw_Exception("Undefined tile edge.", Here());
+        break;
+        }
+      }
+
+      // Convert displacement from ij to xy.
+      const PointXY xyDisplacement = dxy_by_dij_[t] * ijDisplacement;
+
+      // Get neighbour xy points in xy space local to tile.
+      const PointXY xy00Local = xy00[t] + xyDisplacement;
+      const PointXY xy10Local = xy10[t] + xyDisplacement;
+      const PointXY xy01Local = xy01[t] + xyDisplacement;
+
+      // Convert from local xy to global xy.
+      const PointXY xy00Global =
+        csTiles.tileCubePeriodicity(xy00Local, static_cast<idx_t>(t));
+      const PointXY xy10Global =
+        csTiles.tileCubePeriodicity(xy10Local, static_cast<idx_t>(t));
+      const PointXY xy01Global =
+        csTiles.tileCubePeriodicity(xy01Local, static_cast<idx_t>(t));
+
+      // Get neighbour tile ID.
+      neighbours_[t].t_[k] = csTiles.indexFromXY(xy00Global.data());
+
+      // Set Jacobian of global xy with respect to local ij.
+      auto dxyGlobal_by_dij =
+        Jacobian2(xy00Global, xy10Global, xy01Global);
+
+      // Rescale by cell width (gains an extra couple of decimal places of precision).
+      dxyGlobal_by_dij = dxyGlobal_by_dij.sign() * cellWidth;
+
+      // Chain rule to get Jacobian with respect to local xy.
+      neighbours_[t].dxyGlobal_by_dxyLocal_[k] =
+        dxyGlobal_by_dij * dij_by_dxy_[t];
+
+      // Set local xy00
+      neighbours_[t].xy00Local_[k] = xy00Local;
+
+      // Set global xy00
+      neighbours_[t].xy00Global_[k] = xy00Global;
+
+    };
+
+    // Assign neighbours (good job we put it all in a lambda!).
+    neighbourAssignment(TileEdge::LEFT);
+    neighbourAssignment(TileEdge::BOTTOM);
+    neighbourAssignment(TileEdge::RIGHT);
+    neighbourAssignment(TileEdge::TOP);
+
+  }
+
+}
+
+PointXY NeighbourJacobian::xy(const PointIJ& ij, idx_t t) const {
+
+  // Get jacobian.
+  const Jacobian2& jac = dxy_by_dij_[static_cast<size_t>(t)];
+  const PointXY& xy00 = xy00_[static_cast<size_t>(t)];
+
+  // Return ij
+  return xy00 + jac * ij;
+}
+
+PointXY NeighbourJacobian::xy(const PointIJT& ijt) const {
+  return xy(ijt.first, ijt.second);
+}
+
+PointIJ NeighbourJacobian::ij(const PointXY& xy, idx_t t) const {
+
+  // Get jacobian.
+  const Jacobian2& jac = dij_by_dxy_[static_cast<size_t>(t)];
+  const PointXY& xy00 = xy00_[static_cast<size_t>(t)];
+
+  // Return ij
+  return jac * (xy - xy00);
+}
+
+PointIJ NeighbourJacobian::ij(const PointXYT& xyt) const {
+  return ij(xyt.first, xyt.second);
+}
+
+PointXYT NeighbourJacobian::xyLocalToGlobal(
+  const PointXY& xyLocal, idx_t tLocal) const {
+
+  // The tileCubePeriodicity method fails when extrapolating along an unowned
+  // tile edge. This method explicitly places an xy point on to a neighbouring
+  // tile to avoid this. Once the correct xy position has been found,
+  // tileCubePeriodicity will correcty find the "owned" xy position of a point
+  // on an unowned tile edge.
+
+  // Declare result.
+  PointXY xyGlobal;
+  idx_t tGlobal;
+
+  // Get ij.
+  const PointIJ ijLocal = ij(xyLocal, tLocal);
+
+  // Get tiles.
+  const auto& csTiles = csProjection_->getCubedSphereTiles();
+
+  if (ijInterior(ijLocal)) {
+
+    // We're within the tile boundary (possibly on an edge).
+
+    // Return local values if not on edge.
+    if (!ijEdge(ijLocal)) return std::make_pair(xyLocal, tLocal);
+
+    // We're on an edge. Will need to check with Tiles class.
+    xyGlobal = xyLocal;
+    tGlobal = tLocal;
+  }
+  else {
+    // We're outside the tile boundary.
+    // Figure out which tile xy is on.
+    TileEdge::k k;
+    if      (ijLocal.iNode() < 0 ) k = TileEdge::LEFT;
+    else if (ijLocal.jNode() < 0 ) k = TileEdge::BOTTOM;
+    else if (ijLocal.iNode() > N_) k = TileEdge::RIGHT;
+    else if (ijLocal.jNode() > N_) k = TileEdge::TOP;
+
+    // Get reference points and jacobian.
+    const PointXY& xy00Local_ =
+      neighbours_[static_cast<size_t>(tLocal)].xy00Local_[k];
+    const PointXY& xy00Global_ =
+      neighbours_[static_cast<size_t>(tLocal)].xy00Global_[k];
+    const Jacobian2& jac =
+      neighbours_[static_cast<size_t>(tLocal)].dxyGlobal_by_dxyLocal_[k];
+
+    // Get t.
+    tGlobal = neighbours_[static_cast<size_t>(tLocal)].t_[k];
+
+    // Calculate global xy.
+    xyGlobal = xy00Global_ + jac * (xyLocal - xy00Local_);
+  }
+
+  // Need to be very careful with floating point comparisons used in projection
+  // class. Move point on to edge if it is very close.
+  xyGlobal = snapToEdge(xyGlobal, tGlobal);
+
+  // Correct for edge-ownership rules.
+  xyGlobal = csTiles.tileCubePeriodicity(xyGlobal, tGlobal);
+  tGlobal = csTiles.indexFromXY(xyGlobal.data());
+
+  return std::make_pair(xyGlobal, tGlobal);
+}
+
+PointXYT NeighbourJacobian::xyLocalToGlobal(
+  const PointXYT& xytLocal) const {
+  return xyLocalToGlobal(xytLocal.first, xytLocal.second);
+}
+
+PointIJT NeighbourJacobian::ijLocalToGlobal(
+  const PointIJ &ijLocal, idx_t tLocal) const {
+
+  // Use xyLocalToGlobal method to take care of this.
+
+  // Get global xyt.
+  PointXYT xytGlobal = xyLocalToGlobal(xy(ijLocal, tLocal), tLocal);
+
+  // convert to ijt
+  return std::make_pair(ij(xytGlobal), xytGlobal.second);
+}
+
+PointIJT NeighbourJacobian::ijLocalToGlobal(
+  const PointIJT& ijtLocal) const {
+  return ijLocalToGlobal(ijtLocal.first, ijtLocal.second);
+}
+
+bool NeighbourJacobian::ijInterior(const PointIJ& ij) const {
+  return ij.iNode() >= 0  && ij.iNode() <= N_ and
+         ij.jNode() >= 0  && ij.jNode() <= N_;
+}
+
+bool NeighbourJacobian::ijEdge(const PointIJ &ij) const {
+  return ijInterior(ij) && (ij.iNode() == 0  ||
+                            ij.iNode() == N_ ||
+                            ij.jNode() == 0  ||
+                            ij.jNode() == N_);
+}
+
+bool NeighbourJacobian::ijCross(const PointIJ& ij) const {
+
+  const bool inCorner = (ij.iNode() < 0   && ij.jNode() < 0 ) || // bottom-left corner.
+                        (ij.iNode() > N_  && ij.jNode() < 0 ) || // bottom-right corner.
+                        (ij.iNode() > N_  && ij.jNode() > N_) || // top-right corner.
+                        (ij.iNode() < 0   && ij.jNode() > N_);   // top-left corner.
+  return !inCorner;
+}
+
+PointXY NeighbourJacobian::snapToEdge(const PointXY& xy, idx_t t) const {
+
+  const auto nudgeValue = [](double a, double b) -> double {
+
+    // Set tolerance to machine epsilon * 360 degrees.
+    constexpr double tol = 360. * std::numeric_limits<double>::epsilon();
+
+    // If a is nearly equal to b, return b. Otherwise return a.
+    return std::abs(a - b) <= tol ? b : a;
+
+  };
+
+  // If point is near edge, place it exactly on edge.
+  const PointXY& xyMin = xyMin_[static_cast<size_t>(t)];
+  const PointXY& xyMax = xyMax_[static_cast<size_t>(t)];
+  return PointXY(nudgeValue(nudgeValue(xy.x(), xyMin.x()), xyMax.x()),
+                 nudgeValue(nudgeValue(xy.y(), xyMin.y()), xyMax.y()));
+
+}
+
+}
+}
+}
+}

--- a/src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.cc
+++ b/src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.cc
@@ -5,9 +5,9 @@
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+#include "atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h"
 #include "atlas/grid/CubedSphereGrid.h"
 #include "atlas/grid/Iterator.h"
-#include "atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h"
 #include "atlas/projection/detail/CubedSphereProjectionBase.h"
 
 namespace atlas {
@@ -20,64 +20,55 @@ namespace cubedsphere {
 // Projection cast
 // -----------------------------------------------------------------------------
 
-const CubedSphereProjectionBase* castProjection(
-  const ProjectionImpl* projectionPtr) {
+const CubedSphereProjectionBase* castProjection( const ProjectionImpl* projectionPtr ) {
+    const auto* const csProjectionPtr = dynamic_cast<const CubedSphereProjectionBase*>( projectionPtr );
 
-  const auto* const csProjectionPtr =
-    dynamic_cast<const CubedSphereProjectionBase*>(projectionPtr);
-
-  if (!csProjectionPtr) {
-    throw_Exception("Cannot cast " + projectionPtr->type()
-      + " to CubedSphereProjectionBase*.", Here());
-  }
-  return csProjectionPtr;
+    if ( !csProjectionPtr ) {
+        throw_Exception( "Cannot cast " + projectionPtr->type() + " to CubedSphereProjectionBase*.", Here() );
+    }
+    return csProjectionPtr;
 }
 
 // -----------------------------------------------------------------------------
 // Jacobian2 class
 // -----------------------------------------------------------------------------
 
-Jacobian2::Jacobian2(
-  double df0_by_dx0, double df0_by_dx1, double df1_by_dx0, double df1_by_dx1) {
-  data_ << df0_by_dx0, df0_by_dx1, df1_by_dx0, df1_by_dx1;
+Jacobian2::Jacobian2( double df0_by_dx0, double df0_by_dx1, double df1_by_dx0, double df1_by_dx1 ) {
+    data_ << df0_by_dx0, df0_by_dx1, df1_by_dx0, df1_by_dx1;
 }
 
-Jacobian2::Jacobian2(const Point2& f00, const Point2& f10, const Point2& f01,
-  double dx0, double dx1) : Jacobian2(
-    (f10[0] - f00[0]) / dx0, (f01[0] - f00[0]) / dx1,
-    (f10[1] - f00[1]) / dx0, (f01[1] - f00[1]) / dx1) {}
+Jacobian2::Jacobian2( const Point2& f00, const Point2& f10, const Point2& f01, double dx0, double dx1 ) :
+    Jacobian2( ( f10[0] - f00[0] ) / dx0, ( f01[0] - f00[0] ) / dx1, ( f10[1] - f00[1] ) / dx0,
+               ( f01[1] - f00[1] ) / dx1 ) {}
 
-Jacobian2::Jacobian2(const Point2& f00, const Point2& f10, const Point2& f01) :
-  Jacobian2(f00, f10, f01, 1., 1.) {}
+Jacobian2::Jacobian2( const Point2& f00, const Point2& f10, const Point2& f01 ) : Jacobian2( f00, f10, f01, 1., 1. ) {}
 
-Jacobian2::Jacobian2(const Eigen::Matrix2d& data) : data_(data) {}
+Jacobian2::Jacobian2( const Eigen::Matrix2d& data ) : data_( data ) {}
 
-Jacobian2 Jacobian2::operator*(double a) const {
-  return Jacobian2(data_ * a);
+Jacobian2 Jacobian2::operator*( double a ) const {
+    return Jacobian2( data_ * a );
 }
 
-Point2 Jacobian2::operator*(const Point2& dx) const {
+Point2 Jacobian2::operator*( const Point2& dx ) const {
+    // Declare result.
+    Point2 df;
 
-  // Declare result.
-  Point2 df;
+    // Compute product using Eigen maps.
+    Eigen::Map<Eigen::Vector2d>( df.data() ) = data_ * Eigen::Map<const Eigen::Vector2d>( dx.data() );
 
-  // Compute product using Eigen maps.
-  Eigen::Map<Eigen::Vector2d>(df.data()) =
-    data_ * Eigen::Map<const Eigen::Vector2d>(dx.data());
-
-  return df;
+    return df;
 }
 
-Jacobian2 Jacobian2::operator*(const Jacobian2& Jb) const {
-  return Jacobian2(data_ * Jb.data_);
+Jacobian2 Jacobian2::operator*( const Jacobian2& Jb ) const {
+    return Jacobian2( data_ * Jb.data_ );
 }
 
 Jacobian2 Jacobian2::inverse() const {
-  return Jacobian2(data_.inverse());
+    return Jacobian2( data_.inverse() );
 }
 
 Jacobian2 Jacobian2::sign() const {
-  return Jacobian2(data_.array().sign().matrix());
+    return Jacobian2( data_.array().sign().matrix() );
 }
 
 
@@ -85,316 +76,288 @@ Jacobian2 Jacobian2::sign() const {
 // NeighbourJacobian class
 // -----------------------------------------------------------------------------
 
-NeighbourJacobian::NeighbourJacobian(const CubedSphereGrid& csGrid) {
+NeighbourJacobian::NeighbourJacobian( const CubedSphereGrid& csGrid ) {
+    // N must be greater than 2.
+    if ( csGrid.N() < 2 ) {
+        throw_Exception( "Jacobians can only be calculated for N > 1 .", Here() );
+    }
 
-  // N must be greater than 2.
-  if (csGrid.N() < 2) {
-    throw_Exception("Jacobians can only be calculated for N > 1 .", Here());
-  }
+    // Assumes cell centre staggering.
+    if ( csGrid.stagger() != "C" ) {
+        throw_Exception( "NeighbourJacobian class only works for cell-centre grid", Here() );
+    }
 
-  // Assumes cell centre staggering.
-  if (csGrid.stagger() != "C") {
-    throw_Exception(
-      "NeighbourJacobian class only works for cell-centre grid", Here());
-  }
+    // Get projection.
+    csProjection_ = castProjection( csGrid.projection().get() );
 
-  // Get projection.
-  csProjection_ = castProjection(csGrid.projection().get());
+    // Get tiles.
+    const auto& csTiles = csProjection_->getCubedSphereTiles();
 
-  // Get tiles.
-  const auto& csTiles = csProjection_->getCubedSphereTiles();
-
-  // Get grid size.
-  N_ = csGrid.N();
+    // Get grid size.
+    N_ = csGrid.N();
 
 
-  // Get cell width.
-  const double cellWidth = 90. / N_;
+    // Get cell width.
+    const double cellWidth = 90. / N_;
 
-  // Get xy of points (i = 0, j = 0), (i = 1, j = 0) and (i = 0, j = 1) on tiles.
-  std::array<PointXY, 6> xy00;
-  std::array<PointXY, 6> xy10;
-  std::array<PointXY, 6> xy01;
+    // Get xy of points (i = 0, j = 0), (i = 1, j = 0) and (i = 0, j = 1) on tiles.
+    std::array<PointXY, 6> xy00;
+    std::array<PointXY, 6> xy10;
+    std::array<PointXY, 6> xy01;
 
-  // Loop over grid points.
-  auto ijtIt = csGrid.tij().begin();
-  for (const PointXY& xy : csGrid.xy()) {
+    // Loop over grid points.
+    auto ijtIt = csGrid.tij().begin();
+    for ( const PointXY& xy : csGrid.xy() ) {
+        const idx_t i = ( *ijtIt ).i();
+        const idx_t j = ( *ijtIt ).j();
+        const auto t  = static_cast<size_t>( ( *ijtIt ).t() );
 
-    const idx_t i = (*ijtIt).i();
-    const idx_t j = (*ijtIt).j();
-    const auto t = static_cast<size_t>((*ijtIt).t());
+        if ( i == 0 && j == 0 )
+            xy00[t] = xy;
+        else if ( i == 1 && j == 0 )
+            xy10[t] = xy;
+        else if ( i == 0 && j == 1 )
+            xy01[t] = xy;
 
-    if      (i == 0  && j == 0) xy00[t] = xy;
-    else if (i == 1  && j == 0) xy10[t] = xy;
-    else if (i == 0  && j == 1) xy01[t] = xy;
+        ++ijtIt;
+    }
 
-    ++ijtIt;
-  }
+    for ( size_t t = 0; t < 6; ++t ) {
+        // Calculate tile Jacobians.
+        dxy_by_dij_[t] = Jacobian2( xy00[t], xy10[t], xy01[t] );
 
-  for (size_t t = 0; t < 6; ++t) {
+        // Rescale by cell width (gains an extra couple of decimal places of precision).
+        dxy_by_dij_[t] = dxy_by_dij_[t].sign() * cellWidth;
 
-    // Calculate tile Jacobians.
-    dxy_by_dij_[t] = Jacobian2(xy00[t], xy10[t], xy01[t]);
+        // Get inverse.
+        dij_by_dxy_[t] = dxy_by_dij_[t].inverse();
 
-    // Rescale by cell width (gains an extra couple of decimal places of precision).
-    dxy_by_dij_[t] = dxy_by_dij_[t].sign() * cellWidth;
+        // Set xy00. Grid point needs moving to (i = 0, j = 0).
+        xy00_[t] = xy00[t] + dxy_by_dij_[t] * PointIJ( -0.5, -0.5 );
 
-    // Get inverse.
-    dij_by_dxy_[t] = dxy_by_dij_[t].inverse();
+        // Get other three corners so we can work out xy min/max.
+        const PointXY xyN0 = xy00_[t] + dxy_by_dij_[t] * PointIJ( N_, 0 );
+        const PointXY xyNN = xy00_[t] + dxy_by_dij_[t] * PointIJ( N_, N_ );
+        const PointXY xy0N = xy00_[t] + dxy_by_dij_[t] * PointIJ( 0, N_ );
 
-    // Set xy00. Grid point needs moving to (i = 0, j = 0).
-    xy00_[t] = xy00[t] + dxy_by_dij_[t] * PointIJ(-0.5, -0.5);
+        // Get xy min/max.
+        std::tie( xyMin_[t].x(), xyMax_[t].x() ) = std::minmax( {xy00_[t].x(), xyN0.x(), xyNN.x(), xy0N.x()} );
+        std::tie( xyMin_[t].y(), xyMax_[t].y() ) = std::minmax( {xy00_[t].y(), xyN0.y(), xyNN.y(), xy0N.y()} );
 
-    // Get other three corners so we can work out xy min/max.
-    const PointXY xyN0 = xy00_[t] + dxy_by_dij_[t] * PointIJ(N_, 0 );
-    const PointXY xyNN = xy00_[t] + dxy_by_dij_[t] * PointIJ(N_, N_);
-    const PointXY xy0N = xy00_[t] + dxy_by_dij_[t] * PointIJ(0 , N_);
+        // Round to nearest degree.
+        xyMin_[t].x() = std::round( xyMin_[t].x() );
+        xyMax_[t].x() = std::round( xyMax_[t].x() );
+        xyMin_[t].y() = std::round( xyMin_[t].y() );
+        xyMax_[t].y() = std::round( xyMax_[t].y() );
 
-    // Get xy min/max.
-    std::tie(xyMin_[t].x(), xyMax_[t].x()) =
-      std::minmax({xy00_[t].x(), xyN0.x(), xyNN.x(), xy0N.x()});
-    std::tie(xyMin_[t].y(), xyMax_[t].y()) =
-      std::minmax({xy00_[t].y(), xyN0.y(), xyNN.y(), xy0N.y()});
+        // Neighbour assignment lambda.
+        const auto neighbourAssignment = [&]( TileEdge::k k ) -> void {
+            // Shift points in to neighbouring tiles.
+            PointIJ ijDisplacement;
+            switch ( k ) {
+                case TileEdge::LEFT: {
+                    ijDisplacement = PointIJ( -2, 0 );
+                    break;
+                }
+                case TileEdge::BOTTOM: {
+                    ijDisplacement = PointIJ( 0, -2 );
+                    break;
+                }
+                case TileEdge::RIGHT: {
+                    ijDisplacement = PointIJ( N_, 0 );
+                    break;
+                }
+                case TileEdge::TOP: {
+                    ijDisplacement = PointIJ( 0, N_ );
+                    break;
+                }
+                case TileEdge::UNDEFINED: {
+                    throw_Exception( "Undefined tile edge.", Here() );
+                    break;
+                }
+            }
 
-    // Round to nearest degree.
-    xyMin_[t].x() = std::round(xyMin_[t].x());
-    xyMax_[t].x() = std::round(xyMax_[t].x());
-    xyMin_[t].y() = std::round(xyMin_[t].y());
-    xyMax_[t].y() = std::round(xyMax_[t].y());
+            // Convert displacement from ij to xy.
+            const PointXY xyDisplacement = dxy_by_dij_[t] * ijDisplacement;
 
-    // Neighbour assignment lambda.
-    const auto neighbourAssignment = [&](TileEdge::k k) -> void {
+            // Get neighbour xy points in xy space local to tile.
+            const PointXY xy00Local = xy00[t] + xyDisplacement;
+            const PointXY xy10Local = xy10[t] + xyDisplacement;
+            const PointXY xy01Local = xy01[t] + xyDisplacement;
 
-      // Shift points in to neighbouring tiles.
-      PointIJ ijDisplacement;
-      switch (k) {
-        case TileEdge::LEFT : {
-          ijDisplacement = PointIJ(-2, 0);
-          break;
-          }
-        case TileEdge::BOTTOM : {
-          ijDisplacement = PointIJ(0, -2);
-          break;
-        }
-        case TileEdge::RIGHT : {
-          ijDisplacement = PointIJ(N_, 0);
-          break;
-        }
-        case TileEdge::TOP : {
-          ijDisplacement = PointIJ(0, N_);
-          break;
-        }
-        case TileEdge::UNDEFINED : {
-        throw_Exception("Undefined tile edge.", Here());
-        break;
-        }
-      }
+            // Convert from local xy to global xy.
+            const PointXY xy00Global = csTiles.tileCubePeriodicity( xy00Local, static_cast<idx_t>( t ) );
+            const PointXY xy10Global = csTiles.tileCubePeriodicity( xy10Local, static_cast<idx_t>( t ) );
+            const PointXY xy01Global = csTiles.tileCubePeriodicity( xy01Local, static_cast<idx_t>( t ) );
 
-      // Convert displacement from ij to xy.
-      const PointXY xyDisplacement = dxy_by_dij_[t] * ijDisplacement;
+            // Get neighbour tile ID.
+            neighbours_[t].t_[k] = csTiles.indexFromXY( xy00Global.data() );
 
-      // Get neighbour xy points in xy space local to tile.
-      const PointXY xy00Local = xy00[t] + xyDisplacement;
-      const PointXY xy10Local = xy10[t] + xyDisplacement;
-      const PointXY xy01Local = xy01[t] + xyDisplacement;
+            // Set Jacobian of global xy with respect to local ij.
+            auto dxyGlobal_by_dij = Jacobian2( xy00Global, xy10Global, xy01Global );
 
-      // Convert from local xy to global xy.
-      const PointXY xy00Global =
-        csTiles.tileCubePeriodicity(xy00Local, static_cast<idx_t>(t));
-      const PointXY xy10Global =
-        csTiles.tileCubePeriodicity(xy10Local, static_cast<idx_t>(t));
-      const PointXY xy01Global =
-        csTiles.tileCubePeriodicity(xy01Local, static_cast<idx_t>(t));
+            // Rescale by cell width (gains an extra couple of decimal places of precision).
+            dxyGlobal_by_dij = dxyGlobal_by_dij.sign() * cellWidth;
 
-      // Get neighbour tile ID.
-      neighbours_[t].t_[k] = csTiles.indexFromXY(xy00Global.data());
+            // Chain rule to get Jacobian with respect to local xy.
+            neighbours_[t].dxyGlobal_by_dxyLocal_[k] = dxyGlobal_by_dij * dij_by_dxy_[t];
 
-      // Set Jacobian of global xy with respect to local ij.
-      auto dxyGlobal_by_dij =
-        Jacobian2(xy00Global, xy10Global, xy01Global);
+            // Set local xy00
+            neighbours_[t].xy00Local_[k] = xy00Local;
 
-      // Rescale by cell width (gains an extra couple of decimal places of precision).
-      dxyGlobal_by_dij = dxyGlobal_by_dij.sign() * cellWidth;
+            // Set global xy00
+            neighbours_[t].xy00Global_[k] = xy00Global;
+        };
 
-      // Chain rule to get Jacobian with respect to local xy.
-      neighbours_[t].dxyGlobal_by_dxyLocal_[k] =
-        dxyGlobal_by_dij * dij_by_dxy_[t];
+        // Assign neighbours (good job we put it all in a lambda!).
+        neighbourAssignment( TileEdge::LEFT );
+        neighbourAssignment( TileEdge::BOTTOM );
+        neighbourAssignment( TileEdge::RIGHT );
+        neighbourAssignment( TileEdge::TOP );
+    }
+}
 
-      // Set local xy00
-      neighbours_[t].xy00Local_[k] = xy00Local;
+PointXY NeighbourJacobian::xy( const PointIJ& ij, idx_t t ) const {
+    // Get jacobian.
+    const Jacobian2& jac = dxy_by_dij_[static_cast<size_t>( t )];
+    const PointXY& xy00  = xy00_[static_cast<size_t>( t )];
 
-      // Set global xy00
-      neighbours_[t].xy00Global_[k] = xy00Global;
+    // Return ij
+    return xy00 + jac * ij;
+}
 
+PointXY NeighbourJacobian::xy( const PointIJT& ijt ) const {
+    return xy( ijt.first, ijt.second );
+}
+
+PointIJ NeighbourJacobian::ij( const PointXY& xy, idx_t t ) const {
+    // Get jacobian.
+    const Jacobian2& jac = dij_by_dxy_[static_cast<size_t>( t )];
+    const PointXY& xy00  = xy00_[static_cast<size_t>( t )];
+
+    // Return ij
+    return jac * ( xy - xy00 );
+}
+
+PointIJ NeighbourJacobian::ij( const PointXYT& xyt ) const {
+    return ij( xyt.first, xyt.second );
+}
+
+PointXYT NeighbourJacobian::xyLocalToGlobal( const PointXY& xyLocal, idx_t tLocal ) const {
+    // The tileCubePeriodicity method fails when extrapolating along an unowned
+    // tile edge. This method explicitly places an xy point on to a neighbouring
+    // tile to avoid this. Once the correct xy position has been found,
+    // tileCubePeriodicity will correcty find the "owned" xy position of a point
+    // on an unowned tile edge.
+
+    // Declare result.
+    PointXY xyGlobal;
+    idx_t tGlobal;
+
+    // Get ij.
+    const PointIJ ijLocal = ij( xyLocal, tLocal );
+
+    // Get tiles.
+    const auto& csTiles = csProjection_->getCubedSphereTiles();
+
+    if ( ijInterior( ijLocal ) ) {
+        // We're within the tile boundary (possibly on an edge).
+
+        // Return local values if not on edge.
+        if ( !ijEdge( ijLocal ) )
+            return std::make_pair( xyLocal, tLocal );
+
+        // We're on an edge. Will need to check with Tiles class.
+        xyGlobal = xyLocal;
+        tGlobal  = tLocal;
+    }
+    else {
+        // We're outside the tile boundary.
+        // Figure out which tile xy is on.
+        TileEdge::k k;
+        if ( ijLocal.iNode() < 0 )
+            k = TileEdge::LEFT;
+        else if ( ijLocal.jNode() < 0 )
+            k = TileEdge::BOTTOM;
+        else if ( ijLocal.iNode() > N_ )
+            k = TileEdge::RIGHT;
+        else if ( ijLocal.jNode() > N_ )
+            k = TileEdge::TOP;
+
+        // Get reference points and jacobian.
+        const PointXY& xy00Local_  = neighbours_[static_cast<size_t>( tLocal )].xy00Local_[k];
+        const PointXY& xy00Global_ = neighbours_[static_cast<size_t>( tLocal )].xy00Global_[k];
+        const Jacobian2& jac       = neighbours_[static_cast<size_t>( tLocal )].dxyGlobal_by_dxyLocal_[k];
+
+        // Get t.
+        tGlobal = neighbours_[static_cast<size_t>( tLocal )].t_[k];
+
+        // Calculate global xy.
+        xyGlobal = xy00Global_ + jac * ( xyLocal - xy00Local_ );
+    }
+
+    // Need to be very careful with floating point comparisons used in projection
+    // class. Move point on to edge if it is very close.
+    xyGlobal = snapToEdge( xyGlobal, tGlobal );
+
+    // Correct for edge-ownership rules.
+    xyGlobal = csTiles.tileCubePeriodicity( xyGlobal, tGlobal );
+    tGlobal  = csTiles.indexFromXY( xyGlobal.data() );
+
+    return std::make_pair( xyGlobal, tGlobal );
+}
+
+PointXYT NeighbourJacobian::xyLocalToGlobal( const PointXYT& xytLocal ) const {
+    return xyLocalToGlobal( xytLocal.first, xytLocal.second );
+}
+
+PointIJT NeighbourJacobian::ijLocalToGlobal( const PointIJ& ijLocal, idx_t tLocal ) const {
+    // Use xyLocalToGlobal method to take care of this.
+
+    // Get global xyt.
+    PointXYT xytGlobal = xyLocalToGlobal( xy( ijLocal, tLocal ), tLocal );
+
+    // convert to ijt
+    return std::make_pair( ij( xytGlobal ), xytGlobal.second );
+}
+
+PointIJT NeighbourJacobian::ijLocalToGlobal( const PointIJT& ijtLocal ) const {
+    return ijLocalToGlobal( ijtLocal.first, ijtLocal.second );
+}
+
+bool NeighbourJacobian::ijInterior( const PointIJ& ij ) const {
+    return ij.iNode() >= 0 && ij.iNode() <= N_ and ij.jNode() >= 0 && ij.jNode() <= N_;
+}
+
+bool NeighbourJacobian::ijEdge( const PointIJ& ij ) const {
+    return ijInterior( ij ) && ( ij.iNode() == 0 || ij.iNode() == N_ || ij.jNode() == 0 || ij.jNode() == N_ );
+}
+
+bool NeighbourJacobian::ijCross( const PointIJ& ij ) const {
+    const bool inCorner = ( ij.iNode() < 0 && ij.jNode() < 0 ) ||    // bottom-left corner.
+                          ( ij.iNode() > N_ && ij.jNode() < 0 ) ||   // bottom-right corner.
+                          ( ij.iNode() > N_ && ij.jNode() > N_ ) ||  // top-right corner.
+                          ( ij.iNode() < 0 && ij.jNode() > N_ );     // top-left corner.
+    return !inCorner;
+}
+
+PointXY NeighbourJacobian::snapToEdge( const PointXY& xy, idx_t t ) const {
+    const auto nudgeValue = []( double a, double b ) -> double {
+        // Set tolerance to machine epsilon * 360 degrees.
+        constexpr double tol = 360. * std::numeric_limits<double>::epsilon();
+
+        // If a is nearly equal to b, return b. Otherwise return a.
+        return std::abs( a - b ) <= tol ? b : a;
     };
 
-    // Assign neighbours (good job we put it all in a lambda!).
-    neighbourAssignment(TileEdge::LEFT);
-    neighbourAssignment(TileEdge::BOTTOM);
-    neighbourAssignment(TileEdge::RIGHT);
-    neighbourAssignment(TileEdge::TOP);
-
-  }
-
+    // If point is near edge, place it exactly on edge.
+    const PointXY& xyMin = xyMin_[static_cast<size_t>( t )];
+    const PointXY& xyMax = xyMax_[static_cast<size_t>( t )];
+    return PointXY( nudgeValue( nudgeValue( xy.x(), xyMin.x() ), xyMax.x() ),
+                    nudgeValue( nudgeValue( xy.y(), xyMin.y() ), xyMax.y() ) );
 }
 
-PointXY NeighbourJacobian::xy(const PointIJ& ij, idx_t t) const {
-
-  // Get jacobian.
-  const Jacobian2& jac = dxy_by_dij_[static_cast<size_t>(t)];
-  const PointXY& xy00 = xy00_[static_cast<size_t>(t)];
-
-  // Return ij
-  return xy00 + jac * ij;
-}
-
-PointXY NeighbourJacobian::xy(const PointIJT& ijt) const {
-  return xy(ijt.first, ijt.second);
-}
-
-PointIJ NeighbourJacobian::ij(const PointXY& xy, idx_t t) const {
-
-  // Get jacobian.
-  const Jacobian2& jac = dij_by_dxy_[static_cast<size_t>(t)];
-  const PointXY& xy00 = xy00_[static_cast<size_t>(t)];
-
-  // Return ij
-  return jac * (xy - xy00);
-}
-
-PointIJ NeighbourJacobian::ij(const PointXYT& xyt) const {
-  return ij(xyt.first, xyt.second);
-}
-
-PointXYT NeighbourJacobian::xyLocalToGlobal(
-  const PointXY& xyLocal, idx_t tLocal) const {
-
-  // The tileCubePeriodicity method fails when extrapolating along an unowned
-  // tile edge. This method explicitly places an xy point on to a neighbouring
-  // tile to avoid this. Once the correct xy position has been found,
-  // tileCubePeriodicity will correcty find the "owned" xy position of a point
-  // on an unowned tile edge.
-
-  // Declare result.
-  PointXY xyGlobal;
-  idx_t tGlobal;
-
-  // Get ij.
-  const PointIJ ijLocal = ij(xyLocal, tLocal);
-
-  // Get tiles.
-  const auto& csTiles = csProjection_->getCubedSphereTiles();
-
-  if (ijInterior(ijLocal)) {
-
-    // We're within the tile boundary (possibly on an edge).
-
-    // Return local values if not on edge.
-    if (!ijEdge(ijLocal)) return std::make_pair(xyLocal, tLocal);
-
-    // We're on an edge. Will need to check with Tiles class.
-    xyGlobal = xyLocal;
-    tGlobal = tLocal;
-  }
-  else {
-    // We're outside the tile boundary.
-    // Figure out which tile xy is on.
-    TileEdge::k k;
-    if      (ijLocal.iNode() < 0 ) k = TileEdge::LEFT;
-    else if (ijLocal.jNode() < 0 ) k = TileEdge::BOTTOM;
-    else if (ijLocal.iNode() > N_) k = TileEdge::RIGHT;
-    else if (ijLocal.jNode() > N_) k = TileEdge::TOP;
-
-    // Get reference points and jacobian.
-    const PointXY& xy00Local_ =
-      neighbours_[static_cast<size_t>(tLocal)].xy00Local_[k];
-    const PointXY& xy00Global_ =
-      neighbours_[static_cast<size_t>(tLocal)].xy00Global_[k];
-    const Jacobian2& jac =
-      neighbours_[static_cast<size_t>(tLocal)].dxyGlobal_by_dxyLocal_[k];
-
-    // Get t.
-    tGlobal = neighbours_[static_cast<size_t>(tLocal)].t_[k];
-
-    // Calculate global xy.
-    xyGlobal = xy00Global_ + jac * (xyLocal - xy00Local_);
-  }
-
-  // Need to be very careful with floating point comparisons used in projection
-  // class. Move point on to edge if it is very close.
-  xyGlobal = snapToEdge(xyGlobal, tGlobal);
-
-  // Correct for edge-ownership rules.
-  xyGlobal = csTiles.tileCubePeriodicity(xyGlobal, tGlobal);
-  tGlobal = csTiles.indexFromXY(xyGlobal.data());
-
-  return std::make_pair(xyGlobal, tGlobal);
-}
-
-PointXYT NeighbourJacobian::xyLocalToGlobal(
-  const PointXYT& xytLocal) const {
-  return xyLocalToGlobal(xytLocal.first, xytLocal.second);
-}
-
-PointIJT NeighbourJacobian::ijLocalToGlobal(
-  const PointIJ &ijLocal, idx_t tLocal) const {
-
-  // Use xyLocalToGlobal method to take care of this.
-
-  // Get global xyt.
-  PointXYT xytGlobal = xyLocalToGlobal(xy(ijLocal, tLocal), tLocal);
-
-  // convert to ijt
-  return std::make_pair(ij(xytGlobal), xytGlobal.second);
-}
-
-PointIJT NeighbourJacobian::ijLocalToGlobal(
-  const PointIJT& ijtLocal) const {
-  return ijLocalToGlobal(ijtLocal.first, ijtLocal.second);
-}
-
-bool NeighbourJacobian::ijInterior(const PointIJ& ij) const {
-  return ij.iNode() >= 0  && ij.iNode() <= N_ and
-         ij.jNode() >= 0  && ij.jNode() <= N_;
-}
-
-bool NeighbourJacobian::ijEdge(const PointIJ &ij) const {
-  return ijInterior(ij) && (ij.iNode() == 0  ||
-                            ij.iNode() == N_ ||
-                            ij.jNode() == 0  ||
-                            ij.jNode() == N_);
-}
-
-bool NeighbourJacobian::ijCross(const PointIJ& ij) const {
-
-  const bool inCorner = (ij.iNode() < 0   && ij.jNode() < 0 ) || // bottom-left corner.
-                        (ij.iNode() > N_  && ij.jNode() < 0 ) || // bottom-right corner.
-                        (ij.iNode() > N_  && ij.jNode() > N_) || // top-right corner.
-                        (ij.iNode() < 0   && ij.jNode() > N_);   // top-left corner.
-  return !inCorner;
-}
-
-PointXY NeighbourJacobian::snapToEdge(const PointXY& xy, idx_t t) const {
-
-  const auto nudgeValue = [](double a, double b) -> double {
-
-    // Set tolerance to machine epsilon * 360 degrees.
-    constexpr double tol = 360. * std::numeric_limits<double>::epsilon();
-
-    // If a is nearly equal to b, return b. Otherwise return a.
-    return std::abs(a - b) <= tol ? b : a;
-
-  };
-
-  // If point is near edge, place it exactly on edge.
-  const PointXY& xyMin = xyMin_[static_cast<size_t>(t)];
-  const PointXY& xyMax = xyMax_[static_cast<size_t>(t)];
-  return PointXY(nudgeValue(nudgeValue(xy.x(), xyMin.x()), xyMax.x()),
-                 nudgeValue(nudgeValue(xy.y(), xyMin.y()), xyMax.y()));
-
-}
-
-}
-}
-}
-}
+}  // namespace cubedsphere
+}  // namespace detail
+}  // namespace meshgenerator
+}  // namespace atlas

--- a/src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.cc
+++ b/src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.cc
@@ -326,7 +326,7 @@ PointIJT NeighbourJacobian::ijLocalToGlobal( const PointIJT& ijtLocal ) const {
 }
 
 bool NeighbourJacobian::ijInterior( const PointIJ& ij ) const {
-    return ij.iNode() >= 0 && ij.iNode() <= N_ and ij.jNode() >= 0 && ij.jNode() <= N_;
+    return ij.iNode() >= 0 && ij.iNode() <= N_ && ij.jNode() >= 0 && ij.jNode() <= N_;
 }
 
 bool NeighbourJacobian::ijEdge( const PointIJ& ij ) const {

--- a/src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h
+++ b/src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h
@@ -1,0 +1,251 @@
+/*
+ * (C) Crown Copyright 2021 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#pragma once
+
+#include "atlas/library/config.h"
+#include "atlas/runtime/Exception.h"
+#include "atlas/util/Point.h"
+
+#include "eckit/maths/Eigen.h"
+
+namespace atlas {
+class CubedSphereGrid;
+}
+
+namespace atlas {
+}
+
+namespace atlas {
+namespace projection {
+namespace detail {
+class ProjectionImpl;
+class CubedSphereProjectionBase;
+}
+}
+}
+
+namespace atlas {
+namespace meshgenerator {
+namespace detail {
+namespace cubedsphere {
+
+using namespace projection::detail;
+
+/// Enum for (i, j, t) coordinate fields.
+struct Coordinates {
+  enum k : idx_t {I, J, T};
+};
+
+/// Enum for tile edges.
+struct TileEdge {
+  enum k : size_t {LEFT, BOTTOM, RIGHT, TOP, UNDEFINED};
+};
+
+/// Cast Projection to CubedSphereProjectionBase.
+const CubedSphereProjectionBase* castProjection(const ProjectionImpl* projectionPtr);
+
+/// Class to store (i, j) indices as a Point2 coordinate.
+class PointIJ : public Point2 {
+public:
+
+  using Point2::Point2;
+
+  /// Index constructor.
+  inline PointIJ(idx_t i, idx_t j) :
+    Point2(static_cast<double>(i), static_cast<double>(j)) {}
+
+  /// @{
+  ///  Return i or j by value.
+  inline double i() const {return x_[0];}
+  inline double j() const {return x_[1];}
+  /// @}
+
+  /// @{
+  /// Return i or j by reference
+  inline double& i() {return x_[0];}
+  inline double& j() {return x_[1];}
+  /// @}
+
+  /// @{
+  /// Round i or j to node index.
+  inline idx_t iNode() const {return static_cast<idx_t>(std::round(i()));}
+  inline idx_t jNode() const {return static_cast<idx_t>(std::round(j()));}
+  /// @}
+
+  /// @{
+  /// Round i or j to cell index.
+  inline idx_t iCell() const {return static_cast<idx_t>(std::floor(i()));}
+  inline idx_t jCell() const {return static_cast<idx_t>(std::floor(j()));}
+  /// @}
+
+};
+
+/// (PointXY, t) tuple def.
+using PointXYT = std::pair<PointXY, idx_t>;
+
+/// (PointIJ, t) tuple def.
+using PointIJT = std::pair<PointIJ, idx_t>;
+
+/// \brief   Jacobian class for 2 dimensional vector fields.
+///
+/// \details Wrapper class for an Eigen matrix which stores the partial
+///          of f(x). Objects can be constructed directly from the four partial
+///          derivatives, or by supplying three Point2 objects with the
+///          following relative positions:
+///
+///             ^
+///             | *f(X0, X1 + dx1)
+///             |
+///          x1 |
+///             |
+///             | *f(X0, X1)  *f(X0 + dx0, X1)
+///             +---------------------------->
+///                          x0
+class Jacobian2 {
+
+  public:
+
+  /// Default constructor.
+  Jacobian2() = default;
+
+  /// Partial derivative constructor.
+  Jacobian2(
+    double df0_by_dx0, double df0_by_dx1, double df1_by_dx0, double df1_by_dx1);
+
+  /// Discrete point constructor (explicit dx).
+  Jacobian2(const Point2& f00, const Point2& f10, const Point2& f01,
+    double dx0, double dx1);
+
+  /// Discrete point contructor (implicit dx).
+  Jacobian2(const Point2& f00, const Point2& f10, const Point2& f01);
+
+  /// Jacobian-scalar multiplication.
+  Jacobian2 operator*(double a) const;
+
+  /// Jacobian-vector multiplication.
+  Point2 operator*(const Point2& dx) const;
+
+  /// Jacobian-Jacobian multiplication.
+  Jacobian2 operator*(const Jacobian2& Jb) const;
+
+  /// Inverse Jacobian (partial derivatives of x(f)).
+  Jacobian2 inverse() const;
+
+  /// Get signed elements of matrix (i.e, 0, +1, -1).
+  Jacobian2 sign() const;
+
+private:
+  // Data constructor.
+  inline Jacobian2(const Eigen::Matrix2d& data);
+
+  // Data storage.
+  Eigen::Matrix2d data_{};
+};
+
+/// \brief   Class to convert between ij and xy on a tile and its four
+///          surrounding neighbours.
+///
+///          Helper class to deal with the coordinate system roations and
+///          displacements between a tile and its neighbours. This class
+///          is specifcially written to comupute the (x, y) and (t, i, j)
+///          coordinates of halos that extend across tile boundaries.
+class NeighbourJacobian {
+public:
+
+  /// Default constructor.
+  NeighbourJacobian() = default;
+
+  /// Grid-data constructor.
+  NeighbourJacobian(const CubedSphereGrid& csGrid);
+
+  /// @{
+  /// Convert ij on local tile t to xy.
+  PointXY xy(const PointIJ& ij, idx_t t) const;
+  PointXY xy(const std::pair<PointIJ, idx_t>& ijt) const;
+  /// @}
+
+  /// @{
+  /// Convert xy on local tile t to ij.
+  PointIJ ij(const PointXY& xy, idx_t t) const;
+  PointIJ ij(const std::pair<PointXY, idx_t>& xyt) const;
+  /// @}
+
+  /// @{
+  /// Convert extrapolated xy on tile t to global xy and t (needed for halos).
+  std::pair<PointXY, idx_t>
+    xyLocalToGlobal(const PointXY& xyLocal, idx_t tLocal) const;
+  std::pair<PointXY, idx_t>
+    xyLocalToGlobal(const std::pair<PointXY, idx_t>& xytLocal) const;
+  /// @}
+
+  /// @{
+  /// Convert extrapolated ij on tile t to global ij and t (needed for halos).
+  std::pair<PointIJ, idx_t>
+    ijLocalToGlobal(const PointIJ& ijLocal, idx_t tLocal) const;
+  std::pair<PointIJ, idx_t>
+    ijLocalToGlobal(const std::pair<PointIJ, idx_t>& ijtLocal) const;
+  /// @}
+
+  /// Return true if ij is interior or on the edge of a tile.
+  bool ijInterior(const PointIJ& ij) const;
+
+  /// Return true if ij is on the edge of a tile.
+  bool ijEdge(const PointIJ& ij) const;
+
+  /// Return true if ij is in the valid "+" halo extension of at tile.
+  bool ijCross(const PointIJ& ij) const;
+
+  /// Makes sure points near tile edges are *exactly* on the edge.
+  PointXY snapToEdge(const PointXY& xy, idx_t t) const;
+
+private:
+
+  // Pointer to grid projection.
+  const CubedSphereProjectionBase* csProjection_{};
+
+  // Grid size.
+  idx_t N_{};
+
+  // Jacobian of xy with respect to ij for each tile.
+  std::array<Jacobian2, 6> dxy_by_dij_{};
+
+  // Jacobian of ij with respect to xy for each tile.
+  std::array<Jacobian2, 6> dij_by_dxy_{};
+
+  // Lower-left xy position on each tile.
+  std::array<PointXY, 6> xy00_{};
+
+  // Min xy on each tile.
+  std::array<PointXY, 6> xyMin_{};
+
+  // Max xy on each tile.
+  std::array<PointXY, 6> xyMax_{};
+
+  // Properties of four neighbours of a tile.
+  struct Neighbours {
+
+    // Tile ID.
+    std::array<idx_t, 4> t_{};
+
+    // Jacobian of remote xy with respect to local xy.
+    std::array<Jacobian2, 4> dxyGlobal_by_dxyLocal_{};
+
+    // Lower left most local xy position on neighbour tiles.
+    std::array<PointXY, 4> xy00Local_;
+    std::array<PointXY, 4> xy00Global_;
+  };
+
+  // Set of neighbours for each tile.
+  std::array<Neighbours, 6> neighbours_{};
+
+};
+
+} // namespace cubedsphere
+} // namespace detail
+} // namespace meshgenerator
+} // namespace atlas

--- a/src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h
+++ b/src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h
@@ -11,8 +11,6 @@
 #include "atlas/runtime/Exception.h"
 #include "atlas/util/Point.h"
 
-#include "eckit/maths/Eigen.h"
-
 namespace atlas {
 class CubedSphereGrid;
 }
@@ -128,6 +126,9 @@ public:
     /// Discrete point contructor (implicit dx).
     Jacobian2( const Point2& f00, const Point2& f10, const Point2& f01 );
 
+    /// Determinant of Jacobian.
+    double det() const;
+
     /// Jacobian-scalar multiplication.
     Jacobian2 operator*( double a ) const;
 
@@ -144,11 +145,13 @@ public:
     Jacobian2 sign() const;
 
 private:
-    // Data constructor.
-    inline Jacobian2( const Eigen::Matrix2d& data );
 
     // Data storage.
-    Eigen::Matrix2d data_{};
+    double df0_by_dx0_;
+    double df0_by_dx1_;
+    double df1_by_dx0_;
+    double df1_by_dx1_;
+
 };
 
 /// \brief   Class to convert between ij and xy on a tile and its four

--- a/src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h
+++ b/src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h
@@ -62,6 +62,7 @@ const CubedSphereProjectionBase* castProjection( const ProjectionImpl* projectio
 class PointIJ : public Point2 {
 public:
     using Point2::Point2;
+    PointIJ() : Point2() {}
 
     /// Index constructor.
     inline PointIJ( idx_t i, idx_t j ) : Point2( static_cast<double>( i ), static_cast<double>( j ) ) {}

--- a/src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h
+++ b/src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h
@@ -17,17 +17,16 @@ namespace atlas {
 class CubedSphereGrid;
 }
 
-namespace atlas {
-}
+namespace atlas {}
 
 namespace atlas {
 namespace projection {
 namespace detail {
 class ProjectionImpl;
 class CubedSphereProjectionBase;
-}
-}
-}
+}  // namespace detail
+}  // namespace projection
+}  // namespace atlas
 
 namespace atlas {
 namespace meshgenerator {
@@ -38,51 +37,60 @@ using namespace projection::detail;
 
 /// Enum for (i, j, t) coordinate fields.
 struct Coordinates {
-  enum k : idx_t {I, J, T};
+    enum k : idx_t
+    {
+        I,
+        J,
+        T
+    };
 };
 
 /// Enum for tile edges.
 struct TileEdge {
-  enum k : size_t {LEFT, BOTTOM, RIGHT, TOP, UNDEFINED};
+    enum k : size_t
+    {
+        LEFT,
+        BOTTOM,
+        RIGHT,
+        TOP,
+        UNDEFINED
+    };
 };
 
 /// Cast Projection to CubedSphereProjectionBase.
-const CubedSphereProjectionBase* castProjection(const ProjectionImpl* projectionPtr);
+const CubedSphereProjectionBase* castProjection( const ProjectionImpl* projectionPtr );
 
 /// Class to store (i, j) indices as a Point2 coordinate.
 class PointIJ : public Point2 {
 public:
+    using Point2::Point2;
 
-  using Point2::Point2;
+    /// Index constructor.
+    inline PointIJ( idx_t i, idx_t j ) : Point2( static_cast<double>( i ), static_cast<double>( j ) ) {}
 
-  /// Index constructor.
-  inline PointIJ(idx_t i, idx_t j) :
-    Point2(static_cast<double>(i), static_cast<double>(j)) {}
+    /// @{
+    ///  Return i or j by value.
+    inline double i() const { return x_[0]; }
+    inline double j() const { return x_[1]; }
+    /// @}
 
-  /// @{
-  ///  Return i or j by value.
-  inline double i() const {return x_[0];}
-  inline double j() const {return x_[1];}
-  /// @}
+    /// @{
+    /// Return i or j by reference
+    inline double& i() { return x_[0]; }
+    inline double& j() { return x_[1]; }
+    /// @}
 
-  /// @{
-  /// Return i or j by reference
-  inline double& i() {return x_[0];}
-  inline double& j() {return x_[1];}
-  /// @}
+    /// @{
+    /// Round i or j to node index.
+    inline idx_t iNode() const { return static_cast<idx_t>( std::round( i() ) ); }
+    inline idx_t jNode() const { return static_cast<idx_t>( std::round( j() ) ); }
+    /// @}
 
-  /// @{
-  /// Round i or j to node index.
-  inline idx_t iNode() const {return static_cast<idx_t>(std::round(i()));}
-  inline idx_t jNode() const {return static_cast<idx_t>(std::round(j()));}
-  /// @}
-
-  /// @{
-  /// Round i or j to cell index.
-  inline idx_t iCell() const {return static_cast<idx_t>(std::floor(i()));}
-  inline idx_t jCell() const {return static_cast<idx_t>(std::floor(j()));}
-  /// @}
-
+    /// @{
+    /// Round i or j to cell index.
+    inline idx_t iCell() const { return static_cast<idx_t>( std::floor( i() ) ); }
+    inline idx_t jCell() const { return static_cast<idx_t>( std::floor( j() ) ); }
+    /// @}
 };
 
 /// (PointXY, t) tuple def.
@@ -107,44 +115,40 @@ using PointIJT = std::pair<PointIJ, idx_t>;
 ///             +---------------------------->
 ///                          x0
 class Jacobian2 {
+public:
+    /// Default constructor.
+    Jacobian2() = default;
 
-  public:
+    /// Partial derivative constructor.
+    Jacobian2( double df0_by_dx0, double df0_by_dx1, double df1_by_dx0, double df1_by_dx1 );
 
-  /// Default constructor.
-  Jacobian2() = default;
+    /// Discrete point constructor (explicit dx).
+    Jacobian2( const Point2& f00, const Point2& f10, const Point2& f01, double dx0, double dx1 );
 
-  /// Partial derivative constructor.
-  Jacobian2(
-    double df0_by_dx0, double df0_by_dx1, double df1_by_dx0, double df1_by_dx1);
+    /// Discrete point contructor (implicit dx).
+    Jacobian2( const Point2& f00, const Point2& f10, const Point2& f01 );
 
-  /// Discrete point constructor (explicit dx).
-  Jacobian2(const Point2& f00, const Point2& f10, const Point2& f01,
-    double dx0, double dx1);
+    /// Jacobian-scalar multiplication.
+    Jacobian2 operator*( double a ) const;
 
-  /// Discrete point contructor (implicit dx).
-  Jacobian2(const Point2& f00, const Point2& f10, const Point2& f01);
+    /// Jacobian-vector multiplication.
+    Point2 operator*( const Point2& dx ) const;
 
-  /// Jacobian-scalar multiplication.
-  Jacobian2 operator*(double a) const;
+    /// Jacobian-Jacobian multiplication.
+    Jacobian2 operator*( const Jacobian2& Jb ) const;
 
-  /// Jacobian-vector multiplication.
-  Point2 operator*(const Point2& dx) const;
+    /// Inverse Jacobian (partial derivatives of x(f)).
+    Jacobian2 inverse() const;
 
-  /// Jacobian-Jacobian multiplication.
-  Jacobian2 operator*(const Jacobian2& Jb) const;
-
-  /// Inverse Jacobian (partial derivatives of x(f)).
-  Jacobian2 inverse() const;
-
-  /// Get signed elements of matrix (i.e, 0, +1, -1).
-  Jacobian2 sign() const;
+    /// Get signed elements of matrix (i.e, 0, +1, -1).
+    Jacobian2 sign() const;
 
 private:
-  // Data constructor.
-  inline Jacobian2(const Eigen::Matrix2d& data);
+    // Data constructor.
+    inline Jacobian2( const Eigen::Matrix2d& data );
 
-  // Data storage.
-  Eigen::Matrix2d data_{};
+    // Data storage.
+    Eigen::Matrix2d data_{};
 };
 
 /// \brief   Class to convert between ij and xy on a tile and its four
@@ -156,96 +160,88 @@ private:
 ///          coordinates of halos that extend across tile boundaries.
 class NeighbourJacobian {
 public:
+    /// Default constructor.
+    NeighbourJacobian() = default;
 
-  /// Default constructor.
-  NeighbourJacobian() = default;
+    /// Grid-data constructor.
+    NeighbourJacobian( const CubedSphereGrid& csGrid );
 
-  /// Grid-data constructor.
-  NeighbourJacobian(const CubedSphereGrid& csGrid);
+    /// @{
+    /// Convert ij on local tile t to xy.
+    PointXY xy( const PointIJ& ij, idx_t t ) const;
+    PointXY xy( const std::pair<PointIJ, idx_t>& ijt ) const;
+    /// @}
 
-  /// @{
-  /// Convert ij on local tile t to xy.
-  PointXY xy(const PointIJ& ij, idx_t t) const;
-  PointXY xy(const std::pair<PointIJ, idx_t>& ijt) const;
-  /// @}
+    /// @{
+    /// Convert xy on local tile t to ij.
+    PointIJ ij( const PointXY& xy, idx_t t ) const;
+    PointIJ ij( const std::pair<PointXY, idx_t>& xyt ) const;
+    /// @}
 
-  /// @{
-  /// Convert xy on local tile t to ij.
-  PointIJ ij(const PointXY& xy, idx_t t) const;
-  PointIJ ij(const std::pair<PointXY, idx_t>& xyt) const;
-  /// @}
+    /// @{
+    /// Convert extrapolated xy on tile t to global xy and t (needed for halos).
+    std::pair<PointXY, idx_t> xyLocalToGlobal( const PointXY& xyLocal, idx_t tLocal ) const;
+    std::pair<PointXY, idx_t> xyLocalToGlobal( const std::pair<PointXY, idx_t>& xytLocal ) const;
+    /// @}
 
-  /// @{
-  /// Convert extrapolated xy on tile t to global xy and t (needed for halos).
-  std::pair<PointXY, idx_t>
-    xyLocalToGlobal(const PointXY& xyLocal, idx_t tLocal) const;
-  std::pair<PointXY, idx_t>
-    xyLocalToGlobal(const std::pair<PointXY, idx_t>& xytLocal) const;
-  /// @}
+    /// @{
+    /// Convert extrapolated ij on tile t to global ij and t (needed for halos).
+    std::pair<PointIJ, idx_t> ijLocalToGlobal( const PointIJ& ijLocal, idx_t tLocal ) const;
+    std::pair<PointIJ, idx_t> ijLocalToGlobal( const std::pair<PointIJ, idx_t>& ijtLocal ) const;
+    /// @}
 
-  /// @{
-  /// Convert extrapolated ij on tile t to global ij and t (needed for halos).
-  std::pair<PointIJ, idx_t>
-    ijLocalToGlobal(const PointIJ& ijLocal, idx_t tLocal) const;
-  std::pair<PointIJ, idx_t>
-    ijLocalToGlobal(const std::pair<PointIJ, idx_t>& ijtLocal) const;
-  /// @}
+    /// Return true if ij is interior or on the edge of a tile.
+    bool ijInterior( const PointIJ& ij ) const;
 
-  /// Return true if ij is interior or on the edge of a tile.
-  bool ijInterior(const PointIJ& ij) const;
+    /// Return true if ij is on the edge of a tile.
+    bool ijEdge( const PointIJ& ij ) const;
 
-  /// Return true if ij is on the edge of a tile.
-  bool ijEdge(const PointIJ& ij) const;
+    /// Return true if ij is in the valid "+" halo extension of at tile.
+    bool ijCross( const PointIJ& ij ) const;
 
-  /// Return true if ij is in the valid "+" halo extension of at tile.
-  bool ijCross(const PointIJ& ij) const;
-
-  /// Makes sure points near tile edges are *exactly* on the edge.
-  PointXY snapToEdge(const PointXY& xy, idx_t t) const;
+    /// Makes sure points near tile edges are *exactly* on the edge.
+    PointXY snapToEdge( const PointXY& xy, idx_t t ) const;
 
 private:
+    // Pointer to grid projection.
+    const CubedSphereProjectionBase* csProjection_{};
 
-  // Pointer to grid projection.
-  const CubedSphereProjectionBase* csProjection_{};
+    // Grid size.
+    idx_t N_{};
 
-  // Grid size.
-  idx_t N_{};
+    // Jacobian of xy with respect to ij for each tile.
+    std::array<Jacobian2, 6> dxy_by_dij_{};
 
-  // Jacobian of xy with respect to ij for each tile.
-  std::array<Jacobian2, 6> dxy_by_dij_{};
+    // Jacobian of ij with respect to xy for each tile.
+    std::array<Jacobian2, 6> dij_by_dxy_{};
 
-  // Jacobian of ij with respect to xy for each tile.
-  std::array<Jacobian2, 6> dij_by_dxy_{};
+    // Lower-left xy position on each tile.
+    std::array<PointXY, 6> xy00_{};
 
-  // Lower-left xy position on each tile.
-  std::array<PointXY, 6> xy00_{};
+    // Min xy on each tile.
+    std::array<PointXY, 6> xyMin_{};
 
-  // Min xy on each tile.
-  std::array<PointXY, 6> xyMin_{};
+    // Max xy on each tile.
+    std::array<PointXY, 6> xyMax_{};
 
-  // Max xy on each tile.
-  std::array<PointXY, 6> xyMax_{};
+    // Properties of four neighbours of a tile.
+    struct Neighbours {
+        // Tile ID.
+        std::array<idx_t, 4> t_{};
 
-  // Properties of four neighbours of a tile.
-  struct Neighbours {
+        // Jacobian of remote xy with respect to local xy.
+        std::array<Jacobian2, 4> dxyGlobal_by_dxyLocal_{};
 
-    // Tile ID.
-    std::array<idx_t, 4> t_{};
+        // Lower left most local xy position on neighbour tiles.
+        std::array<PointXY, 4> xy00Local_;
+        std::array<PointXY, 4> xy00Global_;
+    };
 
-    // Jacobian of remote xy with respect to local xy.
-    std::array<Jacobian2, 4> dxyGlobal_by_dxyLocal_{};
-
-    // Lower left most local xy position on neighbour tiles.
-    std::array<PointXY, 4> xy00Local_;
-    std::array<PointXY, 4> xy00Global_;
-  };
-
-  // Set of neighbours for each tile.
-  std::array<Neighbours, 6> neighbours_{};
-
+    // Set of neighbours for each tile.
+    std::array<Neighbours, 6> neighbours_{};
 };
 
-} // namespace cubedsphere
-} // namespace detail
-} // namespace meshgenerator
-} // namespace atlas
+}  // namespace cubedsphere
+}  // namespace detail
+}  // namespace meshgenerator
+}  // namespace atlas

--- a/src/tests/mesh/test_cubedsphere_meshgen.cc
+++ b/src/tests/mesh/test_cubedsphere_meshgen.cc
@@ -6,19 +6,19 @@
  */
 
 #include "atlas/array/MakeView.h"
-#include "atlas/functionspace/NodeColumns.h"
-#include "atlas/functionspace/CellColumns.h"
 #include "atlas/field/FieldSet.h"
+#include "atlas/functionspace/CellColumns.h"
+#include "atlas/functionspace/NodeColumns.h"
 #include "atlas/grid.h"
 #include "atlas/grid/CubedSphereGrid.h"
+#include "atlas/grid/Partitioner.h"
 #include "atlas/grid/Tiles.h"
+#include "atlas/grid/detail/partitioner/CubedSpherePartitioner.h"
 #include "atlas/mesh.h"
 #include "atlas/meshgenerator.h"
 #include "atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h"
-#include "atlas/output/Gmsh.h"
-#include "atlas/grid/Partitioner.h"
-#include "atlas/grid/detail/partitioner/CubedSpherePartitioner.h"
 #include "atlas/option.h"
+#include "atlas/output/Gmsh.h"
 #include "atlas/util/CoordinateEnums.h"
 #include "tests/AtlasTestEnvironment.h"
 
@@ -27,321 +27,289 @@
 namespace atlas {
 namespace test {
 
-CASE("cubedsphere_mesh_jacobian_test") {
+CASE( "cubedsphere_mesh_jacobian_test" ) {
+    using namespace meshgenerator::detail::cubedsphere;
 
-  using namespace meshgenerator::detail::cubedsphere;
+    // Set grid an N2 grid with a halo size of 1.
+    const auto grid = atlas::Grid( "CS-LFR-C-2" );
 
-  // Set grid an N2 grid with a halo size of 1.
-  const auto grid = atlas::Grid("CS-LFR-C-2");
+    // Set Jacobian
+    const auto jacobian = NeighbourJacobian( CubedSphereGrid( grid ) );
 
-  // Set Jacobian
-  const auto jacobian = NeighbourJacobian(CubedSphereGrid(grid));
+    // Set vectors of known good outputs.
+    const auto xyLocalKgoVec = std::vector<PointXY>{
+        {0, -90},   {45, -90},  {90, -90},  {-45, -45}, {135, -45}, {-45, 0},   {135, 0},   {-45, 45},  {135, 45},
+        {0, 90},    {45, 90},   {90, 90},   {90, -90},  {135, -90}, {180, -90}, {45, -45},  {225, -45}, {45, 0},
+        {225, 0},   {45, 45},   {225, 45},  {90, 90},   {135, 90},  {180, 90},  {315, -45}, {315, 0},   {315, 45},
+        {270, -90}, {270, 90},  {225, -90}, {225, 90},  {180, -90}, {180, 90},  {135, -45}, {135, 0},   {135, 45},
+        {405, -45}, {405, 0},   {405, 45},  {360, -90}, {360, 90},  {315, -90}, {315, 90},  {270, -90}, {270, 90},
+        {225, -45}, {225, 0},   {225, 45},  {0, 0},     {45, 0},    {90, 0},    {-45, 45},  {135, 45},  {-45, 90},
+        {135, 90},  {-45, 135}, {135, 135}, {0, 180},   {45, 180},  {90, 180},  {-45, -45}, {-45, -90}, {-45, -135},
+        {0, 0},     {0, -180},  {45, 0},    {45, -180}, {90, 0},    {90, -180}, {135, -45}, {135, -90}, {135, -135}};
 
-  // Set vectors of known good outputs.
-  const auto xyLocalKgoVec = std::vector<PointXY>{
-    {0,-90}, {45,-90}, {90,-90}, {-45,-45}, {135,-45}, {-45,0}, {135,0},
-    {-45,45}, {135,45}, {0,90}, {45,90}, {90,90}, {90,-90}, {135,-90},
-    {180,-90}, {45,-45}, {225,-45}, {45,0}, {225,0}, {45,45}, {225,45}, {90,90},
-    {135,90}, {180,90}, {315,-45}, {315,0}, {315,45}, {270,-90}, {270,90},
-    {225,-90}, {225,90}, {180,-90}, {180,90}, {135,-45}, {135,0}, {135,45},
-    {405,-45}, {405,0}, {405,45}, {360,-90}, {360,90}, {315,-90}, {315,90},
-    {270,-90}, {270,90}, {225,-45}, {225,0}, {225,45}, {0,0}, {45,0}, {90,0},
-    {-45,45}, {135,45}, {-45,90}, {135,90}, {-45,135}, {135,135}, {0,180},
-    {45,180}, {90,180}, {-45,-45}, {-45,-90}, {-45,-135}, {0,0}, {0,-180},
-    {45,0}, {45,-180}, {90,0}, {90,-180}, {135,-45}, {135,-90}, {135,-135}};
+    const auto xyGlobalKgoVec = std::vector<PointXY>{
+        {315, -45}, {45, -90}, {135, -45}, {315, -45}, {135, -45}, {315, 0},   {135, 0},   {0, 90},    {90, 90},
+        {0, 90},    {45, 90},  {90, 90},   {45, -45},  {45, -90},  {225, -45}, {45, -45},  {225, -45}, {45, 0},
+        {225, 0},   {45, 45},  {45, 135},  {45, 45},   {45, 90},   {45, 135},  {315, -45}, {315, 0},   {0, 90},
+        {315, -45}, {0, 90},   {45, -90},  {45, 90},   {135, -45}, {90, 90},   {135, -45}, {135, 0},   {90, 90},
+        {45, -45},  {45, 0},   {45, 45},   {45, -45},  {45, 45},   {45, -90},  {45, 90},   {225, -45}, {45, 135},
+        {225, -45}, {225, 0},  {45, 135},  {0, 0},     {45, 0},    {90, 0},    {0, 0},     {90, 0},    {315, 0},
+        {135, 0},   {270, 0},  {180, 0},   {270, 0},   {225, 0},   {180, 0},   {0, 0},     {315, 0},   {270, 0},
+        {0, 0},     {270, 0},  {45, 0},    {225, 0},   {90, 0},    {180, 0},   {90, 0},    {135, 0},   {180, 0}};
 
-  const auto xyGlobalKgoVec = std::vector<PointXY>{
-    {315,-45}, {45,-90}, {135,-45}, {315,-45}, {135,-45}, {315,0}, {135,0},
-    {0,90}, {90,90}, {0,90}, {45,90}, {90,90}, {45,-45}, {45,-90}, {225,-45},
-    {45,-45}, {225,-45}, {45,0}, {225,0}, {45,45}, {45,135}, {45,45}, {45,90},
-    {45,135}, {315,-45}, {315,0}, {0,90}, {315,-45}, {0,90}, {45,-90}, {45,90},
-    {135,-45}, {90,90}, {135,-45}, {135,0}, {90,90}, {45,-45}, {45,0}, {45,45},
-    {45,-45}, {45,45}, {45,-90}, {45,90}, {225,-45}, {45,135}, {225,-45},
-    {225,0}, {45,135}, {0,0}, {45,0}, {90,0}, {0,0}, {90,0}, {315,0}, {135,0},
-    {270,0}, {180,0}, {270,0}, {225,0}, {180,0}, {0,0}, {315,0}, {270,0}, {0,0},
-    {270,0}, {45,0}, {225,0}, {90,0}, {180,0}, {90,0}, {135,0}, {180,0}};
+    const auto ijGlobalKgoVec = std::vector<PointIJ>{
+        {0, 1}, {1, 1}, {1, 0}, {0, 1}, {1, 0}, {1, 1}, {1, 1}, {0, 1}, {2, 1}, {0, 1}, {1, 1}, {2, 1},
+        {1, 0}, {1, 1}, {0, 1}, {1, 0}, {0, 1}, {1, 1}, {1, 1}, {1, 0}, {1, 2}, {1, 0}, {1, 1}, {1, 2},
+        {0, 1}, {1, 1}, {0, 1}, {0, 1}, {0, 1}, {1, 1}, {1, 1}, {1, 0}, {2, 1}, {1, 0}, {1, 1}, {2, 1},
+        {1, 0}, {1, 1}, {1, 0}, {1, 0}, {1, 0}, {1, 1}, {1, 1}, {0, 1}, {1, 2}, {0, 1}, {1, 1}, {1, 2},
+        {0, 1}, {1, 1}, {0, 1}, {0, 1}, {0, 1}, {1, 1}, {1, 1}, {1, 2}, {1, 2}, {1, 2}, {1, 1}, {1, 2},
+        {0, 1}, {1, 1}, {1, 2}, {0, 1}, {1, 2}, {1, 1}, {1, 1}, {0, 1}, {1, 2}, {0, 1}, {1, 1}, {1, 2}};
 
-  const auto ijGlobalKgoVec = std::vector<PointIJ>{
-    {0,1}, {1,1}, {1,0}, {0,1}, {1,0}, {1,1}, {1,1}, {0,1}, {2,1}, {0,1}, {1,1},
-    {2,1}, {1,0}, {1,1}, {0,1}, {1,0}, {0,1}, {1,1}, {1,1}, {1,0}, {1,2}, {1,0},
-    {1,1}, {1,2}, {0,1}, {1,1}, {0,1}, {0,1}, {0,1}, {1,1}, {1,1}, {1,0}, {2,1},
-    {1,0}, {1,1}, {2,1}, {1,0}, {1,1}, {1,0}, {1,0}, {1,0}, {1,1}, {1,1}, {0,1},
-    {1,2}, {0,1}, {1,1}, {1,2}, {0,1}, {1,1}, {0,1}, {0,1}, {0,1}, {1,1}, {1,1},
-    {1,2}, {1,2}, {1,2}, {1,1}, {1,2}, {0,1}, {1,1}, {1,2}, {0,1}, {1,2}, {1,1},
-    {1,1}, {0,1}, {1,2}, {0,1}, {1,1}, {1,2}};
+    const auto tKgoVec = std::vector<idx_t>{3, 5, 1, 3, 1, 3, 1, 4, 4, 4, 4, 4, 0, 5, 2, 0, 2, 0, 2, 4, 4, 4, 4, 4,
+                                            3, 3, 4, 3, 4, 5, 4, 1, 4, 1, 1, 4, 0, 0, 4, 0, 4, 5, 4, 2, 4, 2, 2, 4,
+                                            0, 0, 1, 0, 1, 3, 1, 3, 2, 3, 2, 2, 0, 3, 3, 0, 3, 0, 2, 1, 2, 1, 1, 2};
 
-  const auto tKgoVec = std::vector<idx_t>{
-    3, 5, 1, 3, 1, 3, 1, 4, 4, 4, 4, 4, 0, 5, 2, 0, 2, 0, 2, 4, 4, 4, 4, 4, 3,
-    3, 4, 3, 4, 5, 4, 1, 4, 1, 1, 4, 0, 0, 4, 0, 4, 5, 4, 2, 4, 2, 2, 4, 0, 0,
-    1, 0, 1, 3, 1, 3, 2, 3, 2, 2, 0, 3, 3, 0, 3, 0, 2, 1, 2, 1, 1, 2};
-
-  // Set kgo iterators.
-  auto xyLocalKgoIt = xyLocalKgoVec.cbegin();
-  auto xyGlobalKgoIt = xyGlobalKgoVec.cbegin();
-  auto ijGlobalKgoIt = ijGlobalKgoVec.cbegin();
-  auto tKgoIt = tKgoVec.cbegin();
+    // Set kgo iterators.
+    auto xyLocalKgoIt  = xyLocalKgoVec.cbegin();
+    auto xyGlobalKgoIt = xyGlobalKgoVec.cbegin();
+    auto ijGlobalKgoIt = ijGlobalKgoVec.cbegin();
+    auto tKgoIt        = tKgoVec.cbegin();
 
 
-  // Play around with some grids.
-  for (idx_t t = 0; t < 6; ++t) {
-    for (idx_t j = - 1; j < 4; ++j) {
-      for (idx_t i = - 1; i < 4; ++i) {
+    // Play around with some grids.
+    for ( idx_t t = 0; t < 6; ++t ) {
+        for ( idx_t j = -1; j < 4; ++j ) {
+            for ( idx_t i = -1; i < 4; ++i ) {
+                // Set ij object.
+                const auto ij = PointIJ( i, j );
 
-        // Set ij object.
-        const auto ij = PointIJ(i, j);
+                // Only look at halo values.
+                if ( !jacobian.ijCross( ij ) )
+                    continue;
+                if ( jacobian.ijInterior( ij ) )
+                    continue;
 
-        // Only look at halo values.
-        if (!jacobian.ijCross(ij)) continue;
-        if (jacobian.ijInterior(ij)) continue;
+                // Get known good outputs.
+                const auto xyLocalKgo  = *xyLocalKgoIt++;
+                const auto xyGlobalKgo = *xyGlobalKgoIt++;
+                const auto ijGlobalKgo = *ijGlobalKgoIt++;
+                const auto tKgo        = *tKgoIt++;
 
-        // Get known good outputs.
-        const auto xyLocalKgo = *xyLocalKgoIt++;
-        const auto xyGlobalKgo = *xyGlobalKgoIt++;
-        const auto ijGlobalKgo = *ijGlobalKgoIt++;
-        const auto tKgo = *tKgoIt++;
+                // Test known good output.
+                const auto xyLocal   = jacobian.xy( ij, t );
+                const auto xytGlobal = jacobian.xyLocalToGlobal( xyLocal, t );
+                const auto ijtGlobal = jacobian.ijLocalToGlobal( ij, t );
 
-        // Test known good output.
-        const auto xyLocal = jacobian.xy(ij, t);
-        const auto xytGlobal = jacobian.xyLocalToGlobal(xyLocal, t);
-        const auto ijtGlobal = jacobian.ijLocalToGlobal(ij, t);
+                EXPECT( xyLocal == xyLocalKgo );
+                EXPECT( xytGlobal.first == xyGlobalKgo );
+                EXPECT( xytGlobal.second == tKgo );
+                EXPECT( ijtGlobal.first == ijGlobalKgo );
+                EXPECT( ijtGlobal.second == tKgo );
 
-        EXPECT(xyLocal == xyLocalKgo);
-        EXPECT(xytGlobal.first == xyGlobalKgo);
-        EXPECT(xytGlobal.second == tKgo);
-        EXPECT(ijtGlobal.first == ijGlobalKgo);
-        EXPECT(ijtGlobal.second == tKgo);
+                // Check xy and ij transforms are consistent.
+                EXPECT( jacobian.ij( ( jacobian.xyLocalToGlobal( xyLocal, t ) ) ) ==
+                        jacobian.ijLocalToGlobal( ij, t ).first );
 
-        // Check xy and ij transforms are consistent.
-        EXPECT(jacobian.ij((jacobian.xyLocalToGlobal(xyLocal, t))) ==
-          jacobian.ijLocalToGlobal(ij, t).first);
-
-        EXPECT(jacobian.xy((jacobian.ijLocalToGlobal(ij, t))) ==
-          jacobian.xyLocalToGlobal(xyLocal, t).first);
-
-      }
+                EXPECT( jacobian.xy( ( jacobian.ijLocalToGlobal( ij, t ) ) ) ==
+                        jacobian.xyLocalToGlobal( xyLocal, t ).first );
+            }
+        }
     }
-  }
 }
 
 
-double testFunction(double lon, double lat) {
-  return std::sin(3 * lon * M_PI / 180) * std::sin(2 * lat * M_PI / 180);
+double testFunction( double lon, double lat ) {
+    return std::sin( 3 * lon * M_PI / 180 ) * std::sin( 2 * lat * M_PI / 180 );
 }
 
 
-void testHaloExchange(const std::string& gridStr, const std::string& partitionerStr,
-                     idx_t halo, bool output = true) {
+void testHaloExchange( const std::string& gridStr, const std::string& partitionerStr, idx_t halo, bool output = true ) {
+    // Set grid.
+    const auto grid = Grid( gridStr );
 
-  // Set grid.
-  const auto grid = Grid(gridStr);
+    // Set mesh config.
+    const auto meshConfig = util::Config( "partitioner", partitionerStr ) | util::Config( "halo", halo );
 
-  // Set mesh config.
-  const auto meshConfig =
-    util::Config("partitioner", partitionerStr) |
-    util::Config("halo", halo);
+    // Set mesh generator.
+    const auto meshGen = MeshGenerator( "cubedsphere", meshConfig );
 
-  // Set mesh generator.
-  const auto meshGen = MeshGenerator("cubedsphere", meshConfig);
+    // Set mesh
+    const auto mesh = meshGen.generate( grid );
 
-  // Set mesh
-  const auto mesh = meshGen.generate(grid);
+    // Set function space.
+    const auto nodeColumns = functionspace::NodeColumns( mesh );
+    const auto cellColumns = functionspace::CellColumns( mesh );
 
-  // Set function space.
-  const auto nodeColumns = functionspace::NodeColumns(mesh);
-  const auto cellColumns = functionspace::CellColumns(mesh);
+    // ---------------------------------------------------------------------------
+    // Test node columns halo exchange.
+    // ---------------------------------------------------------------------------
 
-  // ---------------------------------------------------------------------------
-  // Test node columns halo exchange.
-  // ---------------------------------------------------------------------------
+    Log::info() << "Starting node columns test." << std::endl;
 
-  Log::info() << "Starting node columns test." << std::endl;
+    // make a test field.
+    auto testField1 = nodeColumns.createField<double>( util::Config( "name", "test field (node columns)" ) );
 
-  // make a test field.
-  auto testField1 = nodeColumns.createField<double>(util::Config("name", "test field (node columns)"));
+    // Make some field views.
+    auto testView1  = array::make_view<double, 1>( testField1 );
+    auto lonLatView = array::make_view<double, 2>( nodeColumns.lonlat() );
+    auto ghostView  = array::make_view<idx_t, 1>( nodeColumns.ghost() );
 
-  // Make some field views.
-  auto testView1 = array::make_view<double, 1>(testField1);
-  auto lonLatView = array::make_view<double, 2>(nodeColumns.lonlat());
-  auto ghostView = array::make_view<idx_t, 1>(nodeColumns.ghost());
+    // Set non-ghost values.
+    idx_t testFuncCallCount = 0;
+    for ( idx_t i = 0; i < nodeColumns.size(); ++i ) {
+        // Stop once we've reached ghost points.
+        if ( ghostView( i ) )
+            break;
 
-  // Set non-ghost values.
-  idx_t testFuncCallCount = 0;
-  for (idx_t i = 0; i < nodeColumns.size(); ++i) {
+        testView1( i ) = testFunction( lonLatView( i, LON ), lonLatView( i, LAT ) );
+        ++testFuncCallCount;
+    }
 
-    // Stop once we've reached ghost points.
-    if (ghostView(i)) break;
+    // Make sure that some of the field values were ghosts.
+    if ( halo > 0 ) {
+        EXPECT( testFuncCallCount < nodeColumns.size() );
+    }
 
-    testView1(i) = testFunction(lonLatView(i, LON), lonLatView(i, LAT));
-    ++testFuncCallCount;
+    nodeColumns.haloExchange( testField1 );
 
-  }
+    // Check all values after halo exchange.
+    double maxError = 0;
+    for ( idx_t i = 0; i < nodeColumns.size(); ++i ) {
+        const double testVal = testFunction( lonLatView( i, LON ), lonLatView( i, LAT ) );
+        maxError             = std::max( maxError, std::abs( testView1( i ) - testVal ) );
+    }
 
-  // Make sure that some of the field values were ghosts.
-  if (halo > 0) {
-    EXPECT(testFuncCallCount < nodeColumns.size());
-  }
+    mpi::comm().allReduceInPlace( maxError, eckit::mpi::Operation::Code::MAX );
+    Log::info() << "Test field max error (NodeColumns) : " << maxError << std::scientific << std::endl;
+    EXPECT( maxError < 1e-12 );
 
-  nodeColumns.haloExchange(testField1);
+    Log::info() << "Passed node columns test." << std::endl;
 
-  // Check all values after halo exchange.
-  double maxError = 0;
-  for (idx_t i = 0; i < nodeColumns.size(); ++i) {
+    // ---------------------------------------------------------------------------
+    // Test cell columns halo exchange.
+    // ---------------------------------------------------------------------------
 
-    const double testVal = testFunction(lonLatView(i, LON), lonLatView(i, LAT));
-    maxError = std::max(maxError, std::abs(testView1(i) - testVal));
+    Log::info() << "Starting cell columns test." << std::endl;
 
-  }
+    // make a test field.
+    auto testField2 = cellColumns.createField<double>( util::Config( "name", "test field (cell columns)" ) );
 
-  mpi::comm().allReduceInPlace(maxError, eckit::mpi::Operation::Code::MAX);
-  Log::info() << "Test field max error (NodeColumns) : " << maxError << std::scientific << std::endl;
-  EXPECT(maxError < 1e-12);
+    // Make some field views.
+    auto testView2 = array::make_view<double, 1>( testField2 );
+    auto haloView  = array::make_view<idx_t, 1>( cellColumns.mesh().cells().halo() );
+    lonLatView     = array::make_view<double, 2>( cellColumns.mesh().cells().field( "lonlat" ) );
 
-  Log::info() << "Passed node columns test." << std::endl;
+    // Set non-halo values.
+    testFuncCallCount = 0;
+    for ( idx_t i = 0; i < cellColumns.size(); ++i ) {
+        if ( haloView( i ) )
+            break;
 
-  // ---------------------------------------------------------------------------
-  // Test cell columns halo exchange.
-  // ---------------------------------------------------------------------------
+        testView2( i ) = testFunction( lonLatView( i, LON ), lonLatView( i, LAT ) );
+        ++testFuncCallCount;
+    }
 
-  Log::info() << "Starting cell columns test." << std::endl;
+    // Make sure that some of the field values were ghosts.
+    if ( halo > 0 ) {
+        EXPECT( testFuncCallCount < cellColumns.size() );
+    }
 
-  // make a test field.
-  auto testField2 = cellColumns.createField<double>(util::Config("name", "test field (cell columns)"));
+    cellColumns.haloExchange( testField2 );
 
-  // Make some field views.
-  auto testView2 = array::make_view<double, 1>(testField2);
-  auto haloView = array::make_view<idx_t, 1>(cellColumns.mesh().cells().halo());
-  lonLatView = array::make_view<double, 2>(cellColumns.mesh().cells().field("lonlat"));
+    // Check all values after halo exchange.
+    maxError = 0;
+    for ( idx_t i = 0; i < cellColumns.size(); ++i ) {
+        // Test field and test function should be the same.
+        const double testVal = testFunction( lonLatView( i, LON ), lonLatView( i, LAT ) );
+        maxError             = std::max( maxError, std::abs( testView2( i ) - testVal ) );
+    }
 
-  // Set non-halo values.
-  testFuncCallCount = 0;
-  for (idx_t i = 0; i < cellColumns.size(); ++i) {
+    mpi::comm().allReduceInPlace( maxError, eckit::mpi::Operation::Code::MAX );
+    Log::info() << "Test field max error (CellColumns) : " << maxError << std::scientific << std::endl;
+    EXPECT( maxError < 1e-12 );
 
-
-    if (haloView(i)) break;
-
-    testView2(i) = testFunction(lonLatView(i, LON), lonLatView(i, LAT));
-    ++testFuncCallCount;
-
-  }
-
-  // Make sure that some of the field values were ghosts.
-  if (halo > 0) {
-    EXPECT(testFuncCallCount < cellColumns.size());
-  }
-
-  cellColumns.haloExchange(testField2);
-
-  // Check all values after halo exchange.
-  maxError = 0;
-  for (idx_t i = 0; i < cellColumns.size(); ++i) {
-
-    // Test field and test function should be the same.
-    const double testVal = testFunction(lonLatView(i, LON), lonLatView(i, LAT));
-    maxError = std::max(maxError, std::abs(testView2(i) - testVal));
-
-  }
-
-  mpi::comm().allReduceInPlace(maxError, eckit::mpi::Operation::Code::MAX);
-  Log::info() << "Test field max error (CellColumns) : " << maxError << std::scientific << std::endl;
-  EXPECT(maxError < 1e-12);
-
-  Log::info() << "Passed cell columns test." << std::endl;
+    Log::info() << "Passed cell columns test." << std::endl;
 
 
-  if (output) {
+    if ( output ) {
+        // Make a field set of useful diagnostic quantities.
 
-      // Make a field set of useful diagnostic quantities.
+        auto nodeFields = atlas::FieldSet{};
+        nodeFields.add( mesh.nodes().xy() );
+        nodeFields.add( mesh.nodes().lonlat() );
+        nodeFields.add( mesh.nodes().ghost() );
+        nodeFields.add( mesh.nodes().halo() );
+        nodeFields.add( mesh.nodes().remote_index() );
+        nodeFields.add( mesh.nodes().partition() );
+        nodeFields.add( mesh.nodes().global_index() );
+        nodeFields.add( mesh.nodes().field( "ijt" ) );
+        nodeFields.add( testField1 );
 
-      auto nodeFields = atlas::FieldSet{};
-      nodeFields.add(mesh.nodes().xy());
-      nodeFields.add(mesh.nodes().lonlat());
-      nodeFields.add(mesh.nodes().ghost());
-      nodeFields.add(mesh.nodes().halo());
-      nodeFields.add(mesh.nodes().remote_index());
-      nodeFields.add(mesh.nodes().partition());
-      nodeFields.add(mesh.nodes().global_index());
-      nodeFields.add(mesh.nodes().field("ijt"));
-      nodeFields.add(testField1);
+        auto cellFields = FieldSet{};
+        cellFields.add( mesh.cells().halo() );
+        cellFields.add( mesh.cells().remote_index() );
+        cellFields.add( mesh.cells().partition() );
+        cellFields.add( mesh.cells().global_index() );
+        cellFields.add( testField2 );
 
-      auto cellFields = FieldSet{};
-      cellFields.add(mesh.cells().halo());
-      cellFields.add(mesh.cells().remote_index());
-      cellFields.add(mesh.cells().partition());
-      cellFields.add(mesh.cells().global_index());
-      cellFields.add(testField2);
+        // Set gmsh config.
+        const auto gmshConfigXy = util::Config( "coordinates", "xy" ) | util::Config( "ghost", true );
 
-      // Set gmsh config.
-      const auto gmshConfigXy =
-        util::Config("coordinates", "xy") |
-        util::Config("ghost", true);
+        const auto gmshConfigXyz = util::Config( "coordinates", "xyz" ) | util::Config( "ghost", true );
 
-      const auto gmshConfigXyz =
-        util::Config("coordinates", "xyz") |
-        util::Config("ghost", true);
+        // Set gmsh objects.
+        const auto fileStr = gridStr + "_" + partitionerStr + "_halo" + std::to_string( halo );
 
-      // Set gmsh objects.
-      const auto fileStr =
-       gridStr + "_" + partitionerStr + "_halo" + std::to_string(halo);
+        // Node columns output.
+        auto gmshXy  = output::Gmsh( fileStr + "_NC_xy.msh", gmshConfigXy );
+        auto gmshXyz = output::Gmsh( fileStr + "_NC_xyz.msh", gmshConfigXyz );
 
-      // Node columns output.
-      auto gmshXy =
-       output::Gmsh(fileStr + "_NC_xy.msh", gmshConfigXy);
-      auto gmshXyz =
-       output::Gmsh(fileStr + "_NC_xyz.msh", gmshConfigXyz);
+        gmshXy.write( mesh );
+        gmshXy.write( nodeFields, nodeColumns );
 
-      gmshXy.write(mesh);
-      gmshXy.write(nodeFields, nodeColumns);
+        gmshXyz.write( mesh );
+        gmshXyz.write( nodeFields, nodeColumns );
 
-      gmshXyz.write(mesh);
-      gmshXyz.write(nodeFields, nodeColumns);
+        // Cell columns output.
+        gmshXy  = output::Gmsh( fileStr + "_CC_xy.msh", gmshConfigXy );
+        gmshXyz = output::Gmsh( fileStr + "_CC_xyz.msh", gmshConfigXyz );
 
-      // Cell columns output.
-      gmshXy =
-       output::Gmsh(fileStr + "_CC_xy.msh", gmshConfigXy);
-      gmshXyz =
-       output::Gmsh(fileStr + "_CC_xyz.msh", gmshConfigXyz);
+        gmshXy.write( mesh );
+        gmshXy.write( cellFields, cellColumns );
 
-      gmshXy.write(mesh);
-      gmshXy.write(cellFields, cellColumns);
-
-      gmshXyz.write(mesh);
-      gmshXyz.write(cellFields, cellColumns);
-
-  }
-
+        gmshXyz.write( mesh );
+        gmshXyz.write( cellFields, cellColumns );
+    }
 }
 
-CASE("cubedsphere_mesh_test") {
+CASE( "cubedsphere_mesh_test" ) {
+    SECTION( "N12, halo = 0" ) {
+        testHaloExchange( "CS-LFR-C-12", "equal_regions", 0 );
+        testHaloExchange( "CS-LFR-C-12", "cubedsphere", 0 );
+    }
 
-  SECTION("N12, halo = 0") {
-    testHaloExchange("CS-LFR-C-12", "equal_regions", 0);
-    testHaloExchange("CS-LFR-C-12", "cubedsphere", 0);
-  }
-
-  SECTION("N12, halo = 1") {
-    testHaloExchange("CS-LFR-C-12", "equal_regions", 1);
-    testHaloExchange("CS-LFR-C-12", "cubedsphere", 1);
-  }
-  SECTION("N12, halo = 2") {
-    testHaloExchange("CS-LFR-C-12", "equal_regions", 2);
-    testHaloExchange("CS-LFR-C-12", "cubedsphere", 2);
-  }
-  SECTION("N12, halo = 3") {
-    testHaloExchange("CS-LFR-C-12", "equal_regions", 3);
-    testHaloExchange("CS-LFR-C-12", "cubedsphere", 3);
-  }
-  SECTION("Prime number mesh (N211)") {
-    testHaloExchange("CS-LFR-C-211", "equal_regions", 1, false);
-    testHaloExchange("CS-LFR-C-211", "cubedsphere", 1, false);
-  }
+    SECTION( "N12, halo = 1" ) {
+        testHaloExchange( "CS-LFR-C-12", "equal_regions", 1 );
+        testHaloExchange( "CS-LFR-C-12", "cubedsphere", 1 );
+    }
+    SECTION( "N12, halo = 2" ) {
+        testHaloExchange( "CS-LFR-C-12", "equal_regions", 2 );
+        testHaloExchange( "CS-LFR-C-12", "cubedsphere", 2 );
+    }
+    SECTION( "N12, halo = 3" ) {
+        testHaloExchange( "CS-LFR-C-12", "equal_regions", 3 );
+        testHaloExchange( "CS-LFR-C-12", "cubedsphere", 3 );
+    }
+    SECTION( "Prime number mesh (N211)" ) {
+        testHaloExchange( "CS-LFR-C-211", "equal_regions", 1, false );
+        testHaloExchange( "CS-LFR-C-211", "cubedsphere", 1, false );
+    }
 }
-
 
 
 }  // namespace test
 }  // namespace atlas
 
 int main( int argc, char** argv ) {
-  return atlas::test::run( argc, argv );
+    return atlas::test::run( argc, argv );
 }
-

--- a/src/tests/mesh/test_cubedsphere_meshgen.cc
+++ b/src/tests/mesh/test_cubedsphere_meshgen.cc
@@ -6,77 +6,342 @@
  */
 
 #include "atlas/array/MakeView.h"
-#include "atlas/field/FieldSet.h"
 #include "atlas/functionspace/NodeColumns.h"
+#include "atlas/functionspace/CellColumns.h"
+#include "atlas/field/FieldSet.h"
 #include "atlas/grid.h"
-#include "atlas/grid/Partitioner.h"
+#include "atlas/grid/CubedSphereGrid.h"
 #include "atlas/grid/Tiles.h"
-#include "atlas/grid/detail/partitioner/CubedSpherePartitioner.h"
 #include "atlas/mesh.h"
 #include "atlas/meshgenerator.h"
-#include "atlas/option.h"
+#include "atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h"
 #include "atlas/output/Gmsh.h"
+#include "atlas/grid/Partitioner.h"
+#include "atlas/grid/detail/partitioner/CubedSpherePartitioner.h"
+#include "atlas/option.h"
 #include "atlas/util/CoordinateEnums.h"
-
 #include "tests/AtlasTestEnvironment.h"
+
+#include "eckit/mpi/Operation.h"
 
 namespace atlas {
 namespace test {
 
-CASE( "cubedsphere_mesh_test" ) {
-    // Set grid.
-    const auto grid = atlas::Grid( "CS-LFR-C-16" );
+CASE("cubedsphere_mesh_jacobian_test") {
 
-    // Set mesh config.
-    auto meshConfig = util::Config( "partitioner", "equal_regions" );
+  using namespace meshgenerator::detail::cubedsphere;
 
-    // Set mesh generators.
-    const auto csMeshgen = atlas::MeshGenerator( "cubedsphere" );              // defaults to cubed sphere partitioner.
-    const auto erMeshgen = atlas::MeshGenerator( "cubedsphere", meshConfig );  // Equal regions partitioner.
+  // Set grid an N2 grid with a halo size of 1.
+  const auto grid = atlas::Grid("CS-LFR-C-2");
 
-    const auto csMesh = csMeshgen.generate( grid );
-    const auto erMesh = erMeshgen.generate( grid );
+  // Set Jacobian
+  const auto jacobian = NeighbourJacobian(CubedSphereGrid(grid));
+
+  // Set vectors of known good outputs.
+  const auto xyLocalKgoVec = std::vector<PointXY>{
+    {0,-90}, {45,-90}, {90,-90}, {-45,-45}, {135,-45}, {-45,0}, {135,0},
+    {-45,45}, {135,45}, {0,90}, {45,90}, {90,90}, {90,-90}, {135,-90},
+    {180,-90}, {45,-45}, {225,-45}, {45,0}, {225,0}, {45,45}, {225,45}, {90,90},
+    {135,90}, {180,90}, {315,-45}, {315,0}, {315,45}, {270,-90}, {270,90},
+    {225,-90}, {225,90}, {180,-90}, {180,90}, {135,-45}, {135,0}, {135,45},
+    {405,-45}, {405,0}, {405,45}, {360,-90}, {360,90}, {315,-90}, {315,90},
+    {270,-90}, {270,90}, {225,-45}, {225,0}, {225,45}, {0,0}, {45,0}, {90,0},
+    {-45,45}, {135,45}, {-45,90}, {135,90}, {-45,135}, {135,135}, {0,180},
+    {45,180}, {90,180}, {-45,-45}, {-45,-90}, {-45,-135}, {0,0}, {0,-180},
+    {45,0}, {45,-180}, {90,0}, {90,-180}, {135,-45}, {135,-90}, {135,-135}};
+
+  const auto xyGlobalKgoVec = std::vector<PointXY>{
+    {315,-45}, {45,-90}, {135,-45}, {315,-45}, {135,-45}, {315,0}, {135,0},
+    {0,90}, {90,90}, {0,90}, {45,90}, {90,90}, {45,-45}, {45,-90}, {225,-45},
+    {45,-45}, {225,-45}, {45,0}, {225,0}, {45,45}, {45,135}, {45,45}, {45,90},
+    {45,135}, {315,-45}, {315,0}, {0,90}, {315,-45}, {0,90}, {45,-90}, {45,90},
+    {135,-45}, {90,90}, {135,-45}, {135,0}, {90,90}, {45,-45}, {45,0}, {45,45},
+    {45,-45}, {45,45}, {45,-90}, {45,90}, {225,-45}, {45,135}, {225,-45},
+    {225,0}, {45,135}, {0,0}, {45,0}, {90,0}, {0,0}, {90,0}, {315,0}, {135,0},
+    {270,0}, {180,0}, {270,0}, {225,0}, {180,0}, {0,0}, {315,0}, {270,0}, {0,0},
+    {270,0}, {45,0}, {225,0}, {90,0}, {180,0}, {90,0}, {135,0}, {180,0}};
+
+  const auto ijGlobalKgoVec = std::vector<PointIJ>{
+    {0,1}, {1,1}, {1,0}, {0,1}, {1,0}, {1,1}, {1,1}, {0,1}, {2,1}, {0,1}, {1,1},
+    {2,1}, {1,0}, {1,1}, {0,1}, {1,0}, {0,1}, {1,1}, {1,1}, {1,0}, {1,2}, {1,0},
+    {1,1}, {1,2}, {0,1}, {1,1}, {0,1}, {0,1}, {0,1}, {1,1}, {1,1}, {1,0}, {2,1},
+    {1,0}, {1,1}, {2,1}, {1,0}, {1,1}, {1,0}, {1,0}, {1,0}, {1,1}, {1,1}, {0,1},
+    {1,2}, {0,1}, {1,1}, {1,2}, {0,1}, {1,1}, {0,1}, {0,1}, {0,1}, {1,1}, {1,1},
+    {1,2}, {1,2}, {1,2}, {1,1}, {1,2}, {0,1}, {1,1}, {1,2}, {0,1}, {1,2}, {1,1},
+    {1,1}, {0,1}, {1,2}, {0,1}, {1,1}, {1,2}};
+
+  const auto tKgoVec = std::vector<idx_t>{
+    3, 5, 1, 3, 1, 3, 1, 4, 4, 4, 4, 4, 0, 5, 2, 0, 2, 0, 2, 4, 4, 4, 4, 4, 3,
+    3, 4, 3, 4, 5, 4, 1, 4, 1, 1, 4, 0, 0, 4, 0, 4, 5, 4, 2, 4, 2, 2, 4, 0, 0,
+    1, 0, 1, 3, 1, 3, 2, 3, 2, 2, 0, 3, 3, 0, 3, 0, 2, 1, 2, 1, 1, 2};
+
+  // Set kgo iterators.
+  auto xyLocalKgoIt = xyLocalKgoVec.cbegin();
+  auto xyGlobalKgoIt = xyGlobalKgoVec.cbegin();
+  auto ijGlobalKgoIt = ijGlobalKgoVec.cbegin();
+  auto tKgoIt = tKgoVec.cbegin();
 
 
-    // Set gmsh config.
-    auto gmshConfigXy     = atlas::util::Config( "coordinates", "xy" );
-    auto gmshConfigXyz    = atlas::util::Config( "coordinates", "xyz" );
-    auto gmshConfigLonLat = atlas::util::Config( "coordinates", "lonlat" );
+  // Play around with some grids.
+  for (idx_t t = 0; t < 6; ++t) {
+    for (idx_t j = - 1; j < 4; ++j) {
+      for (idx_t i = - 1; i < 4; ++i) {
 
-    gmshConfigXy.set( "ghost", true );
-    gmshConfigXy.set( "info", true );
+        // Set ij object.
+        const auto ij = PointIJ(i, j);
 
-    gmshConfigXyz.set( "ghost", true );
-    gmshConfigXyz.set( "info", true );
+        // Only look at halo values.
+        if (!jacobian.ijCross(ij)) continue;
+        if (jacobian.ijInterior(ij)) continue;
 
-    gmshConfigLonLat.set( "ghost", true );
-    gmshConfigLonLat.set( "info", true );
+        // Get known good outputs.
+        const auto xyLocalKgo = *xyLocalKgoIt++;
+        const auto xyGlobalKgo = *xyGlobalKgoIt++;
+        const auto ijGlobalKgo = *ijGlobalKgoIt++;
+        const auto tKgo = *tKgoIt++;
 
-    // Set gmsh objects.
-    auto gmshXy     = atlas::output::Gmsh( "cs_xy_mesh.msh", gmshConfigXy );
-    auto gmshXyz    = atlas::output::Gmsh( "cs_xyz_mesh.msh", gmshConfigXyz );
-    auto gmshLonLat = atlas::output::Gmsh( "cs_lonlat_mesh.msh", gmshConfigLonLat );
+        // Test known good output.
+        const auto xyLocal = jacobian.xy(ij, t);
+        const auto xytGlobal = jacobian.xyLocalToGlobal(xyLocal, t);
+        const auto ijtGlobal = jacobian.ijLocalToGlobal(ij, t);
 
-    // Write gmsh.
-    gmshXy.write( csMesh );
-    gmshXyz.write( csMesh );
-    gmshLonLat.write( csMesh );
+        EXPECT(xyLocal == xyLocalKgo);
+        EXPECT(xytGlobal.first == xyGlobalKgo);
+        EXPECT(xytGlobal.second == tKgo);
+        EXPECT(ijtGlobal.first == ijGlobalKgo);
+        EXPECT(ijtGlobal.second == tKgo);
 
-    // Set gmsh objects.
-    gmshXy     = atlas::output::Gmsh( "er_xy_mesh.msh", gmshConfigXy );
-    gmshXyz    = atlas::output::Gmsh( "er_xyz_mesh.msh", gmshConfigXyz );
-    gmshLonLat = atlas::output::Gmsh( "er_lonlat_mesh.msh", gmshConfigLonLat );
+        // Check xy and ij transforms are consistent.
+        EXPECT(jacobian.ij((jacobian.xyLocalToGlobal(xyLocal, t))) ==
+          jacobian.ijLocalToGlobal(ij, t).first);
 
-    // Write gmsh.
-    gmshXy.write( erMesh );
-    gmshXyz.write( erMesh );
-    gmshLonLat.write( erMesh );
+        EXPECT(jacobian.xy((jacobian.ijLocalToGlobal(ij, t))) ==
+          jacobian.xyLocalToGlobal(xyLocal, t).first);
+
+      }
+    }
+  }
 }
+
+
+double testFunction(double lon, double lat) {
+  return std::sin(3 * lon * M_PI / 180) * std::sin(2 * lat * M_PI / 180);
+}
+
+
+void testHaloExchange(const std::string& gridStr, const std::string& partitionerStr,
+                     idx_t halo, bool output = true) {
+
+  // Set grid.
+  const auto grid = Grid(gridStr);
+
+  // Set mesh config.
+  const auto meshConfig =
+    util::Config("partitioner", partitionerStr) |
+    util::Config("halo", halo);
+
+  // Set mesh generator.
+  const auto meshGen = MeshGenerator("cubedsphere", meshConfig);
+
+  // Set mesh
+  const auto mesh = meshGen.generate(grid);
+
+  // Set function space.
+  const auto nodeColumns = functionspace::NodeColumns(mesh);
+  const auto cellColumns = functionspace::CellColumns(mesh);
+
+  // ---------------------------------------------------------------------------
+  // Test node columns halo exchange.
+  // ---------------------------------------------------------------------------
+
+  Log::info() << "Starting node columns test." << std::endl;
+
+  // make a test field.
+  auto testField1 = nodeColumns.createField<double>(util::Config("name", "test field (node columns)"));
+
+  // Make some field views.
+  auto testView1 = array::make_view<double, 1>(testField1);
+  auto lonLatView = array::make_view<double, 2>(nodeColumns.lonlat());
+  auto ghostView = array::make_view<idx_t, 1>(nodeColumns.ghost());
+
+  // Set non-ghost values.
+  idx_t testFuncCallCount = 0;
+  for (idx_t i = 0; i < nodeColumns.size(); ++i) {
+
+    // Stop once we've reached ghost points.
+    if (ghostView(i)) break;
+
+    testView1(i) = testFunction(lonLatView(i, LON), lonLatView(i, LAT));
+    ++testFuncCallCount;
+
+  }
+
+  // Make sure that some of the field values were ghosts.
+  if (halo > 0) {
+    EXPECT(testFuncCallCount < nodeColumns.size());
+  }
+
+  nodeColumns.haloExchange(testField1);
+
+  // Check all values after halo exchange.
+  double maxError = 0;
+  for (idx_t i = 0; i < nodeColumns.size(); ++i) {
+
+    const double testVal = testFunction(lonLatView(i, LON), lonLatView(i, LAT));
+    maxError = std::max(maxError, std::abs(testView1(i) - testVal));
+
+  }
+
+  mpi::comm().allReduceInPlace(maxError, eckit::mpi::Operation::Code::MAX);
+  Log::info() << "Test field max error (NodeColumns) : " << maxError << std::scientific << std::endl;
+  EXPECT(maxError < 1e-12);
+
+  Log::info() << "Passed node columns test." << std::endl;
+
+  // ---------------------------------------------------------------------------
+  // Test cell columns halo exchange.
+  // ---------------------------------------------------------------------------
+
+  Log::info() << "Starting cell columns test." << std::endl;
+
+  // make a test field.
+  auto testField2 = cellColumns.createField<double>(util::Config("name", "test field (cell columns)"));
+
+  // Make some field views.
+  auto testView2 = array::make_view<double, 1>(testField2);
+  auto haloView = array::make_view<idx_t, 1>(cellColumns.mesh().cells().halo());
+  lonLatView = array::make_view<double, 2>(cellColumns.mesh().cells().field("lonlat"));
+
+  // Set non-halo values.
+  testFuncCallCount = 0;
+  for (idx_t i = 0; i < cellColumns.size(); ++i) {
+
+
+    if (haloView(i)) break;
+
+    testView2(i) = testFunction(lonLatView(i, LON), lonLatView(i, LAT));
+    ++testFuncCallCount;
+
+  }
+
+  // Make sure that some of the field values were ghosts.
+  if (halo > 0) {
+    EXPECT(testFuncCallCount < cellColumns.size());
+  }
+
+  cellColumns.haloExchange(testField2);
+
+  // Check all values after halo exchange.
+  maxError = 0;
+  for (idx_t i = 0; i < cellColumns.size(); ++i) {
+
+    // Test field and test function should be the same.
+    const double testVal = testFunction(lonLatView(i, LON), lonLatView(i, LAT));
+    maxError = std::max(maxError, std::abs(testView2(i) - testVal));
+
+  }
+
+  mpi::comm().allReduceInPlace(maxError, eckit::mpi::Operation::Code::MAX);
+  Log::info() << "Test field max error (CellColumns) : " << maxError << std::scientific << std::endl;
+  EXPECT(maxError < 1e-12);
+
+  Log::info() << "Passed cell columns test." << std::endl;
+
+
+  if (output) {
+
+      // Make a field set of useful diagnostic quantities.
+
+      auto nodeFields = atlas::FieldSet{};
+      nodeFields.add(mesh.nodes().xy());
+      nodeFields.add(mesh.nodes().lonlat());
+      nodeFields.add(mesh.nodes().ghost());
+      nodeFields.add(mesh.nodes().halo());
+      nodeFields.add(mesh.nodes().remote_index());
+      nodeFields.add(mesh.nodes().partition());
+      nodeFields.add(mesh.nodes().global_index());
+      nodeFields.add(mesh.nodes().field("ijt"));
+      nodeFields.add(testField1);
+
+      auto cellFields = FieldSet{};
+      cellFields.add(mesh.cells().halo());
+      cellFields.add(mesh.cells().remote_index());
+      cellFields.add(mesh.cells().partition());
+      cellFields.add(mesh.cells().global_index());
+      cellFields.add(testField2);
+
+      // Set gmsh config.
+      const auto gmshConfigXy =
+        util::Config("coordinates", "xy") |
+        util::Config("ghost", true);
+
+      const auto gmshConfigXyz =
+        util::Config("coordinates", "xyz") |
+        util::Config("ghost", true);
+
+      // Set gmsh objects.
+      const auto fileStr =
+       gridStr + "_" + partitionerStr + "_halo" + std::to_string(halo);
+
+      // Node columns output.
+      auto gmshXy =
+       output::Gmsh(fileStr + "_NC_xy.msh", gmshConfigXy);
+      auto gmshXyz =
+       output::Gmsh(fileStr + "_NC_xyz.msh", gmshConfigXyz);
+
+      gmshXy.write(mesh);
+      gmshXy.write(nodeFields, nodeColumns);
+
+      gmshXyz.write(mesh);
+      gmshXyz.write(nodeFields, nodeColumns);
+
+      // Cell columns output.
+      gmshXy =
+       output::Gmsh(fileStr + "_CC_xy.msh", gmshConfigXy);
+      gmshXyz =
+       output::Gmsh(fileStr + "_CC_xyz.msh", gmshConfigXyz);
+
+      gmshXy.write(mesh);
+      gmshXy.write(cellFields, cellColumns);
+
+      gmshXyz.write(mesh);
+      gmshXyz.write(cellFields, cellColumns);
+
+  }
+
+}
+
+CASE("cubedsphere_mesh_test") {
+
+  SECTION("N12, halo = 0") {
+    testHaloExchange("CS-LFR-C-12", "equal_regions", 0);
+    testHaloExchange("CS-LFR-C-12", "cubedsphere", 0);
+  }
+
+  SECTION("N12, halo = 1") {
+    testHaloExchange("CS-LFR-C-12", "equal_regions", 1);
+    testHaloExchange("CS-LFR-C-12", "cubedsphere", 1);
+  }
+  SECTION("N12, halo = 2") {
+    testHaloExchange("CS-LFR-C-12", "equal_regions", 2);
+    testHaloExchange("CS-LFR-C-12", "cubedsphere", 2);
+  }
+  SECTION("N12, halo = 3") {
+    testHaloExchange("CS-LFR-C-12", "equal_regions", 3);
+    testHaloExchange("CS-LFR-C-12", "cubedsphere", 3);
+  }
+  SECTION("Prime number mesh (N211)") {
+    testHaloExchange("CS-LFR-C-211", "equal_regions", 1, false);
+    testHaloExchange("CS-LFR-C-211", "cubedsphere", 1, false);
+  }
+}
+
 
 
 }  // namespace test
 }  // namespace atlas
 
 int main( int argc, char** argv ) {
-    return atlas::test::run( argc, argv );
+  return atlas::test::run( argc, argv );
 }
+


### PR DESCRIPTION
### This is an updated version of [this PR](https://github.com/JCSDA-internal/atlas/pull/58), that should be mergeable with the ecmwf/develop branch. Original text is as follows:

This PR implements the multi-PE cubed-sphere mesh generator with halos.

The mesh generator internally treats the tiles of the cubed-sphere as separate overlapping meshes. Halos are added at tile boundaries and at partition boundaries on tile interiors.

In addition to the usual `mesh.cells()` and `mesh.nodes()` fields, the following the fields are added to mesh cells/nodes objects:

* **xy**. The xy positions of owned data follow the conventions give in the `Tiles` class. The xy projection of halo data is contiguous with the formal xy projection of the owned data. This should will make interpolation significantly simpler. Cells and nodes both have xy fields.

* **lonlat**. Cells receive lonlat coordinates as well as nodes.

* **ijt**. Cells and nodes have fields giving the (i, j, t) coordinates of the data. Halo (i, j, t) indices are extrapolated from the owned data, i.e. i and j can be less than zero and greater than N for tile-boundary halos. This information can be used to construct a structured `CubedSphere` function space, similar to `StructuredColumns`.


Utility classes were written for the mesh generator in `src/atlas/meshgenerator/detail/cubedsphere/CubedSphereUtility.h, CubedSphereUtility.cc`. The main class is `NeighbourJacobian`. This handles the xy and ij coordinate transforms between a tile and its four neighbours. I've put it here for the time being, but there's probably a better home for it. It's indispensable for finding the ij and xy positions of halos. I also believe it will be useful for the interpolation of vector fields.

_Fig. 1. The xy projection for an N12 cubed sphere mesh with `cubed_sphere` partitioner and `halo = 3` on 8 PEs. Some of the halos overlap in this projection and are not visible in the figure._
![allhalo3xyz](https://user-images.githubusercontent.com/20695114/130488829-eadc5302-13d5-4d3e-bc97-b200f877dacc.png)

_Fig 2. The mesh on PE 7 from Fig. 1. Note that the xy projection of the halos is contiguous with owned data projection._
![part7halo3xy](https://user-images.githubusercontent.com/20695114/130488861-7fbd802e-5c37-4ac3-8732-2e053bde559e.png)

_Fig. 3. As Fig. 2, but projected into xyz space using the lonlat coordinates. Note that "gaps" in the cross shaped halo distribution in Fig. 2 do not exist in 3D space._
![part7halo3xyz](https://user-images.githubusercontent.com/20695114/130488878-f2038cfa-6114-46a5-bf5e-384ead8dd057.png)



I've added test executable `src/tests/mesh/test_cubedsphere_meshgen.cc`

This performs two tests.
* The first test makes sure the `NeighbourJacobian` can correctly place halo points around an `N2` grid.
* The second test runs the cubed sphere mesh generator with different partitioner and halo-size configurations. It ensures that a simple test field (see below) can be written to owned nodes/cells and distributed to halo nodes cells via the Atlas halo-exchange methods.

_Fig 4. A simple test field with f(lon, lat) = sin(3 * lon) * sin(2 * lat)_
![testfield](https://user-images.githubusercontent.com/20695114/130490684-58882f25-c569-48bf-92d5-31a34b6d7457.png)

### Changes since last PR.

In addition to the above, I've refactored the code so that it uses significantly less memory than before. It still has to construct _some_  global information, but I've limited it to 24 bytes for each global node and each global cell. Further memory is allocated for local information, but this is restricted to _only_ the nodes/cells on the PE. It can build an N1280 mesh (~10^7 elements) using somewhere around 500MB per PE.

I've also improved the accuracy of the mesh generator and tested this with the horrible grid size N211 (a prime number, yuck!). The halo nodes/cells and their respective owned nodes/cells are now in the same position to a precision near machine epsilon.

Finally, I've added logic to properly number and sort the halo fields. A CellColumns and NodeColumns halo field from an N12 grid with equal_regions partitioning are shown below:

![equal_regions_cell_halo](https://user-images.githubusercontent.com/20695114/133300722-9e7e6d5d-7200-425b-9a4a-41110118150e.png)
![equal_regions_node_halo](https://user-images.githubusercontent.com/20695114/133300745-a4ee275a-26e7-47db-b2b3-baaa81ba7618.png)
