### PR TITLE
Feature: Serial distribution to use entire mesh on every partition

### DIFF
--- a/src/atlas/grid/detail/distribution/SerialDistribution.cc
+++ b/src/atlas/grid/detail/distribution/SerialDistribution.cc
@@ -14,6 +14,7 @@
 #include <ostream>
 
 #include "atlas/grid/Grid.h"
+#include "atlas/parallel/mpi/mpi.h"
 
 namespace atlas {
 namespace grid {
@@ -23,6 +24,7 @@ namespace distribution {
 SerialDistribution::SerialDistribution(const Grid& grid): DistributionFunctionT<SerialDistribution>(grid) {
     type_          = "serial";
     nb_partitions_ = 1;
+    rank_          = mpi::rank();
     size_          = grid.size();
     nb_pts_.resize(nb_partitions_, grid.size());
     max_pts_ = *std::max_element(nb_pts_.begin(), nb_pts_.end());

--- a/src/atlas/grid/detail/distribution/SerialDistribution.h
+++ b/src/atlas/grid/detail/distribution/SerialDistribution.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "atlas/parallel/mpi/mpi.h"
 #include "atlas/grid/detail/distribution/DistributionFunction.h"
 
 namespace atlas {
@@ -22,7 +21,10 @@ class SerialDistribution : public DistributionFunctionT<SerialDistribution> {
 public:
     SerialDistribution(const Grid& grid);
 
-    ATLAS_ALWAYS_INLINE int function(gidx_t gidx) const { return mpi::rank(); }
+    ATLAS_ALWAYS_INLINE int function(gidx_t gidx) const { return rank_; }
+
+private:
+    int rank_{0};
 };
 
 }  // namespace distribution

--- a/src/atlas/grid/detail/distribution/SerialDistribution.h
+++ b/src/atlas/grid/detail/distribution/SerialDistribution.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-
+#include "atlas/parallel/mpi/mpi.h"
 #include "atlas/grid/detail/distribution/DistributionFunction.h"
 
 namespace atlas {
@@ -22,7 +22,7 @@ class SerialDistribution : public DistributionFunctionT<SerialDistribution> {
 public:
     SerialDistribution(const Grid& grid);
 
-    ATLAS_ALWAYS_INLINE int function(gidx_t gidx) const { return 0; }
+    ATLAS_ALWAYS_INLINE int function(gidx_t gidx) const { return mpi::rank(); }
 };
 
 }  // namespace distribution


### PR DESCRIPTION
## Description

JEDI-OOPS has a "round-robin" configuration, that evenly and randomly distributes observations across each MPI partition. I would like an atlas distribution to support this configuration for use in embarrassingly parallel applications - where each observation requires no communication with any other. The advantage of this is that it will increase the speed of the program whilst allowing for easy testing against domain-decomposed partitioning.

This change will create a copy of the mesh on each MPI parititon allowing atlas to be run in parallel for this kind of problem. I will then create a PointCloud functionspace containing the observation locations on that particular partition and interpolate the gridded data to these locations.

Please let me know if you think this is a bad idea, or if you would prefer I introduce a new distribution for this task ("parallel distribution?") rather than change the serial distribution.

## Impact

Fundamentally changes the "serial" distribution which might have impacts for current users due to increased memory requirements.