### PR TITLE
Added fused multiply-add to discriminant calculation.

### DIFF
--- a/src/atlas/interpolation/element/Quad2D.cc
+++ b/src/atlas/interpolation/element/Quad2D.cc
@@ -71,16 +71,25 @@ method::Intersect Quad2D::localRemap(const PointXY& p, double edgeEpsilon, doubl
             //   x1 = (-b - sign(b) sqrt(b^2 - 4ac)) / 2a
             //   x2 = c / ax1
 
-            double det = b * b - 4. * a * c;
-            if (det > -areaEpsilon * 2. * quadArea) {
-                // Solution is real.
-                const auto sign = [](double a) { return std::signbit(a) ? -1. : 1.; };
+            // Kahan's algorithm for accurate difference of products.
+            const auto prodDiff = [](double a, double b, double c, double d){
+              // return ab - cd
+              const double w = d * c;
+              const double e = std::fma(-d, c, w);
+              const double f = std::fma(a, b, -w);
+              return f + e;
+            };
 
-                double sqrtDet = std::sqrt(std::max(0., det));
+            double discriminant = prodDiff(b, b, 4. * a, c);
+
+            if (discriminant > -areaEpsilon * 2. * quadArea) {
+                // Solution is real.
+
+                double sqrtDiscriminant = std::sqrt(std::max(0., discriminant));
 
                 // "Classic" solution to quadratic formula with no cancelation
                 // on numerator.
-                weight = (-b - sign(b) * sqrtDet) / (2. * a);
+                weight = (-b - std::copysign(sqrtDiscriminant, b)) / (2. * a);
                 if (checkWeight(weight, edgeEpsilon)) {
                     return true;
                 }


### PR DESCRIPTION
@pmaciel @wdeconinck @twsearle 

This is the fused multiply-add operation that corrects for the potential loss of [half the significant figures in the quadratic solve](https://en.wikipedia.org/wiki/Loss_of_significance#A_better_algorithm).

The solution here was basically taken from [this Stack Overflow post](https://stackoverflow.com/questions/63665010/accurate-floating-point-computation-of-the-sum-and-difference-of-two-products)

The problem is that this could potentially be slow if the hardware doesn't support fused multiply-add operations (there doesn't seem to be a consistent macro to check for this either).

Anyway, if you're interested, I'll write a proper test for it. If not, never mind! 😊

p.s., I've just realised this also applies to the determinants of 2x2 matrices! 😮

