### PR TITLE
Fix `More processors requested than permitted` error on HPC

### DIFF
--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -22,6 +22,8 @@ jobs:
           ninja
         --modules-package: |
           openmpi
+          fftw
+          eigen
         --dependencies: |
           ${{ inputs.eckit || 'ecmwf/eckit@develop' }}
         --parallel: 64

--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -27,4 +27,6 @@ jobs:
         --dependencies: |
           ${{ inputs.eckit || 'ecmwf/eckit@develop' }}
         --parallel: 64
+        --env: |
+          ATLAS_RUN_MPI_ARGS=--oversubscribe
     secrets: inherit

--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -21,12 +21,9 @@ jobs:
           ecbuild
           ninja
         --modules-package: |
-          openmpi
           fftw
           eigen
         --dependencies: |
           ${{ inputs.eckit || 'ecmwf/eckit@develop' }}
         --parallel: 64
-        --env: |
-          ATLAS_RUN_MPI_ARGS=--oversubscribe
     secrets: inherit


### PR DESCRIPTION
Load fftw and eigen modules.
Remove openmpi as build-package-hpc does not support that yet.