### PR TITLE
fix: Catch periodicity issues in BilinearRemapping interpolation

### DIFF
--- a/src/atlas/interpolation/element/Quad2D.h
+++ b/src/atlas/interpolation/element/Quad2D.h
@@ -10,6 +10,7 @@
 #include <iosfwd>
 #include <limits>
 
+#include "atlas/runtime/Exception.h"
 #include "atlas/interpolation/Vector2D.h"
 #include "atlas/interpolation/method/Intersect.h"
 #include "atlas/util/Point.h"
@@ -44,6 +45,18 @@ public:
 
     double area() const;
 
+    const Vector2D& p(int i) {
+        if (i == 0)
+            return v00;
+        if (i == 1)
+            return v10;
+        if (i == 2)
+            return v11;
+        if (i == 3)
+            return v01;
+        throw_OutOfRange("Quad2D::p(i)", i, 4, Here());
+    }
+
     void print(std::ostream&) const;
 
     friend std::ostream& operator<<(std::ostream& s, const Quad2D& p) {
@@ -57,9 +70,9 @@ private:           // members
     Vector2D v11;  // aka v2
     Vector2D v01;  // aka v3
 
-    static double cross2d(const Vector2D& a, const Vector2D& b) { return a.x() * b.y() - a.y() * b.x(); }
-
     bool inQuadrilateral(const Vector2D& p) const;
+
+    static double cross2d(const Vector2D& a, const Vector2D& b) { return a.x() * b.y() - a.y() * b.x(); }
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/atlas/interpolation/method/bil/BilinearRemapping.h
+++ b/src/atlas/interpolation/method/bil/BilinearRemapping.h
@@ -16,7 +16,7 @@
 
 #include "atlas/array/ArrayView.h"
 #include "atlas/functionspace/FunctionSpace.h"
-#include "atlas/interpolation/method/PointIndex2.h"
+#include "atlas/interpolation/method/PointIndex3.h"
 #include "atlas/mesh/Elements.h"
 
 namespace atlas {
@@ -53,7 +53,7 @@ protected:
    * point to the nearest element(s), returning the (normalized) interpolation
    * weights
    */
-    Triplets projectPointToElements(size_t ip, const ElemIndex2::NodeList& elems, std::ostream& failures_log) const;
+    Triplets projectPointToElements(size_t ip, const ElemIndex3::NodeList& elems, std::ostream& failures_log) const;
 
     virtual const FunctionSpace& source() const override { return source_; }
     virtual const FunctionSpace& target() const override { return target_; }
@@ -68,6 +68,7 @@ protected:
     mesh::MultiBlockConnectivity* connectivity_;
     std::unique_ptr<array::ArrayView<double, 2>> ilonlat_;
     std::unique_ptr<array::ArrayView<double, 2>> olonlat_;
+    std::unique_ptr<array::ArrayView<double, 2>> oxyz_;
     std::unique_ptr<array::ArrayView<gidx_t, 1>> igidx_;
 
     Field target_lonlat_;


### PR DESCRIPTION
### Description

PR  #85 exposed an issue with this interpolation method. I thought I had a solution for this in wdeconinck/atlas-orca#2, however, upon further discussion it became clear that this approach is flawed and insufficient to account for the perodicity in the grid.

This fix should remedy problems with the grid periodicity, as well as falling back to inverse distance weighting when all else fails. This matches the behaviour of the similar NEMOVAR interpolation.

### Summary of Changes 

  * Use the 3D kdtree to locate 8 nearest grid elements
  * retry observations which fail in case they are in a cell which overlaps the eastern edge of the grid
  * If all else fails, trust the closest cell is the one found by the 3D KDTree and perform an inverse distance weighted interpolation

### Issues

Part of issue #4

