### PR TITLE
Refactor of adjoint interpolation interface.

### DIFF
--- a/src/atlas/interpolation/method/Method.cc
+++ b/src/atlas/interpolation/method/Method.cc
@@ -132,9 +132,6 @@ void Method::interpolate_field_rank3( const Field& src, Field& tgt, const Matrix
 
 template <typename Value>
 void Method::adjoint_interpolate_field_rank1( Field& src, const Field& tgt, const Matrix& W ) const {
-   // Field tmp( src.name(), src.datatype().kind(), src.shape() );
-   // tmp.set_levels( src.levels() );
-
     array::ArrayT<Value> tmp( src.shape() );
 
     auto tmp_v = array::make_view<double, 1>( tmp );
@@ -161,9 +158,6 @@ void Method::adjoint_interpolate_field_rank1( Field& src, const Field& tgt, cons
 
 template <typename Value>
 void Method::adjoint_interpolate_field_rank2( Field& src, const Field& tgt, const Matrix& W ) const {
-   // Field tmp( src.name(), src.datatype().kind(), src.shape() );
-   // tmp.set_levels( src.levels() );
-
     array::ArrayT<Value> tmp( src.shape() );
 
     auto tmp_v = array::make_view<Value, 2>( tmp );
@@ -183,9 +177,6 @@ void Method::adjoint_interpolate_field_rank2( Field& src, const Field& tgt, cons
 
 template <typename Value>
 void Method::adjoint_interpolate_field_rank3( Field& src, const Field& tgt, const Matrix& W ) const {
-   // Field tmp( src.name(), src.datatype().kind(), src.shape() );
-   // tmp.set_levels( src.levels() );
-
     array::ArrayT<Value> tmp( src.shape() );
 
     auto tmp_v = array::make_view<Value, 3>( tmp );

--- a/src/atlas/interpolation/method/Method.cc
+++ b/src/atlas/interpolation/method/Method.cc
@@ -131,17 +131,17 @@ void Method::interpolate_field_rank3( const Field& src, Field& tgt, const Matrix
 }
 
 template <typename Value>
-void Method::adjoint_interpolate_field_rank1( Field& src, Field& tgt, const Matrix& W ) const {
-    Field tmp( src.name(), src.datatype().kind(), src.shape() );
-    tmp.set_levels( src.levels() );
+void Method::adjoint_interpolate_field_rank1( Field& src, const Field& tgt, const Matrix& W ) const {
+   // Field tmp( src.name(), src.datatype().kind(), src.shape() );
+   // tmp.set_levels( src.levels() );
+
+    array::ArrayT<Value> tmp( src.shape() );
 
     auto tmp_v = array::make_view<double, 1>( tmp );
     auto src_v = array::make_view<double, 1>( src );
     auto tgt_v = array::make_view<double, 1>( tgt );
 
-    for ( idx_t t = 0; t < tmp.shape( 0 ); ++t ) {
-        tmp_v( t ) = 0.;
-    }
+    tmp_v.assign(0.);
 
     if ( use_eckit_linalg_spmv_ ) {
         if ( src.datatype() != array::make_datatype<double>() ) {
@@ -156,51 +156,43 @@ void Method::adjoint_interpolate_field_rank1( Field& src, Field& tgt, const Matr
 
     for ( idx_t t = 0; t < tmp.shape( 0 ); ++t ) {
         src_v( t ) += tmp_v( t );
-        tgt_v( t ) = 0.;
     }
 }
 
 template <typename Value>
-void Method::adjoint_interpolate_field_rank2( Field& src, Field& tgt, const Matrix& W ) const {
-    Field tmp( src.name(), src.datatype().kind(), src.shape() );
-    tmp.set_levels( src.levels() );
+void Method::adjoint_interpolate_field_rank2( Field& src, const Field& tgt, const Matrix& W ) const {
+   // Field tmp( src.name(), src.datatype().kind(), src.shape() );
+   // tmp.set_levels( src.levels() );
+
+    array::ArrayT<Value> tmp( src.shape() );
 
     auto tmp_v = array::make_view<Value, 2>( tmp );
     auto src_v = array::make_view<Value, 2>( src );
     auto tgt_v = array::make_view<Value, 2>( tgt );
 
-    for ( idx_t t = 0; t < tmp.shape( 0 ); ++t ) {
-        for ( idx_t k = 0; k < tmp.shape( 1 ); ++k ) {
-            tmp_v( t, k ) = 0.;
-        }
-    }
+    tmp_v.assign(0.);
 
     sparse_matrix_multiply( W, tgt_v, tmp_v, sparse::backend::omp() );
 
     for ( idx_t t = 0; t < tmp.shape( 0 ); ++t ) {
         for ( idx_t k = 0; k < tmp.shape( 1 ); ++k ) {
             src_v( t, k ) += tmp_v( t, k );
-            tgt_v( t, k ) = 0.;
         }
     }
 }
 
 template <typename Value>
-void Method::adjoint_interpolate_field_rank3( Field& src, Field& tgt, const Matrix& W ) const {
-    Field tmp( src.name(), src.datatype().kind(), src.shape() );
-    tmp.set_levels( src.levels() );
+void Method::adjoint_interpolate_field_rank3( Field& src, const Field& tgt, const Matrix& W ) const {
+   // Field tmp( src.name(), src.datatype().kind(), src.shape() );
+   // tmp.set_levels( src.levels() );
+
+    array::ArrayT<Value> tmp( src.shape() );
 
     auto tmp_v = array::make_view<Value, 3>( tmp );
     auto src_v = array::make_view<Value, 3>( src );
     auto tgt_v = array::make_view<Value, 3>( tgt );
 
-    for ( idx_t t = 0; t < tmp.shape( 0 ); ++t ) {
-        for ( idx_t j = 0; j < tmp.shape( 1 ); ++j ) {
-            for ( idx_t k = 0; k < tmp.shape( 2 ); ++k ) {
-                tmp_v( t, j, k ) = 0.;
-            }
-        }
-    }
+    tmp_v.assign(0.);
 
     sparse_matrix_multiply( W, tgt_v, tmp_v, sparse::backend::omp() );
 
@@ -208,7 +200,6 @@ void Method::adjoint_interpolate_field_rank3( Field& src, Field& tgt, const Matr
         for ( idx_t j = 0; j < tmp.shape( 1 ); ++j ) {
             for ( idx_t k = 0; k < tmp.shape( 2 ); ++k ) {
                 src_v( t, j, k ) += tmp_v( t, j, k );
-                tgt_v( t, j, k ) = 0.;
             }
         }
     }
@@ -244,7 +235,7 @@ void Method::interpolate_field( const Field& src, Field& tgt, const Matrix& W ) 
 }
 
 template <typename Value>
-void Method::adjoint_interpolate_field( Field& src, Field& tgt, const Matrix& W ) const {
+void Method::adjoint_interpolate_field( Field& src, const Field& tgt, const Matrix& W ) const {
     check_compatibility( tgt, src, W );
 
     if ( src.rank() == 1 ) {
@@ -321,12 +312,12 @@ void Method::execute( const Field& source, Field& target ) const {
     this->do_execute( source, target );
 }
 
-void Method::execute_adjoint( FieldSet& source, FieldSet& target ) const {
+void Method::execute_adjoint( FieldSet& source, const FieldSet& target ) const {
     ATLAS_TRACE( "atlas::interpolation::method::Method::execute(FieldSet, FieldSet)" );
     this->do_execute_adjoint( source, target );
 }
 
-void Method::execute_adjoint( Field& source, Field& target ) const {
+void Method::execute_adjoint( Field& source, const Field& target ) const {
     ATLAS_TRACE( "atlas::interpolation::method::Method::execute(Field, Field)" );
     this->do_execute_adjoint( source, target );
 }
@@ -395,7 +386,7 @@ void Method::do_execute( const Field& src, Field& tgt ) const {
     tgt.set_dirty();
 }
 
-void Method::do_execute_adjoint( FieldSet& fieldsSource, FieldSet& fieldsTarget ) const {
+void Method::do_execute_adjoint( FieldSet& fieldsSource, const FieldSet& fieldsTarget ) const {
     ATLAS_TRACE( "atlas::interpolation::method::Method::do_execute_adjoint()" );
 
     const idx_t N = fieldsSource.size();
@@ -406,7 +397,7 @@ void Method::do_execute_adjoint( FieldSet& fieldsSource, FieldSet& fieldsTarget 
     }
 }
 
-void Method::do_execute_adjoint( Field& src, Field& tgt ) const {
+void Method::do_execute_adjoint( Field& src, const Field& tgt ) const {
     ATLAS_TRACE( "atlas::interpolation::method::Method::do_execute_adjoint()" );
 
     if ( nonLinear_( src ) ) {

--- a/src/atlas/interpolation/method/Method.h
+++ b/src/atlas/interpolation/method/Method.h
@@ -57,8 +57,17 @@ public:
     void execute( const FieldSet& source, FieldSet& target ) const;
     void execute( const Field& source, Field& target ) const;
 
-    void execute_adjoint( FieldSet& source, FieldSet& target ) const;
-    void execute_adjoint( Field& source, Field& target ) const;
+    /**
+     * @brief execute_adjoint
+     * @param source - it is either a FieldSet or a Field
+     * @param target - it is either a FieldSet or a Field
+     *                 Note that formally in an adjoint operation of this
+     *                 type we should be setting the values in the target
+     *                 to zero. This is not done for efficiency reasons and
+     *                 because in most cases it is not necessary.
+     */
+    void execute_adjoint( FieldSet& source, const FieldSet& target ) const;
+    void execute_adjoint( Field& source, const Field& target ) const;
 
     virtual void print( std::ostream& ) const = 0;
 
@@ -71,8 +80,8 @@ protected:
     virtual void do_execute( const FieldSet& source, FieldSet& target ) const;
     virtual void do_execute( const Field& source, Field& target ) const;
 
-    virtual void do_execute_adjoint( FieldSet& source, FieldSet& target ) const;
-    virtual void do_execute_adjoint( Field& source, Field& target ) const;
+    virtual void do_execute_adjoint( FieldSet& source, const FieldSet& target ) const;
+    virtual void do_execute_adjoint( Field& source, const Field& target ) const;
 
     using Triplet  = eckit::linalg::Triplet;
     using Triplets = std::vector<Triplet>;
@@ -120,16 +129,16 @@ private:
     void interpolate_field_rank3( const Field& src, Field& tgt, const Matrix& ) const;
 
     template <typename Value>
-    void adjoint_interpolate_field( Field& src, Field& tgt, const Matrix& ) const;
+    void adjoint_interpolate_field( Field& src, const Field& tgt, const Matrix& ) const;
 
     template <typename Value>
-    void adjoint_interpolate_field_rank1( Field& src, Field& tgt, const Matrix& ) const;
+    void adjoint_interpolate_field_rank1( Field& src, const Field& tgt, const Matrix& ) const;
 
     template <typename Value>
-    void adjoint_interpolate_field_rank2( Field& src, Field& tgt, const Matrix& ) const;
+    void adjoint_interpolate_field_rank2( Field& src, const Field& tgt, const Matrix& ) const;
 
     template <typename Value>
-    void adjoint_interpolate_field_rank3( Field& src, Field& tgt, const Matrix& ) const;
+    void adjoint_interpolate_field_rank3( Field& src, const Field& tgt, const Matrix& ) const;
 
     void check_compatibility( const Field& src, const Field& tgt, const Matrix& W ) const;
 };

--- a/src/tests/interpolation/test_interpolation_structured2D.cc
+++ b/src/tests/interpolation/test_interpolation_structured2D.cc
@@ -280,9 +280,9 @@ struct AdjointTolerance {
     static const Value value;
 };
 template <>
-const double AdjointTolerance<double>::value = 1.e-8;
+const double AdjointTolerance<double>::value = 2.e-14;
 template <>
-const float AdjointTolerance<float>::value = 3.e-1;
+const float AdjointTolerance<float>::value = 4.e-6;
 
 
 template <typename Value>
@@ -389,9 +389,11 @@ void test_interpolation_structured_using_fs_API_for_fieldset() {
 
         for ( std::size_t t = 0; t < AxAx.size(); ++t ) {
             Log::debug() << " Adjoint test t  = " << t << " (Ax).(Ax) = " << AxAx[t] << " x.(AtAx) = " << xAtAx[t]
-                         << std::endl;
+                      << " std::abs( 1.0 - xAtAx[t]/AxAx[t] ) " << std::abs( 1.0 - xAtAx[t]/AxAx[t] )
+                      << " AdjointTolerance<Value>::value " << AdjointTolerance<Value>::value
+                      << std::endl;
 
-            EXPECT_APPROX_EQ( AxAx[t], xAtAx[t], AdjointTolerance<Value>::value );
+            EXPECT( std::abs( 1.0 - xAtAx[t]/AxAx[t] ) < AdjointTolerance<Value>::value );
         }
     }
 


### PR DESCRIPTION
Changes are as follows:
1) setting target to const in the adjoint 
2) using ArrayT for the temporary array
3) using .assign(0.) to fill array
4) setting tolerances in tests to have a relative error