### PR TITLE
Remove rank 3 restriction of redistribution class.

### DIFF
--- a/src/atlas/redistribution/detail/RedistributeGeneric.cc
+++ b/src/atlas/redistribution/detail/RedistributeGeneric.cc
@@ -215,35 +215,42 @@ std::pair<std::vector<idx_t>, std::vector<int>> getUidIntersection(const std::ve
 // Iterate over a field, in the order of an index list, and apply a functor to
 // each element.
 
-// Rank 1 overload.
-template <typename Value, typename Functor>
-void iterateField(const std::vector<idx_t>& idxList, array::ArrayView<Value, 1>& fieldView, const Functor& f) {
-    for (const idx_t i : idxList) {
-        f(fieldView(i));
-    }
-}
-
-// Rank 2 overload.
-template <typename Value, typename Functor>
-void iterateField(const std::vector<idx_t>& idxList, array::ArrayView<Value, 2>& fieldView, const Functor f) {
-    for (const idx_t i : idxList) {
-        for (idx_t j = 0; j < fieldView.shape(1); ++j) {
-            f(fieldView(i, j));
+// Recursive ForEach to visit all elements of field.
+template <int Rank, int Dim = 0>
+struct ForEach {
+    template <typename Value, typename Functor, typename... Idxs>
+    static void apply(const std::vector<idx_t>& idxList, array::ArrayView<Value, Rank>& fieldView,
+                      const Functor& f, Idxs... idxs) {
+        // Iterate over dimension Dim of array.
+        for (idx_t idx = 0; idx < fieldView.shape(Dim); ++idx) {
+            ForEach<Rank, Dim + 1>::apply(idxList, fieldView, f, idxs..., idx);
         }
     }
-}
+};
 
-// Rank 3 overload.
-template <typename Value, typename Functor>
-void iterateField(const std::vector<idx_t>& idxList, array::ArrayView<Value, 3>& fieldView, const Functor f) {
-    for (const idx_t i : idxList) {
-        for (idx_t j = 0; j < fieldView.shape(1); ++j) {
-            for (idx_t k = 0; k < fieldView.shape(2); ++k) {
-                f(fieldView(i, j, k));
-            }
+// Beginning of recursion when Dim == 0.
+template <int Rank>
+struct ForEach<Rank, 0> {
+    template <typename Value, typename Functor, typename... Idxs>
+    static void apply(const std::vector<idx_t>& idxList, array::ArrayView<Value, Rank>& fieldView,
+                      const Functor& f, Idxs... idxs) {
+        // Iterate over dimension 0 of array in order defined by idxList.
+        for (idx_t idx : idxList) {
+            ForEach<Rank, 1>::apply(idxList, fieldView, f, idxs..., idx);
         }
     }
-}
+};
+
+// End of recursion when Dim == Rank.
+template <int Rank>
+struct ForEach<Rank, Rank> {
+    template <typename Value, typename Functor, typename... Idxs>
+    static void apply(const std::vector<idx_t>& idxList, array::ArrayView<Value, Rank>& fieldView,
+                      const Functor& f, Idxs... idxs) {
+        // Apply functor.
+        f(fieldView(idxs...));
+    }
+};
 
 }  // namespace
 
@@ -297,25 +304,23 @@ void RedistributeGeneric::execute(const FieldSet& sourceFieldSet, FieldSet& targ
 
 // Determine datatype.
 void RedistributeGeneric::do_execute(const Field& sourceField, Field& targetField) const {
+
+    // Available datatypes defined in array/LocalView.cc
     switch (sourceField.datatype().kind()) {
         case array::DataType::KIND_REAL64: {
-            do_execute<double>(sourceField, targetField);
-            break;
+            return do_execute<double>(sourceField, targetField);
         }
         case array::DataType::KIND_REAL32: {
-            do_execute<float>(sourceField, targetField);
-            break;
+            return do_execute<float>(sourceField, targetField);
         }
         case array::DataType::KIND_INT64: {
-            do_execute<long>(sourceField, targetField);
-            break;
+            return do_execute<long>(sourceField, targetField);
         }
         case array::DataType::KIND_INT32: {
-            do_execute<int>(sourceField, targetField);
-            break;
+            return do_execute<int>(sourceField, targetField);
         }
         default: {
-            throw_NotImplemented("No implementation for data type " + sourceField.datatype().str(), Here());
+            ATLAS_THROW_EXCEPTION("No implementation for data type " + sourceField.datatype().str());
         }
     }
 }
@@ -323,21 +328,20 @@ void RedistributeGeneric::do_execute(const Field& sourceField, Field& targetFiel
 // Determine rank.
 template <typename Value>
 void RedistributeGeneric::do_execute(const Field& sourceField, Field& targetField) const {
+
+    // Available ranks defined in array/LocalView.cc
     switch (sourceField.rank()) {
-        case 1: {
-            do_execute<Value, 1>(sourceField, targetField);
-            break;
-        }
-        case 2: {
-            do_execute<Value, 2>(sourceField, targetField);
-            break;
-        }
-        case 3: {
-            do_execute<Value, 3>(sourceField, targetField);
-            break;
-        }
+        case 1: {return do_execute<Value, 1>(sourceField, targetField);}
+        case 2: {return do_execute<Value, 2>(sourceField, targetField);}
+        case 3: {return do_execute<Value, 3>(sourceField, targetField);}
+        case 4: {return do_execute<Value, 4>(sourceField, targetField);}
+        case 5: {return do_execute<Value, 5>(sourceField, targetField);}
+        case 6: {return do_execute<Value, 6>(sourceField, targetField);}
+        case 7: {return do_execute<Value, 7>(sourceField, targetField);}
+        case 8: {return do_execute<Value, 8>(sourceField, targetField);}
+        case 9: {return do_execute<Value, 9>(sourceField, targetField);}
         default: {
-            throw_NotImplemented("No implementation for rank " + std::to_string(sourceField.rank()), Here());
+            ATLAS_THROW_EXCEPTION("No implementation for rank " + std::to_string(sourceField.rank()));
         }
     }
 }
@@ -380,14 +384,17 @@ void RedistributeGeneric::do_execute(const Field& sourceField, Field& targetFiel
     auto recvBufferIt = recvBuffer.cbegin();
 
     // Copy sourceField to sendBuffer.
-    iterateField(sourceLocalIdx_, sourceView, [&](const Value& elem) { *sendBufferIt++ = elem; });
+    ForEach<Rank>::apply(sourceLocalIdx_, sourceView,
+                         [&](const Value& elem){*sendBufferIt++ = elem;});
 
     // Perform MPI communication.
     mpi::comm().allToAllv(sendBuffer.data(), sendCounts.data(), sendDisps.data(), recvBuffer.data(), recvCounts.data(),
                           recvDisps.data());
 
     // Copy recvBuffer to targetField.
-    iterateField(targetLocalIdx_, targetView, [&](Value& elem) { elem = *recvBufferIt++; });
+    ForEach<Rank>::apply(targetLocalIdx_, targetView,
+                         [&](Value& elem){elem = *recvBufferIt++;});
+
 }
 
 namespace {


### PR DESCRIPTION
This is a minor feature update which removes the field rank restrictions in the redistribution class. Before, the class could only redistribute fields of rank 3, or lower. Now, it can redistribute all ranks supported by Atlas.