### PR TITLE
Bugfix/cubed sphere interpolation

### DIFF
--- a/src/atlas/interpolation/method/cubedsphere/CubedSphereBilinear.cc
+++ b/src/atlas/interpolation/method/cubedsphere/CubedSphereBilinear.cc
@@ -84,10 +84,12 @@ void CubedSphereBilinear::do_setup(const FunctionSpace& source, const FunctionSp
             }
         }
 
-        // fill sparse matrix and return.
-        Matrix A(target_.size(), source_.size(), weights);
-        setMatrix(A);
+
     }
+
+    // fill sparse matrix and return.
+    Matrix A(target_.size(), source_.size(), weights);
+    setMatrix(A);
 }
 
 void CubedSphereBilinear::print(std::ostream&) const {

--- a/src/atlas/projection/detail/CubedSphereProjectionBase.h
+++ b/src/atlas/projection/detail/CubedSphereProjectionBase.h
@@ -31,7 +31,7 @@ public:
 
     void hash(eckit::Hash&) const;
 
-    atlas::grid::CubedSphereTiles getCubedSphereTiles() const { return tiles_; };
+    const atlas::grid::CubedSphereTiles& getCubedSphereTiles() const { return tiles_; };
 
     /// @brief   Convert (x, y) coordinate to (alpha, beta) on tile t.
     ///


### PR DESCRIPTION
Found a couple of nasty bugs that slipped through the tests. 

First one is where the CubedSphereBilinear class builds the interpolation matrix for every single target point!

Second one involves the CubedSphereProjectionBase returning a tiles object by value instead of const reference. @MarekWlasak can you confirm that this behaviour is not intentional?