### PR TITLE
feature: Add maxFractionElemsToTry option

### DIFF
--- a/src/atlas/interpolation/method/fe/FiniteElement.cc
+++ b/src/atlas/interpolation/method/fe/FiniteElement.cc
@@ -132,11 +132,9 @@ struct Stencil {
 void FiniteElement::print(std::ostream& out) const {
     functionspace::NodeColumns src(source_);
     functionspace::NodeColumns tgt(target_);
-    if ( mpi::rank() == 0 ) {
-        out << "atlas::interpolation::method::FiniteElement" << std::endl;
-        out << "maxFractionElemsToTry_: " << maxFractionElemsToTry_;
-        out << " treat_failure_as_missing_value_: " << treat_failure_as_missing_value_ << std::endl;
-    }
+    out << "atlas::interpolation::method::FiniteElement" << std::endl;
+    out << "maxFractionElemsToTry_: " << maxFractionElemsToTry_;
+    out << " treat_failure_as_missing_value_: " << treat_failure_as_missing_value_ << std::endl;
     if ( not tgt ) {
         return;
     }
@@ -181,22 +179,20 @@ void FiniteElement::print(std::ostream& out) const {
     tgt.gather().gather(stencil_points_loc, stencil_points_glb);
     tgt.gather().gather(stencil_weights_loc, stencil_weights_glb);
 
-    if (mpi::rank() == 0) {
-        int precision = std::numeric_limits<double>::max_digits10;
-        for (idx_t i = 0; i < global_size; ++i) {
-            out << std::setw(10) << i + 1 << " : ";
-            for (idx_t j = 0; j < stencil_size_glb(i); ++j) {
-                out << std::setw(10) << stencil_points_glb(i, j);
-            }
-            for (idx_t j = stencil_size_glb(i); j < Stencil::max_stencil_size; ++j) {
-                out << "          ";
-            }
-            for (idx_t j = 0; j < stencil_size_glb(i); ++j) {
-                out << std::setw(precision + 5) << std::left << std::setprecision(precision)
-                    << stencil_weights_glb(i, j);
-            }
-            out << std::endl;
+    int precision = std::numeric_limits<double>::max_digits10;
+    for (idx_t i = 0; i < global_size; ++i) {
+        out << std::setw(10) << i + 1 << " : ";
+        for (idx_t j = 0; j < stencil_size_glb(i); ++j) {
+            out << std::setw(10) << stencil_points_glb(i, j);
         }
+        for (idx_t j = stencil_size_glb(i); j < Stencil::max_stencil_size; ++j) {
+            out << "          ";
+        }
+        for (idx_t j = 0; j < stencil_size_glb(i); ++j) {
+            out << std::setw(precision + 5) << std::left << std::setprecision(precision)
+                << stencil_weights_glb(i, j);
+        }
+        out << std::endl;
     }
 }
 

--- a/src/atlas/interpolation/method/fe/FiniteElement.h
+++ b/src/atlas/interpolation/method/fe/FiniteElement.h
@@ -28,7 +28,9 @@ namespace method {
 
 class FiniteElement : public Method {
 public:
-    FiniteElement(const Config& config): Method(config) {}
+    FiniteElement(const Config& config): Method(config) {
+        if (config.has("maxFractionElemsToTry") ) { config.get("maxFractionElemsToTry", maxFractionElemsToTry_); }
+    }
 
     virtual ~FiniteElement() override {}
 
@@ -79,6 +81,7 @@ protected:
     FunctionSpace target_;
 
     bool treat_failure_as_missing_value_{true};
+    double maxFractionElemsToTry_{0.2};
 };
 
 }  // namespace method

--- a/src/atlas/interpolation/method/fe/FiniteElement.h
+++ b/src/atlas/interpolation/method/fe/FiniteElement.h
@@ -29,7 +29,7 @@ namespace method {
 class FiniteElement : public Method {
 public:
     FiniteElement(const Config& config): Method(config) {
-        if (config.has("maxFractionElemsToTry") ) { config.get("max_fraction_elems_to_try", maxFractionElemsToTry_); }
+        if (config.has("max_fraction_elems_to_try") ) { config.get("max_fraction_elems_to_try", maxFractionElemsToTry_); }
     }
 
     virtual ~FiniteElement() override {}

--- a/src/atlas/interpolation/method/fe/FiniteElement.h
+++ b/src/atlas/interpolation/method/fe/FiniteElement.h
@@ -29,7 +29,7 @@ namespace method {
 class FiniteElement : public Method {
 public:
     FiniteElement(const Config& config): Method(config) {
-        if (config.has("maxFractionElemsToTry") ) { config.get("maxFractionElemsToTry", maxFractionElemsToTry_); }
+        if (config.has("maxFractionElemsToTry") ) { config.get("max_fraction_elems_to_try", maxFractionElemsToTry_); }
     }
 
     virtual ~FiniteElement() override {}

--- a/src/atlas/interpolation/method/fe/FiniteElement.h
+++ b/src/atlas/interpolation/method/fe/FiniteElement.h
@@ -29,7 +29,7 @@ namespace method {
 class FiniteElement : public Method {
 public:
     FiniteElement(const Config& config): Method(config) {
-        if (config.has("max_fraction_elems_to_try") ) { config.get("max_fraction_elems_to_try", maxFractionElemsToTry_); }
+        config.get("max_fraction_elems_to_try", maxFractionElemsToTry_);
     }
 
     virtual ~FiniteElement() override {}

--- a/src/tests/interpolation/test_interpolation_finite_element.cc
+++ b/src/tests/interpolation/test_interpolation_finite_element.cc
@@ -43,28 +43,38 @@ CASE("test_interpolation_finite_element") {
 
     auto func = [](double x) -> double { return std::sin(x * M_PI / 180.); };
 
-    Interpolation interpolation(option::type("finite-element"), fs, pointcloud);
+    util::Config config = util::Config("type", "finite-element").set("maxFractionElemsToTry", 0.4);
+    Interpolation interpolation(config, fs, pointcloud);
 
-    Field field_source = fs.createField<double>(option::name("source"));
-    Field field_target("target", array::make_datatype<double>(), array::make_shape(pointcloud.size()));
-
-    auto lonlat = array::make_view<double, 2>(fs.nodes().lonlat());
-    auto source = array::make_view<double, 1>(field_source);
-    for (idx_t j = 0; j < fs.nodes().size(); ++j) {
-        source(j) = func(lonlat(j, LON));
+    SECTION("test maximum nearest neighbour settings") {
+        std::stringstream test_stream;
+        interpolation.print(test_stream);
+        std::string test_string = test_stream.str();
+        EXPECT((test_string.find("maxFractionElemsToTry_: 0.4") != std::string::npos));
     }
 
-    interpolation.execute(field_source, field_target);
+    SECTION("test interpolation outputs") {
+        Field field_source = fs.createField<double>(option::name("source"));
+        Field field_target("target", array::make_datatype<double>(), array::make_shape(pointcloud.size()));
 
-    auto target = array::make_view<double, 1>(field_target);
+        auto lonlat = array::make_view<double, 2>(fs.nodes().lonlat());
+        auto source = array::make_view<double, 1>(field_source);
+        for (idx_t j = 0; j < fs.nodes().size(); ++j) {
+            source(j) = func(lonlat(j, LON));
+        }
 
-    auto check = std::vector<double>{func(00.), func(10.), func(20.), func(30.), func(40.),
-                                     func(50.), func(60.), func(70.), func(80.), func(90.)};
+        interpolation.execute(field_source, field_target);
 
-    for (idx_t j = 0; j < pointcloud.size(); ++j) {
-        static double interpolation_tolerance = 1.e-4;
-        Log::info() << target(j) << "  " << check[j] << std::endl;
-        EXPECT(eckit::types::is_approximately_equal(target(j), check[j], interpolation_tolerance));
+        auto target = array::make_view<double, 1>(field_target);
+
+        auto check = std::vector<double>{func(00.), func(10.), func(20.), func(30.), func(40.),
+                                         func(50.), func(60.), func(70.), func(80.), func(90.)};
+
+        for (idx_t j = 0; j < pointcloud.size(); ++j) {
+            static double interpolation_tolerance = 1.e-4;
+            Log::info() << target(j) << "  " << check[j] << std::endl;
+            EXPECT(eckit::types::is_approximately_equal(target(j), check[j], interpolation_tolerance));
+        }
     }
 }
 

--- a/src/tests/interpolation/test_interpolation_finite_element.cc
+++ b/src/tests/interpolation/test_interpolation_finite_element.cc
@@ -43,8 +43,7 @@ CASE("test_interpolation_finite_element") {
 
     auto func = [](double x) -> double { return std::sin(x * M_PI / 180.); };
 
-    util::Config config = util::Config("type", "finite-element").set("max_fraction_elems_to_try", 0.4);
-    Interpolation interpolation(config, fs, pointcloud);
+    Interpolation interpolation(option::type("finite-element")|util.Config("max_fraction_elems_to_try", 0.4), fs, pointcloud);
 
     SECTION("test maximum nearest neighbour settings") {
         std::stringstream test_stream;

--- a/src/tests/interpolation/test_interpolation_finite_element.cc
+++ b/src/tests/interpolation/test_interpolation_finite_element.cc
@@ -43,7 +43,7 @@ CASE("test_interpolation_finite_element") {
 
     auto func = [](double x) -> double { return std::sin(x * M_PI / 180.); };
 
-    Interpolation interpolation(option::type("finite-element")|util.Config("max_fraction_elems_to_try", 0.4), fs, pointcloud);
+    Interpolation interpolation(option::type("finite-element")|util::Config("max_fraction_elems_to_try", 0.4), fs, pointcloud);
 
     SECTION("test maximum nearest neighbour settings") {
         std::stringstream test_stream;

--- a/src/tests/interpolation/test_interpolation_finite_element.cc
+++ b/src/tests/interpolation/test_interpolation_finite_element.cc
@@ -43,7 +43,7 @@ CASE("test_interpolation_finite_element") {
 
     auto func = [](double x) -> double { return std::sin(x * M_PI / 180.); };
 
-    util::Config config = util::Config("type", "finite-element").set("maxFractionElemsToTry", 0.4);
+    util::Config config = util::Config("type", "finite-element").set("max_fraction_elems_to_try", 0.4);
     Interpolation interpolation(config, fs, pointcloud);
 
     SECTION("test maximum nearest neighbour settings") {


### PR DESCRIPTION
## Summary of changes

* Make maxFractionElemsToTry an option read from the configuration of an interpolation method
* Add the option to the print of the interpolator
* Add a test for the interpolator print function

I have tested this functionality by searching the print output. This is perhaps not so good as I don't actually test the behaviour of `maxFractionElemsToTry`, however I noticed in the code coverage that there was no coverage of the print function, so this should slightly improve things!

I might also open another small PR in the future to add a test for `NodeColumns` to `NodeColumns` finite-element interpolation if that is OK. 

This is my first attempt at a PR in atlas, and I am not very clear on the use of `atlas::util::option` vs `atlas::util::config`, so please let me know if this needs to be improved.

## Issues

Fixes issue #83 