### PR TITLE
Interpolation succeeds when no target points

### DIFF
--- a/src/atlas/interpolation/method/Method.cc
+++ b/src/atlas/interpolation/method/Method.cc
@@ -242,6 +242,9 @@ void Method::check_compatibility(const Field& src, const Field& tgt, const Matri
 
 template <typename Value>
 void Method::interpolate_field(const Field& src, Field& tgt, const Matrix& W) const {
+    // do nothing if there are no observations to interpolate (W will be NULL
+    // and would fail the compatibility check)
+    if (tgt.shape(0) == 0) return;
     check_compatibility(src, tgt, W);
 
     if (src.rank() == 1) {
@@ -260,6 +263,9 @@ void Method::interpolate_field(const Field& src, Field& tgt, const Matrix& W) co
 
 template <typename Value>
 void Method::adjoint_interpolate_field(Field& src, const Field& tgt, const Matrix& W) const {
+    // do nothing if there are no observations to interpolate (W will be NULL
+    // and would fail the compatibility check)
+    if (tgt.shape(0) == 0) return;
     check_compatibility(tgt, src, W);
 
     if (src.rank() == 1) {

--- a/src/atlas/interpolation/method/unstructured/UnstructuredBilinearLonLat.cc
+++ b/src/atlas/interpolation/method/unstructured/UnstructuredBilinearLonLat.cc
@@ -225,6 +225,13 @@ void UnstructuredBilinearLonLat::setup(const FunctionSpace& source) {
     idx_t inp_npts = i_nodes.size();
     idx_t out_npts = olonlat_->shape(0);
 
+     // return early if no output points on this partition reserve is called on
+     // the triplets but also during the sparseMatrix constructor. This won't
+     // work for empty matrices
+     if (out_npts == 0) {
+         return;
+     }
+
     array::ArrayView<int, 1> out_ghosts = array::make_view<int, 1>(target_ghost_);
 
     idx_t Nelements = meshSource.cells().size();

--- a/src/tests/interpolation/test_interpolation_unstructured_bilinear_lonlat.cc
+++ b/src/tests/interpolation/test_interpolation_unstructured_bilinear_lonlat.cc
@@ -32,6 +32,29 @@ namespace test {
 
 //-----------------------------------------------------------------------------
 //
+CASE("test_interpolation_O64_to_empty_PointCloud") {
+    Grid grid("O64");
+    Mesh mesh(grid);
+    NodeColumns fs(mesh);
+
+    atlas::Field points("lonlat", atlas::array::make_datatype<double>(),
+                                  atlas::array::make_shape(0, 2));
+    // Some points at the equator
+    PointCloud pointcloud(points);
+
+    Interpolation interpolation(
+    option::type("unstructured-bilinear-lonlat"), fs, pointcloud);
+
+    Field field_source = fs.createField<double>(option::name("source"));
+    Field field_target("target", array::make_datatype<double>(), array::make_shape(pointcloud.size()));
+
+    auto source = array::make_view<double, 1>(field_source);
+    for (idx_t j = 0; j < fs.nodes().size(); ++j) {
+        source(j) = 0;
+    }
+
+    interpolation.execute(field_source, field_target);
+}
 
 CASE("test_interpolation_O64_to_points_bilinear_remapping") {
     Grid grid("O64");


### PR DESCRIPTION
The interpolator is sometimes called when there are no target points. This is particularly a concern when running interpolations to PointCloud function spaces. For example, under some MPI decompositions, a processor might have no interpolation target locations within its domain because there happen to be no observations in that region in this run.

Without the following changes, interpolating a target field with no target points will cause an error when an eckit::SparseMatrix is constructed. See [eckit/linalg/SparseMatrix#L215](https://github.com/ecmwf/eckit/blob/develop/src/eckit/linalg/SparseMatrix.cc#L215). This change allows the unstructured_bilinear_lonlat interpolator to exit early without adding data to the matrix. When the interpolation is executed it will also end early if there are no target points to interpolate.