### PR TITLE
Add support for rank 2 fields in the 'missing' nonlinear interpolator

### DIFF
--- a/src/atlas/interpolation/nonlinear/Missing.h
+++ b/src/atlas/interpolation/nonlinear/Missing.h
@@ -58,7 +58,7 @@ struct MissingIfAllMissing : Missing {
             Matrix::iterator kt(it);
             Size k = i;
             for (; it != end; ++it, ++i, ++N_entries) {
-                const bool miss = missingValue(values(it.col()));
+                const bool miss = missingValue(values[it.col()]);
 
                 if (miss) {
                     ++N_missing;
@@ -80,7 +80,7 @@ struct MissingIfAllMissing : Missing {
                 else {
                     const Scalar factor = 1. / sum;
                     for (Size j = k; j < k + N_entries; ++j, ++kt) {
-                        if (missingValue(values(kt.col()))) {
+                        if (missingValue(values[kt.col()])) {
                             data[j] = 0.;
                             zeros   = true;
                         }
@@ -98,9 +98,6 @@ struct MissingIfAllMissing : Missing {
         }
 
         return modif;
-    }
-    bool execute_rank2(NonLinear::Matrix& W, const Field& field, int lev) const {
-        ATLAS_NOTIMPLEMENTED;
     }
 
     static std::string static_type() { return "missing-if-all-missing"; }
@@ -134,7 +131,7 @@ struct MissingIfAnyMissing : Missing {
             Matrix::iterator kt(it);
             Size k = i;
             for (; it != end; ++it, ++i, ++N_entries) {
-                const bool miss = missingValue(values(it.col()));
+                const bool miss = missingValue(values[it.col()]);
 
                 if (miss) {
                     ++N_missing;
@@ -162,9 +159,6 @@ struct MissingIfAnyMissing : Missing {
         }
 
         return modif;
-    }
-    bool execute_rank2(NonLinear::Matrix& W, const Field& field, int lev) const {
-      ATLAS_NOTIMPLEMENTED;
     }
 
     static std::string static_type() { return "missing-if-any-missing"; }
@@ -201,7 +195,7 @@ struct MissingIfHeaviestMissing : Missing {
             Matrix::iterator kt(it);
             Size k = i;
             for (; it != end; ++it, ++i, ++N_entries) {
-                const bool miss = missingValue(values(it.col()));
+                const bool miss = missingValue(values[it.col()]);
 
                 if (miss) {
                     ++N_missing;
@@ -228,7 +222,7 @@ struct MissingIfHeaviestMissing : Missing {
                 else {
                     const Scalar factor = 1. / sum;
                     for (Size j = k; j < k + N_entries; ++j, ++kt) {
-                        if (missingValue(values(kt.col()))) {
+                        if (missingValue(values[kt.col()])) {
                             data[j] = 0.;
                             zeros   = true;
                         }
@@ -246,10 +240,6 @@ struct MissingIfHeaviestMissing : Missing {
         }
 
         return modif;
-    }
-
-    bool execute_rank2(NonLinear::Matrix& W, const Field& field, int lev) const {
-      ATLAS_NOTIMPLEMENTED;
     }
 
     static std::string static_type() { return "missing-if-heaviest-missing"; }

--- a/src/atlas/interpolation/nonlinear/Missing.h
+++ b/src/atlas/interpolation/nonlinear/Missing.h
@@ -32,6 +32,21 @@ private:
 template <typename T>
 struct MissingIfAllMissing : Missing {
     bool execute(NonLinear::Matrix& W, const Field& field) const {
+    if (field.rank() == 1) {
+        return execute_rank1(W, field);
+    }
+    //else if (field.rank() == 2) {
+    //    return execute_rank2(W, field);
+    //}
+    //else if (field.rank() == 3) {
+    //    return execute_rank3(W, field);
+    //}
+    else {
+        ATLAS_NOTIMPLEMENTED;
+    }
+    }
+
+    bool execute_rank1(NonLinear::Matrix& W, const Field& field) const {
         field::MissingValue mv(field);
         auto& missingValue = mv.ref();
 

--- a/src/tests/interpolation/test_interpolation_non_linear.cc
+++ b/src/tests/interpolation/test_interpolation_non_linear.cc
@@ -151,9 +151,8 @@ CASE("Interpolation of rank 2 field with MissingValue") {
 
     auto viewA = array::make_view<double, 2>(fieldA);
     for (idx_t j = 0; j < viewA.shape(0); ++j) {
-        for (idx_t k = 0; k < viewA.shape(1); ++k) {
-            viewA(j,k) = 1;
-        }
+        viewA(j,0) = 1;
+        viewA(j,1) = missingValue;
     }
 
     // Set output field (2 points)
@@ -166,12 +165,11 @@ CASE("Interpolation of rank 2 field with MissingValue") {
         for (std::string type : {"equals", "approximately-equals", "nan"}) {
 
             fieldA.metadata().set("missing_value_type", type);
-            viewA(4,0) = type == "nan" ? nan : missingValue;
             viewA(4,1) = type == "nan" ? nan : missingValue;
 
             EXPECT(MissingValue(fieldA));
 
-            Field fieldB("B", array::make_datatype<double>(), array::make_shape(fsB.size(),2));
+            Field fieldB = fsB.createField<double>(option::name("B") | option::levels(2) );
             auto viewB = array::make_view<double, 2>(fieldB);
 
             interpolation.execute(fieldA, fieldB);
@@ -179,8 +177,8 @@ CASE("Interpolation of rank 2 field with MissingValue") {
             MissingValue mv(fieldB);
             EXPECT(mv(viewB(0,0)) == false);
             EXPECT(mv(viewB(1,0)) == false);
-            EXPECT(mv(viewB(0,1)) == false);
-            EXPECT(mv(viewB(1,1)) == false);
+            EXPECT(mv(viewB(0,1)) == true);
+            EXPECT(mv(viewB(1,1)) == true);
         }
     }
 

--- a/src/tests/interpolation/test_interpolation_non_linear.cc
+++ b/src/tests/interpolation/test_interpolation_non_linear.cc
@@ -164,29 +164,23 @@ CASE("Interpolation of rank 2 field with MissingValue") {
                                     fsB);
 
         for (std::string type : {"equals", "approximately-equals", "nan"}) {
-            Field fieldB("B", array::make_datatype<double>(), array::make_shape(fsB.size()));
-            auto viewB = array::make_view<double, 1>(fieldB);
 
             fieldA.metadata().set("missing_value_type", type);
-            viewA(4) = type == "nan" ? nan : missingValue;
+            viewA(4,0) = type == "nan" ? nan : missingValue;
+            viewA(4,1) = type == "nan" ? nan : missingValue;
 
             EXPECT(MissingValue(fieldA));
+
+            Field fieldB("B", array::make_datatype<double>(), array::make_shape(fsB.size(),2));
+            auto viewB = array::make_view<double, 2>(fieldB);
+
             interpolation.execute(fieldA, fieldB);
 
             MissingValue mv(fieldB);
-            EXPECT(mv);
-            EXPECT(mv(viewB(0)) == false);
-            EXPECT(mv(viewB(1)) == false);
-
-            Field fieldBr2("B", array::make_datatype<double>(), array::make_shape(fsB.size(),2));
-            auto viewBr2 = array::make_view<double, 2>(fieldBr2);
-
-            interpolation.execute(fieldA, fieldBr2);
-
-            EXPECT(mv(viewBr2(0,0)) == false);
-            EXPECT(mv(viewBr2(1,0)) == false);
-            EXPECT(mv(viewBr2(0,1)) == false);
-            EXPECT(mv(viewBr2(1,1)) == false);
+            EXPECT(mv(viewB(0,0)) == false);
+            EXPECT(mv(viewB(1,0)) == false);
+            EXPECT(mv(viewB(0,1)) == false);
+            EXPECT(mv(viewB(1,1)) == false);
         }
     }
 

--- a/src/tests/interpolation/test_interpolation_non_linear.cc
+++ b/src/tests/interpolation/test_interpolation_non_linear.cc
@@ -107,10 +107,6 @@ CASE("Interpolation with MissingValue") {
             interpolation.execute(fieldA, fieldB);
 
             MissingValue mv(fieldB);
-            if (fieldB.metadata().has("missing_value"))
-                std::cout <<  "viewB MissingValue value: " << fieldB.metadata().getDouble("missing_value") << std::endl;
-            std::cout <<  "mv(viewB(0)) " << mv(viewB(0));
-            std::cout <<  " viewB(0) " << viewB(0) << std::endl;
             EXPECT(mv);
             EXPECT(mv(viewB(0)));
             EXPECT(mv(viewB(1)));
@@ -156,15 +152,9 @@ CASE("Interpolation of rank 2 field with MissingValue") {
 
     auto viewA = array::make_view<double, 2>(fieldA);
     for (idx_t j = 0; j < viewA.shape(0); ++j) {
-        viewA(j,0) = 10;
+        viewA(j,0) = 10+j;
         viewA(j,1) = missingValue;
-        viewA(j,2) = 10;
-        //viewA(j,0) = 10+j;
-        //viewA(j,1) = 20+j;
-        //viewA(j,2) = 30+j;
-        std::cout <<  "viewA(" << j << ",0) " << viewA(j,0);
-        std::cout << " viewA(" << j << ",1) " << viewA(j,1);
-        std::cout << " viewA(" << j << ",2) " << viewA(j,2) << std::endl;
+        viewA(j,2) = 30+j;
     }
 
     const array::ArraySpec spec(array::ArrayShape{fieldA.shape(0)}, array::ArrayStrides{fieldA.shape(1)});
@@ -206,13 +196,6 @@ CASE("Interpolation of rank 2 field with MissingValue") {
             interpolation.execute(fieldA, fieldB);
 
             MissingValue mv(fieldB);
-            if (fieldB.metadata().has("missing_value"))
-                std::cout <<  "viewB MissingValue value: " << fieldB.metadata().getDouble("missing_value") << std::endl;
-            for (idx_t j = 0; j < viewB.shape(0); ++j) {
-                std::cout <<  "viewB(" << j << ",0) " << viewB(j,0);
-                std::cout << " viewB(" << j << ",1) " << viewB(j,1);
-                std::cout << " viewB(" << j << ",2) " << viewB(j,2) << std::endl;
-            }
             EXPECT(mv(viewB(0,0)) == false);
             EXPECT(mv(viewB(1,0)) == false);
             EXPECT(mv(viewB(0,1)));


### PR DESCRIPTION
### Description of the issue

Interpolation is failing for the `nonlinear::missing` [interpolators](https://github.com/ecmwf/atlas/blob/develop/src/atlas/interpolation/nonlinear/Missing.h) when the source field has vertical levels. In this case, any view of the field is rank 2, with the second dimension indexing over the level number. The example interpolation fails in lines like [Missing.h#L39](https://github.com/ecmwf/atlas/blob/develop/src/atlas/interpolation/nonlinear/Missing.h#L39). I believe this is because there is an assumption that the field has rank 1. For example, when compiling my original test case I would see the following error:
```
In file included from atlas/src/atlas/array/ArrayView.h:18,
                 from atlas/src/atlas/array.h:25,
                 from atlas/src/tests/interpolation/test_interpolation_non_linear.cc:16:
atlas/src/atlas/array/native/NativeArrayView.h: In instantiation of 'void atlas::array::ArrayView<Value, Rank>::check_bounds(Ints ...) const [with Ints = {int}; Value = double; int Rank = 2]':
atlas/src/atlas/array/native/NativeArrayView.h:167:9:   required from 'atlas::array::ArrayView<Value, Rank>::value_type& atlas::array::ArrayView<Value, Rank>::operator()(Idx ...) [with Idx = {int}; Value = double; int Rank = 2; atlas::array::ArrayView<Value, Rank>::value_type = double]'
atlas/src/tests/interpolation/test_interpolation_non_linear.cc:171:20:   required from here
atlas/src/atlas/array/native/NativeArrayView.h:342:38: error: static assertion failed: Expected number of indices is different from rank of array
  342 |         static_assert(sizeof...(idx) == Rank, "Expected number of indices is different from rank of array");
      |                       ~~~~~~~~~~~~~~~^~~~~~~
```

Atlas fields can be scalar or vector fields as well as surface or volume fields. The data layout is such that:
 * Rank=1 -> scalar horizontal field
 * Rank=2, Variables=1 -> scalar columns
 * Rank=2, Variables>1 -> horizontal multiple variables (vector)
 * Rank=3 -> multiple variables in columns 

It is also important for my application that the soluiton is capable of distinguishing between missing values on different levels. For example, my naive first attempt at a solution in this PR I think will lead to data being marked missing at every level if any particular level is considered missing. In ocean applications, a large percentage of the ocean has missing data at one of the deeper levels but not shallower ones.

### Proposed Solution

Originally, we hoped to solve this problem by re-wrapping the raw field data for each level into a new Field. For example:
```C++
const array::ArraySpec spec(array::ArrayShape{src.shape(0)}, array::ArrayStrides{src.shape(1)});
Value* data = const_cast<Value*>(src.array().data<Value>()) + lev;
atlas::Field src_tmp_slice = atlas::Field("s", data, spec);
```
This rank-1 field would be passed to the `Missing` interpolation post-processor and used to update the weights for each level and perform the interpolation independently for each level.

I think there are a couple of issues with this wrapping approach. Instead I have implemented a temporary field buffer, copying the data in and out of a new array. The reasons for this choice are:
  1. I think re-wrapping the data introduces a stride to any operations on the array which would be bad for vectorisation (my understanding is copying into a temporary field will have similar performance to wrapping, but it would be great to be able to test this).
  2. The methods in [Missing.h](https://github.com/ecmwf/atlas/blob/develop/src/atlas/interpolation/nonlinear/Missing.h) index the data using square brackets `[]` rather than round brackets `()`. I believe the square brackets applied to a view from a re-wrapped field don't index in the same way as the view indexed with round brackets. I think the round brackets give the correct result. I am not exactly sure on why this is the case. I am getting a little lost and confused in the detail on the relationship between a view and an array.
  3. Similarly, even after adjusting for the above, the sparse matrix multiply openMP method ([SparseMatrixMultiply_OpenMP.cc](https://github.com/ecmwf/atlas/blob/242ec84223c69f68821dea0fe28d899e5f80d2dc/src/atlas/linalg/sparse/SparseMatrixMultiply_OpenMP.cc#L35)) doesn't result in the answer I would expect. Inserting print statements shows that indexing the view with same index gives a different answer. I am again a bit lost with this, but I think it is to do with the casting of a FieldView to a LocalView in this function.

### Acceptance Criteria (Definition of Done)

 * Test cases with rank-2 to rank-2 nonlinear::missing interpolation included pass.
 * missing value interpolation of data with different missing values on different levels.

### Impact

This is an enhancement to atlas, and should be backwards compatible.