### PR TITLE
Added multiplication methods to `projection::Jacobian`.

### DIFF
--- a/src/atlas/library/config.h
+++ b/src/atlas/library/config.h
@@ -46,7 +46,9 @@ using idx_t  = long;
 /// Integer type for unique indices
 typedef gidx_t uidx_t;
 
-#if ATLAS_ECKIT_VERSION_INT >= 11900  // eckit >= 1.19
+#define ATLAS_ECKIT_VERSION_AT_LEAST(x, y, z) (ATLAS_ECKIT_VERSION_INT >= x * 10000 + y * 100 + z)
+
+#if ATLAS_ECKIT_VERSION_AT_LEAST(1, 19, 0)
 #define ATLAS_ECKIT_HAVE_ECKIT_585 1
 #else
 #define ATLAS_ECKIT_HAVE_ECKIT_585 0

--- a/src/atlas/util/PolygonXY.cc
+++ b/src/atlas/util/PolygonXY.cc
@@ -101,9 +101,10 @@ bool PolygonXY::contains(const Point2& P) const {
         return dx * dx + dy * dy;
     };
 
+    constexpr double eps = 1.e-10;
     // check first bounding box
-    if (coordinatesMax_.y() < P.y() || P.y() < coordinatesMin_.y() || coordinatesMax_.x() < P.x() ||
-        P.x() < coordinatesMin_.x()) {
+    if (coordinatesMax_.y() + eps < P.y() || P.y() < coordinatesMin_.y() - eps || coordinatesMax_.x() + eps < P.x() ||
+        P.x() < coordinatesMin_.x() - eps) {
         return false;
     }
 
@@ -137,6 +138,10 @@ bool PolygonXY::contains(const Point2& P) const {
 
         if (APB != BPA) {
             const double side = cross_product_analog(P, A, B);
+            bool on_edge      = std::abs(side) < eps;
+            if (on_edge) {
+                return true;
+            }
             if (APB && side > 0) {
                 ++wn;
             }

--- a/src/atlas/util/detail/KDTree.h
+++ b/src/atlas/util/detail/KDTree.h
@@ -309,7 +309,7 @@ public:
     }
 
     idx_t size() const override {
-#if ATLAS_ECKIT_VERSION_INT >= 11302  // v1.13.2
+#if ATLAS_ECKIT_VERSION_AT_LEAST(1, 13, 2)
         return static_cast<idx_t>(tree_->size());
 #else
         // Assume ECKIT-515 not implemented.

--- a/src/tests/projection/test_jacobian.cc
+++ b/src/tests/projection/test_jacobian.cc
@@ -163,6 +163,61 @@ CASE("test_lonlat") {
     doTaylorTest(StructuredGrid("N16"), 1e-9);
 }
 
+CASE("test_constructors") {
+    Projection::Jacobian a = {};
+    Projection::Jacobian b = {1., 2., 3., 4.};
+    Projection::Jacobian c = {{5., 6.}, {7., 8.}};
+
+    Log::info() << "a =" << std::endl;
+    Log::info() << a << std::endl;
+    Log::info() << "b =" << std::endl;
+    Log::info() << b << std::endl;
+    Log::info() << "c =" << std::endl;
+    Log::info() << c << std::endl;
+
+    EXPECT_EQ(a[0][0], 0.);
+    EXPECT_EQ(a[0][1], 0.);
+    EXPECT_EQ(a[1][0], 0.);
+    EXPECT_EQ(a[1][1], 0.);
+
+    EXPECT_EQ(b[0][0], 1.);
+    EXPECT_EQ(b[0][1], 2.);
+    EXPECT_EQ(b[1][0], 3.);
+    EXPECT_EQ(b[1][1], 4.);
+
+    EXPECT_EQ(c[0][0], 5.);
+    EXPECT_EQ(c[0][1], 6.);
+    EXPECT_EQ(c[1][0], 7.);
+    EXPECT_EQ(c[1][1], 8.);
+}
+
+CASE("test_multiplication") {
+    const Projection::Jacobian A = {{0., -1.}, {1., 0.}};
+    const Point2 x               = {2., 1.};
+
+    const auto Ax      = A * x;
+    const auto AinvAx  = A.inverse() * Ax;
+    const auto Atimes2 = A * 2.;
+
+    Log::info() << "A =" << std::endl;
+    Log::info() << A << std::endl;
+    Log::info() << "2A =" << std::endl;
+    Log::info() << Atimes2 << std::endl;
+    Log::info() << "x =" << std::endl;
+    Log::info() << x << std::endl;
+    Log::info() << "Ax =" << std::endl;
+    Log::info() << Ax << std::endl;
+    Log::info() << "A^-1 Ax =" << std::endl;
+    Log::info() << AinvAx << std::endl;
+
+    EXPECT_EQ(Atimes2[0][0], 0.);
+    EXPECT_EQ(Atimes2[0][1], -2.);
+    EXPECT_EQ(Atimes2[1][0], 2.);
+    EXPECT_EQ(Atimes2[1][1], 0.);
+    EXPECT_EQ(Ax, Point2(-1., 2.));
+    EXPECT_EQ(AinvAx, x);
+}
+
 
 //-----------------------------------------------------------------------------
 

--- a/src/tests/util/test_kdtree.cc
+++ b/src/tests/util/test_kdtree.cc
@@ -153,7 +153,7 @@ static const IndexKDTree& search() {
 }  // namespace
 //------------------------------------------------------------------------------------------------
 
-static bool ECKIT_515_implemented = (ATLAS_ECKIT_VERSION_INT >= 11302);  // version 1.13.2
+static bool ECKIT_515_implemented = ATLAS_ECKIT_VERSION_AT_LEAST(1, 13, 2);
 // --> implements eckit::KDTree::size() and eckit::KDTree::empty()
 
 CASE("test kdtree") {


### PR DESCRIPTION
As discussed offline, I've added matrix-vector and matrix-scalar multiplication methods to `projection::Jacobian`. I've also added some constructors (there were none) and an output insertion operator. I've refactored the code to make it more compact wherever I could.