### PR TITLE
Fix normalisation issue with StructuredInterpolation2D

### DIFF
--- a/atlas_io/src/atlas_io/types/scalar.cc
+++ b/atlas_io/src/atlas_io/types/scalar.cc
@@ -14,7 +14,7 @@
 #endif
 
 // GNU C++ compiler (version 11) should not try to optimize this code
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__NVCOMPILER)
 #pragma GCC optimize("O0")
 #endif
 

--- a/src/atlas/functionspace/detail/BlockStructuredColumns.h
+++ b/src/atlas/functionspace/detail/BlockStructuredColumns.h
@@ -83,8 +83,10 @@ public:
     Field createField(const eckit::Configuration&) const override;
     Field createField(const Field&, const eckit::Configuration&) const override;
 
+    using FunctionSpaceImpl::scatter;
     void scatter(const FieldSet&, FieldSet&) const override;
     void scatter(const Field&, Field&) const override;
+    using FunctionSpaceImpl::gather;
     void gather(const FieldSet&, FieldSet&) const override;
     void gather(const Field&, Field&) const override;
 

--- a/src/atlas/functionspace/detail/StructuredColumns.h
+++ b/src/atlas/functionspace/detail/StructuredColumns.h
@@ -218,8 +218,8 @@ private:  // data
     mutable util::ObjectHandle<parallel::GatherScatter> gather_scatter_;
     mutable util::ObjectHandle<parallel::Checksum> checksum_;
     mutable util::ObjectHandle<parallel::HaloExchange> halo_exchange_;
-    mutable std::unique_ptr<util::PartitionPolygon> polygon_;
-    mutable util::PartitionPolygons polygons_;
+    mutable std::vector<util::ObjectHandle<util::PartitionPolygon>> polygons_;
+    mutable util::PartitionPolygons all_polygons_;
 
     Field field_xy_;
     Field field_partition_;

--- a/src/atlas/interpolation/method/cubedsphere/CubedSphereBilinear.h
+++ b/src/atlas/interpolation/method/cubedsphere/CubedSphereBilinear.h
@@ -39,8 +39,9 @@ public:
     virtual const FunctionSpace& target() const override { return target_; }
 
 private:
-    virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target) override;
-    virtual void do_setup(const Grid& source, const Grid& target, const Cache&) override;
+    using Method::do_setup;
+    void do_setup(const FunctionSpace& source, const FunctionSpace& target) override;
+    void do_setup(const Grid& source, const Grid& target, const Cache&) override;
 
     FunctionSpace source_;
     FunctionSpace target_;

--- a/src/atlas/interpolation/method/structured/StructuredInterpolation2D.h
+++ b/src/atlas/interpolation/method/structured/StructuredInterpolation2D.h
@@ -35,17 +35,18 @@ class StructuredInterpolation2D : public Method {
 public:
     StructuredInterpolation2D(const Config& config);
 
-    virtual ~StructuredInterpolation2D() override {}
+    ~StructuredInterpolation2D() override {}
 
-    virtual void print(std::ostream&) const override;
+    void print(std::ostream&) const override;
 
+    const Kernel& kernel() const { return *kernel_; }
+
+    const FunctionSpace& source() const override { return source_; }
+
+    const FunctionSpace& target() const override { return target_; }
 
 protected:
     void setup(const FunctionSpace& source);
-
-    virtual const FunctionSpace& source() const override { return source_; }
-
-    virtual const FunctionSpace& target() const override { return target_; }
 
 private:
     virtual void do_setup(const Grid& source, const Grid& target, const Cache&) override;
@@ -75,6 +76,9 @@ protected:
     FunctionSpace target_;
 
     bool matrix_free_;
+    bool verbose_;
+    double convert_units_;
+    idx_t out_npts_;
 
     std::unique_ptr<Kernel> kernel_;
 };

--- a/src/atlas/interpolation/method/structured/StructuredInterpolation2D.tcc
+++ b/src/atlas/interpolation/method/structured/StructuredInterpolation2D.tcc
@@ -12,6 +12,16 @@
 
 #include "StructuredInterpolation2D.h"
 
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <algorithm>
+#include <sstream>
+#include <iomanip>
+#include <chrono>
+#include <thread>
+
+#include "eckit/filesystem/LocalPathName.h"
 
 #include "atlas/array/ArrayView.h"
 #include "atlas/field/Field.h"
@@ -35,6 +45,178 @@ namespace atlas {
 namespace interpolation {
 namespace method {
 
+namespace structured2d {
+
+namespace {
+
+    inline std::string search_replace(const std::string& in, const std::string& search, const std::string& replace) {
+        std::string out = in;
+        int pos = out.find(search);
+        while (pos != std::string::npos) {
+            out.erase(pos, search.length());
+            out.insert(pos, replace);
+            pos = out.find(search, pos + replace.length());
+        }
+        return out;
+    }
+
+    inline std::string left_padded_str(int x, int max = 0) {
+        auto digits = [](long x) -> long { return std::floor(std::log10(std::max(1l, x))) + 1l; };
+        if (max) {
+            std::ostringstream ss;
+            ss << std::setw(digits(max)) << std::setfill('0') << x;
+            return ss.str();
+        }
+        return std::to_string(x);
+    }
+
+    inline std::string filename( const std::string& path ){
+        return search_replace(path, "%p", left_padded_str(mpi::rank(),mpi::size()));
+    }
+
+    template <typename LonLat>
+    inline std::string to_str (const std::vector<idx_t>& points, LonLat lonlat) {
+        std::ostringstream out;
+        out << "[\n";
+        for( size_t j=0; j<points.size(); ++j ) {
+            PointLonLat p = lonlat(points[j]);
+            out << "  [" << p.lon() << "," << p.lat() << "]";
+            if( j < points.size() - 1 ) {
+                out << ",\n";
+            }
+        }
+        out << "\n]";
+        return out.str();
+    };
+
+    inline auto compute_src_west_east(functionspace::StructuredColumns src_fs) {
+        const auto& src_polygon = src_fs.polygon(0);
+        double src_west = std::numeric_limits<double>::max();
+        double src_east = std::numeric_limits<double>::min();
+        for( auto& p : src_polygon.lonlat() ) {
+            src_west = std::min(src_west, p[0]);
+            src_east = std::max(src_east, p[0]);
+        }
+        return std::make_tuple(src_west,src_east);
+    };
+
+
+    inline void output_source_partition_polygon(const std::string& path, functionspace::StructuredColumns src_fs, idx_t halo) {
+        auto& polygon = src_fs.polygon(halo);
+        std::ofstream f(filename(path));
+        f << "[\n  " << polygon.json() << "\n]";
+    }
+
+    inline void output_all_source_partition_polygons(const std::string& path, functionspace::StructuredColumns src_fs, idx_t halo) {
+        auto& polygon = src_fs.polygon(halo);
+        util::PartitionPolygons polygons;
+        polygon.allGather(polygons);
+        if( mpi::rank() == 0 ) {
+            std::ofstream f(path);
+            f << polygons.json();
+        }
+    }
+
+    inline void output_source_grid_points(const std::string& path, functionspace::StructuredColumns src_fs, idx_t halo) {
+        std::ofstream f(filename(path));
+        f << "[\n";
+        if( halo == 0 ) {
+            idx_t size = src_fs.sizeOwned();
+            idx_t n = 0;
+            for( idx_t j=src_fs.j_begin(); j<src_fs.j_end(); ++j ) {
+                for( idx_t i=src_fs.i_begin(j); i<src_fs.i_end(j); ++i ) {
+                    auto p = src_fs.compute_xy(i,j);
+                    f << "  [" << p.x() << "," << p.y() << "]";
+                    if( (++n) != size ) {
+                        f << ",\n";
+                    }
+                }
+            }
+        }
+        else {
+            idx_t size = src_fs.sizeHalo();
+            idx_t n = 0;
+            for( idx_t j=src_fs.j_begin_halo(); j<src_fs.j_end_halo(); ++j ) {
+                for( idx_t i=src_fs.i_begin_halo(j); i<src_fs.i_end_halo(j); ++i ) {
+                    auto p = src_fs.compute_xy(i,j);
+                    f << "  [" << p.x() << "," << p.y() << "]";
+                    if( (++n) != size ) {
+                        f << ",\n";
+                    }
+                }
+            }
+        }
+        f << "\n]";
+    }
+
+
+    template <typename LonLat>
+    inline void output_target_points(const std::string& path, const std::vector<idx_t>& points, LonLat lonlat) {
+        std::ofstream f(filename(path));
+        f << to_str(points,lonlat);
+    }
+
+    template <typename LonLat, typename Interpolation>
+    inline void handle_failed_points(const Interpolation& interpolation, const std::vector<idx_t>& failed_points, LonLat lonlat ) {
+        const auto src_fs = functionspace::StructuredColumns( interpolation.source() );
+        size_t num_failed_points{0};
+        mpi::comm().allReduce(failed_points.size(), num_failed_points, eckit::mpi::sum());
+        if( num_failed_points > 0 ) {
+            std::string halo_str = std::to_string(src_fs.halo());
+            output_source_partition_polygon("atlas_source_partition_polygons_halo_0_p%p.json",src_fs,0);
+            output_source_partition_polygon("atlas_source_partition_polygons_halo_" + halo_str + "_p%p.json",src_fs,src_fs.halo());
+            output_target_points("atlas_target_failed_points_p%p.json", failed_points, lonlat);
+            auto [src_west, src_east] = compute_src_west_east(src_fs);
+            idx_t my_rank = mpi::rank();
+            for( idx_t p=0; p<mpi::size(); ++p ) {
+                if( p == my_rank && failed_points.size() ) {
+                    Log::error() << "Failed to interpolate " << failed_points.size() << " points on rank " << p
+                                 << " after retrying with normalisation to (west=" << src_west-360 << ") and (east=" << src_west+360 << "). "
+                                 << "See " << filename("atlas_target_failed_points_p%p.json") ;
+                    if( failed_points.size() <= 20 ) {
+                        Log::error() << " :\n" << to_str(failed_points, lonlat);
+                    }
+                    Log::error() << std::endl;
+                }
+                mpi::comm().barrier();
+            }
+            output_all_source_partition_polygons("atlas_source_partition_polygons_halo_0.json",src_fs,0);
+            output_all_source_partition_polygons("atlas_source_partition_polygons_halo_"+halo_str+".json",src_fs,src_fs.halo());
+            // output_source_grid_points("atlas_source_grid_points_halo_0_p%p.json",src_fs,0);
+            // output_source_grid_points("atlas_source_grid_points_halo_"+halo_str+"_p%p.json",src_fs,src_fs.halo());
+            {
+                std::ofstream f("atlas_interpolation_info.json");
+                util::Config src_fs_config;
+                src_fs_config.set("source.functionspace","StructuredColumns");
+                src_fs_config.set("source.grid",src_fs.grid().spec());
+                src_fs_config.set("source.halo",src_fs.halo());
+                src_fs_config.set("source.distribution",src_fs.distribution());
+                src_fs_config.set("source.partitions",src_fs.nb_partitions());
+                src_fs_config.set("interpolation","StructuredInterpolation2D<"+interpolation.kernel().className()+">");
+                f << src_fs_config.json();
+            }
+            std::string p_range = "{"+left_padded_str(0,mpi::size()-1)+".."+left_padded_str(mpi::size()-1,mpi::size()-1)+"}";
+            Log::info() << "Dumped files to " << eckit::LocalPathName::cwd() << ": \n"
+                        << "    atlas_target_failed_points_p" << p_range << ".json\n"
+                        << "    atlas_source_partition_polygons_halo_0_p" << p_range << ".json\n"
+                        << "    atlas_source_partition_polygons_halo_0.json\n"
+                        << "    atlas_source_partition_polygons_halo_" << src_fs.halo() << "_p" << p_range << ".json\n"
+                        << "    atlas_source_partition_polygons_halo_" << src_fs.halo() << ".json\n"
+                        << "    atlas_interpolation_info.json\n"
+                        << std::endl;
+
+            std::ostringstream err;
+            err << "StructuredInterpolation2D<" << interpolation.kernel().className() << "> failed for "
+                << num_failed_points << " points with source halo="<<src_fs.halo()
+                << ". Try increasing the source halo. Files have been written for debugging purpose to ["
+                << eckit::LocalPathName::cwd() << "].";
+            ATLAS_THROW_EXCEPTION(err.str());
+        }
+    }
+}
+}
+
+
 template <typename Kernel>
 double StructuredInterpolation2D<Kernel>::convert_units_multiplier( const Field& field ) {
     std::string units = field.metadata().getString( "units", "degrees" );
@@ -50,8 +232,10 @@ double StructuredInterpolation2D<Kernel>::convert_units_multiplier( const Field&
 template <typename Kernel>
 StructuredInterpolation2D<Kernel>::StructuredInterpolation2D( const Method::Config& config ) :
     Method( config ),
-    matrix_free_{false} {
+    matrix_free_{false} ,
+    verbose_{false} {
     config.get( "matrix_free", matrix_free_ );
+    config.get( "verbose", verbose_ );
 }
 
 
@@ -140,61 +324,107 @@ void StructuredInterpolation2D<Kernel>::print( std::ostream& ) const {
 
 template <typename Kernel>
 void StructuredInterpolation2D<Kernel>::setup( const FunctionSpace& source ) {
+    using namespace structured2d;
+
     kernel_.reset( new Kernel( source ) );
 
     if ( functionspace::StructuredColumns( source ).halo() < 1 ) {
         throw_Exception( "The source functionspace must have (halo >= 1) for pole treatment" );
     }
 
+    out_npts_ = 0;
+    if( target_lonlat_ ) {
+        convert_units_ = convert_units_multiplier(target_lonlat_);
+        out_npts_ = target_lonlat_.shape( 0 );
+    }
+    else if( target_lonlat_fields_.empty() ) {
+        convert_units_ = convert_units_multiplier(target_lonlat_fields_[LON]);
+        out_npts_ = target_lonlat_fields_[0].shape(0);
+    }
+
     if ( not matrix_free_ ) {
-        ATLAS_ASSERT( target_lonlat_ );  // TODO: implement setup with target_lonlat_fields_ as well (see execute_impl)
+        ATLAS_TRACE( "Precomputing interpolation matrix" );
 
-        idx_t inp_npts = source.size();
-        idx_t out_npts = target_lonlat_.shape( 0 );
+        std::vector<idx_t> failed_points;
 
-        // return early if no output points on this partition reserve is called on
-        // the triplets but also during the sparseMatrix constructor. This won't
-        // work for empty matrices
-        if (out_npts == 0) {
-            return;
-        }
+        auto triplets = kernel_->allocate_triplets( out_npts_ );
 
-        auto lonlat = array::make_view<double, 2>( target_lonlat_ );
+        using WorkSpace = typename Kernel::WorkSpace;
+        auto [west, east] = compute_src_west_east(source);
+        auto normalise = util::NormaliseLongitude(west);
+        auto interpolate_point = [&]( idx_t n, PointLonLat&& p, WorkSpace& workspace ) -> int {
+            try {
+                p.lon() = normalise(p.lon());
+                kernel_->insert_triplets( n, p, triplets, workspace );
+                return 0;
+            }
+            catch(const eckit::Exception& e) {}
+            if (verbose_) {
+                Log::error() << "Could not interpolate point " << n << " :\t" << p << std::endl;
+            }
+            return 1;
+        };
 
-        double convert_units = convert_units_multiplier( target_lonlat_ );
-
-        auto triplets = kernel_->allocate_triplets( out_npts );
-
-        const auto src_fs = functionspace::StructuredColumns( source );
-        const auto src_dom = RectangularDomain( src_fs.grid().domain() );
-        const double src_west = src_dom ? src_dom.xmin() : 0.;
-        const util::NormaliseLongitude normalise( src_west );
-
-        ATLAS_TRACE_SCOPE( "Precomputing interpolation matrix" ) {
-            if ( target_ghost_ ) {
-                auto ghost = array::make_view<int, 1>( target_ghost_ );
-                atlas_omp_parallel {
-                    typename Kernel::WorkSpace workspace;
-                    atlas_omp_for( idx_t n = 0; n < out_npts; ++n ) {
-                        if ( not ghost( n ) ) {
-                            PointLonLat p{normalise( lonlat( n, LON ) ) * convert_units,
-                                          lonlat( n, LAT ) * convert_units};
-                            kernel_->insert_triplets( n, p, triplets, workspace );
+        auto interpolate_omp = [&]( idx_t out_npts, auto lonlat, auto ghost) {
+            atlas_omp_parallel {
+                WorkSpace workspace;
+                atlas_omp_for( idx_t n = 0; n < out_npts; ++n ) {
+                    if( not ghost(n) ) {
+                        if (interpolate_point(n, lonlat(n), workspace) != 0) {
+                            atlas_omp_critical {
+                                failed_points.emplace_back(n);
+                            }
                         }
                     }
                 }
             }
-            else {
-                atlas_omp_parallel {
-                    typename Kernel::WorkSpace workspace;
-                    atlas_omp_for( idx_t n = 0; n < out_npts; ++n ) {
-                        PointLonLat p{normalise( lonlat( n, LON ) ) * convert_units, lonlat( n, LAT ) * convert_units};
-                        kernel_->insert_triplets( n, p, triplets, workspace );
-                    }
+        };
+
+        if ( target_lonlat_ ) {
+            auto lonlat_view    = array::make_view<double, 2>( target_lonlat_ );
+            auto lonlat = [lonlat_view, convert_units = convert_units_] (idx_t n) {
+                return PointLonLat{lonlat_view(n,LON) * convert_units, lonlat_view(n,LAT) * convert_units};
+            };
+
+            if( out_npts_ != 0 ) {
+                if ( target_ghost_ ) {
+                    auto ghost     = array::make_view<int, 1>( target_ghost_ );
+                    interpolate_omp(out_npts_, lonlat, ghost);
+                }
+                else {
+                    auto no_ghost = [](idx_t n) { return false; };
+                    interpolate_omp(out_npts_, lonlat, no_ghost);
                 }
             }
-            // fill sparse matrix and return
-            Matrix A( out_npts, inp_npts, triplets );
+            handle_failed_points(*this, failed_points, lonlat);
+        }
+        else if ( not target_lonlat_fields_.empty() ) {
+            const auto lon = array::make_view<double, 1>( target_lonlat_fields_[LON] );
+            const auto lat = array::make_view<double, 1>( target_lonlat_fields_[LAT] );
+            auto lonlat = [lon, lat, convert_units = convert_units_] (idx_t n) {
+                return PointLonLat{lon(n) * convert_units, lat(n) * convert_units};
+            };
+
+            if( out_npts_ != 0) {
+                if ( target_ghost_ ) {
+                    auto ghost     = array::make_view<int, 1>( target_ghost_ );
+                    interpolate_omp(out_npts_, lonlat, ghost);
+                }
+                else {
+                    auto no_ghost = [](idx_t n) { return false; };
+                    interpolate_omp(out_npts_, lonlat, no_ghost);
+                }
+            }
+            handle_failed_points(*this, failed_points, lonlat);
+        }
+        else {
+            ATLAS_NOTIMPLEMENTED;
+        }
+
+        // fill sparse matrix
+        if( failed_points.empty() ) {
+            idx_t inp_npts = source.size();
+            Matrix A( out_npts_, inp_npts, triplets );
             setMatrix(A);
         }
     }
@@ -256,12 +486,9 @@ template <typename Kernel>
 template <typename Value, int Rank>
 void StructuredInterpolation2D<Kernel>::execute_impl( const Kernel& kernel, const FieldSet& src_fields,
                                                       FieldSet& tgt_fields ) const {
-    const idx_t N = src_fields.size();
+    using namespace structured2d;
 
-    const auto src_fs = functionspace::StructuredColumns( source() );
-    const auto src_dom = RectangularDomain( src_fs.grid().domain() );
-    const double src_west = src_dom ? src_dom.xmin() : 0.;
-    const util::NormaliseLongitude normalise( src_west );
+    const idx_t N = src_fields.size();
 
     std::vector<array::ArrayView<const Value, Rank> > src_view;
     std::vector<array::ArrayView<Value, Rank> > tgt_view;
@@ -272,65 +499,81 @@ void StructuredInterpolation2D<Kernel>::execute_impl( const Kernel& kernel, cons
         src_view.emplace_back( array::make_view<Value, Rank>( src_fields[i] ) );
         tgt_view.emplace_back( array::make_view<Value, Rank>( tgt_fields[i] ) );
     }
-    if ( target_lonlat_ ) {
-        double convert_units = convert_units_multiplier( target_lonlat_ );
 
-        if ( target_ghost_ ) {
-            idx_t out_npts = target_lonlat_.shape( 0 );
-            auto ghost     = array::make_view<int, 1>( target_ghost_ );
-            auto lonlat    = array::make_view<double, 2>( target_lonlat_ );
+    using WorkSpace = typename Kernel::WorkSpace;
 
-            atlas_omp_parallel {
-                typename Kernel::Stencil stencil;
-                typename Kernel::Weights weights;
-                atlas_omp_for( idx_t n = 0; n < out_npts; ++n ) {
-                    if ( not ghost( n ) ) {
-                        PointLonLat p{ normalise(lonlat( n, LON ) ) * convert_units, lonlat( n, LAT ) * convert_units};
-                        kernel.compute_stencil( p.lon(), p.lat(), stencil );
-                        kernel.compute_weights( p.lon(), p.lat(), stencil, weights );
-                        for ( idx_t i = 0; i < N; ++i ) {
-                            kernel.interpolate( stencil, weights, src_view[i], tgt_view[i], n );
+    auto [west, east] = compute_src_west_east(source());
+    util::NormaliseLongitude normalise{west};
+    auto interpolate_point = [&]( idx_t n, PointLonLat&& p, WorkSpace& workspace ) -> int {
+        try {
+            p.lon() = normalise(p.lon());
+            kernel.compute_stencil( p.lon(), p.lat(), workspace.stencil );
+            kernel.compute_weights( p.lon(), p.lat(), workspace.stencil, workspace.weights );
+            for ( idx_t i = 0; i < N; ++i ) {
+                kernel.interpolate( workspace.stencil, workspace.weights, src_view[i], tgt_view[i], n );
+            }
+            return 0;
+        }
+        catch(const eckit::Exception& e) {}
+        if (verbose_) {
+            Log::error() << "Could not interpolate point " << n << " :\t" << p << std::endl;
+        }
+        return 1;
+    };
+
+    std::vector<idx_t> failed_points;
+
+    auto interpolate_omp = [&]( idx_t out_npts, auto lonlat, auto ghost) {
+        atlas_omp_parallel {
+            WorkSpace workspace;
+            atlas_omp_for( idx_t n = 0; n < out_npts; ++n ) {
+                if( not ghost(n) ) {
+                    if (interpolate_point(n, lonlat(n), workspace) != 0) {
+                        atlas_omp_critical {
+                            failed_points.emplace_back(n);
                         }
                     }
                 }
             }
         }
-        else {
-            idx_t out_npts    = target_lonlat_.shape( 0 );
-            const auto lonlat = array::make_view<double, 2>( target_lonlat_ );
+    };
 
-            atlas_omp_parallel {
-                typename Kernel::Stencil stencil;
-                typename Kernel::Weights weights;
-                atlas_omp_for( idx_t n = 0; n < out_npts; ++n ) {
-                    PointLonLat p{ normalise(lonlat( n, LON )) * convert_units, lonlat( n, LAT ) * convert_units};
-                    kernel.compute_stencil( p.lon(), p.lat(), stencil );
-                    kernel.compute_weights( p.lon(), p.lat(), stencil, weights );
-                    for ( idx_t i = 0; i < N; ++i ) {
-                        kernel.interpolate( stencil, weights, src_view[i], tgt_view[i], n );
-                    }
-                }
+    if ( target_lonlat_ ) {
+        auto lonlat_view    = array::make_view<double, 2>( target_lonlat_ );
+        auto lonlat = [lonlat_view, convert_units = convert_units_] (idx_t n) {
+            return PointLonLat{lonlat_view(n,LON) * convert_units, lonlat_view(n,LAT) * convert_units};
+        };
+
+        if( out_npts_ != 0 ) {
+            if ( target_ghost_ ) {
+                auto ghost     = array::make_view<int, 1>( target_ghost_ );
+                interpolate_omp(out_npts_, lonlat, ghost);
+            }
+            else {
+                auto no_ghost = [](idx_t n) { return false; };
+                interpolate_omp(out_npts_, lonlat, no_ghost);
             }
         }
+        handle_failed_points(*this, failed_points, lonlat);
     }
     else if ( not target_lonlat_fields_.empty() ) {
-        idx_t out_npts       = target_lonlat_fields_[0].shape( 0 );
-        const auto lon       = array::make_view<double, 1>( target_lonlat_fields_[LON] );
-        const auto lat       = array::make_view<double, 1>( target_lonlat_fields_[LAT] );
-        double convert_units = convert_units_multiplier( target_lonlat_fields_[LON] );
+        const auto lon = array::make_view<double, 1>( target_lonlat_fields_[LON] );
+        const auto lat = array::make_view<double, 1>( target_lonlat_fields_[LAT] );
+        auto lonlat = [lon, lat, convert_units = convert_units_] (idx_t n) {
+            return PointLonLat{lon(n) * convert_units, lat(n) * convert_units};
+        };
 
-        atlas_omp_parallel {
-            typename Kernel::Stencil stencil;
-            typename Kernel::Weights weights;
-            atlas_omp_for( idx_t n = 0; n < out_npts; ++n ) {
-                PointLonLat p{normalise(lon( n )) * convert_units, lat( n ) * convert_units};
-                kernel.compute_stencil( p.lon(), p.lat(), stencil );
-                kernel.compute_weights( p.lon(), p.lat(), stencil, weights );
-                for ( idx_t i = 0; i < N; ++i ) {
-                    kernel.interpolate( stencil, weights, src_view[i], tgt_view[i], n );
-                }
+        if( out_npts_ != 0) {
+            if ( target_ghost_ ) {
+                auto ghost     = array::make_view<int, 1>( target_ghost_ );
+                interpolate_omp(out_npts_, lonlat, ghost);
+            }
+            else {
+                auto no_ghost = [](idx_t n) { return false; };
+                interpolate_omp(out_npts_, lonlat, no_ghost);
             }
         }
+        handle_failed_points(*this, failed_points, lonlat);
     }
     else {
         ATLAS_NOTIMPLEMENTED;

--- a/src/atlas/interpolation/method/structured/StructuredInterpolation3D.tcc
+++ b/src/atlas/interpolation/method/structured/StructuredInterpolation3D.tcc
@@ -322,9 +322,9 @@ void StructuredInterpolation3D<Kernel>::execute_impl( const Kernel& kernel, cons
             typename Kernel::Weights weights;
             atlas_omp_for( idx_t n = 0; n < out_npts; ++n ) {
                 for ( idx_t k = 0; k < out_nlev; ++k ) {
-                    const double x = xcoords( n, k ) * convert_units;
-                    const double y = ycoords( n, k ) * convert_units;
-                    const double z = zcoords( n, k );
+                    double x = xcoords( n, k ) * convert_units;
+                    double y = ycoords( n, k ) * convert_units;
+                    double z = zcoords( n, k );
                     kernel.compute_stencil( x, y, z, stencil );
                     kernel.compute_weights( x, y, z, stencil, weights );
                     for ( idx_t i = 0; i < N; ++i ) {

--- a/src/atlas/interpolation/method/structured/kernels/Cubic3DKernel.h
+++ b/src/atlas/interpolation/method/structured/kernels/Cubic3DKernel.h
@@ -73,13 +73,13 @@ public:
     };
 
     template <typename stencil_t>
-    void compute_stencil(const double x, const double y, const double z, stencil_t& stencil) const {
+    void compute_stencil(double& x, const double y, const double z, stencil_t& stencil) const {
         horizontal_interpolation_.compute_stencil(x, y, stencil);
         vertical_interpolation_.compute_stencil(z, stencil);
     }
 
     template <typename weights_t>
-    void compute_weights(const double x, const double y, const double z, weights_t& weights) const {
+    void compute_weights(double x, double y, double z, weights_t& weights) const {
         Stencil stencil;
         compute_stencil(x, y, z, stencil);
         compute_weights(x, y, z, stencil, weights);

--- a/src/atlas/interpolation/method/structured/kernels/Linear3DKernel.h
+++ b/src/atlas/interpolation/method/structured/kernels/Linear3DKernel.h
@@ -65,13 +65,13 @@ public:
     };
 
     template <typename stencil_t>
-    void compute_stencil(const double x, const double y, const double z, stencil_t& stencil) const {
+    void compute_stencil(double& x, const double y, const double z, stencil_t& stencil) const {
         horizontal_interpolation_.compute_stencil(x, y, stencil);
         vertical_interpolation_.compute_stencil(z, stencil);
     }
 
     template <typename weights_t>
-    void compute_weights(const double x, const double y, const double z, weights_t& weights) const {
+    void compute_weights(double x, double y, const double z, weights_t& weights) const {
         Stencil stencil;
         compute_stencil(x, y, z, stencil);
         compute_weights(x, y, z, stencil, weights);

--- a/src/atlas/interpolation/method/structured/kernels/LinearHorizontalKernel.h
+++ b/src/atlas/interpolation/method/structured/kernels/LinearHorizontalKernel.h
@@ -64,12 +64,37 @@ public:
     };
 
     template <typename stencil_t>
-    void compute_stencil(const double x, const double y, stencil_t& stencil) const {
+    void compute_stencil(double& x, double y, stencil_t& stencil, bool retry = true) const {
         compute_horizontal_stencil_(x, y, stencil);
+        for (idx_t j = 0; j < stencil_width(); ++j) {
+            idx_t imin = stencil.i(0, j);
+            idx_t imax = stencil.i(stencil_width()-1, j);
+            if (imin < src_.i_begin_halo(stencil.j(j))) {
+                if (retry ) {
+                    x += 360.;
+                    compute_stencil(x, y, stencil, false);
+                }
+                else {
+                    Log::error() << "Stencil out of bounds" << std::endl;
+                    ATLAS_THROW_EXCEPTION("stencil out of bounds");
+                }
+            }
+            if (imax >= src_.i_end_halo(stencil.j(j))) {
+                if (retry ) {
+                    x -= 360.;
+                    compute_stencil(x, y, stencil, false);
+                }
+                else {
+                    Log::error() << "Stencil out of bounds" << std::endl;
+                    ATLAS_THROW_EXCEPTION("Stencil out of bounds");
+                }
+            }
+        }
     }
 
+
     template <typename weights_t>
-    void compute_weights(const double x, const double y, weights_t& weights) const {
+    void compute_weights(double x, double y, weights_t& weights) const {
         Stencil stencil;
         compute_stencil(x, y, stencil);
         compute_weights(x, y, stencil, weights);
@@ -156,18 +181,18 @@ public:
     }
 
     template <typename array_t>
-    typename array_t::value_type operator()(const double x, const double y, const array_t& input) const {
+    typename array_t::value_type operator()(double x, double y, const array_t& input) const {
         Stencil stencil;
-        compute_stencil(x, y, stencil);
         Weights weights;
+        compute_stencil(x, y, stencil);
         compute_weights(x, y, stencil, weights);
         return interpolate(stencil, weights, input);
     }
 
     template <typename array_t>
-    typename array_t::value_type interpolate(const PointLonLat& p, const array_t& input, WorkSpace& ws) const {
-        compute_stencil(p.lon(), p.lat(), ws.stencil);
-        compute_weights(p.lon(), p.lat(), ws.stencil, ws.weights);
+    typename array_t::value_type interpolate(PointXY p, const array_t& input, WorkSpace& ws) const {
+        compute_stencil(p.x(), p.y(), ws.stencil);
+        compute_weights(p.x(), p.y(), ws.stencil, ws.weights);
         return interpolate(ws.stencil, ws.weights, input);
     }
 
@@ -191,8 +216,8 @@ public:
         insert_triplets(row, p.x(), p.y(), triplets, ws);
     }
 
-    void insert_triplets(const idx_t row, const double x, const double y, Triplets& triplets, WorkSpace& ws) const {
-        compute_horizontal_stencil_(x, y, ws.stencil);
+    void insert_triplets(const idx_t row, double x, double y, Triplets& triplets, WorkSpace& ws) const {
+        compute_stencil(x, y, ws.stencil, true);
         compute_weights(x, y, ws.stencil, ws.weights);
         const auto& wj = ws.weights.weights_j;
 

--- a/src/atlas/interpolation/method/structured/kernels/QuasiCubic3DKernel.h
+++ b/src/atlas/interpolation/method/structured/kernels/QuasiCubic3DKernel.h
@@ -89,13 +89,13 @@ public:
     };
 
     template <typename stencil_t>
-    void compute_stencil(const double x, const double y, const double z, stencil_t& stencil) const {
+    void compute_stencil(double& x, const double y, const double z, stencil_t& stencil) const {
         quasi_cubic_horizontal_interpolation_.compute_stencil(x, y, stencil);
         vertical_interpolation_.compute_stencil(z, stencil);
     }
 
     template <typename weights_t>
-    void compute_weights(const double x, const double y, const double z, weights_t& weights) const {
+    void compute_weights(double x, double y, double z, weights_t& weights) const {
         Stencil stencil;
         compute_stencil(x, y, z, stencil);
         compute_weights(x, y, z, stencil, weights);

--- a/src/atlas/interpolation/method/structured/kernels/QuasiCubicHorizontalKernel.h
+++ b/src/atlas/interpolation/method/structured/kernels/QuasiCubicHorizontalKernel.h
@@ -74,12 +74,37 @@ public:
     };
 
     template <typename stencil_t>
-    void compute_stencil(const double x, const double y, stencil_t& stencil) const {
+    void compute_stencil(double& x, const double y, stencil_t& stencil, bool retry = true) const {
         compute_horizontal_stencil_(x, y, stencil);
+        for (idx_t j = 0; j < stencil_width(); ++j) {
+            idx_t imin = stencil.i(0, j);
+            idx_t imax = stencil.i(stencil_width()-1, j);
+            if (imin < src_.i_begin_halo(stencil.j(j))) {
+                if (retry ) {
+                    x += 360.;
+                    compute_stencil(x, y, stencil, false);
+                }
+                else {
+                    Log::error() << "Stencil out of bounds" << std::endl;
+                    ATLAS_THROW_EXCEPTION("stencil out of bounds");
+                }
+            }
+            if (imax >= src_.i_end_halo(stencil.j(j))) {
+                if (retry ) {
+                    x -= 360.;
+                    compute_stencil(x, y, stencil, false);
+                }
+                else {
+                    Log::error() << "Stencil out of bounds" << std::endl;
+                    ATLAS_THROW_EXCEPTION("Stencil out of bounds");
+                }
+            }
+        }
+
     }
 
     template <typename weights_t>
-    void compute_weights(const double x, const double y, weights_t& weights) const {
+    void compute_weights(double x, double y, weights_t& weights) const {
         Stencil stencil;
         compute_stencil(x, y, stencil);
         compute_weights(x, y, stencil, weights);
@@ -255,7 +280,7 @@ public:
     }
 
     template <typename array_t>
-    typename array_t::value_type operator()(const double x, const double y, const array_t& input) const {
+    typename array_t::value_type operator()(double x, double y, const array_t& input) const {
         Stencil stencil;
         compute_stencil(x, y, stencil);
         Weights weights;
@@ -264,9 +289,9 @@ public:
     }
 
     template <typename array_t>
-    typename array_t::value_type interpolate(const PointLonLat& p, const array_t& input, WorkSpace& ws) const {
-        compute_stencil(p.lon(), p.lat(), ws.stencil);
-        compute_weights(p.lon(), p.lat(), ws.stencil, ws.weights);
+    typename array_t::value_type interpolate(PointXY p, const array_t& input, WorkSpace& ws) const {
+        compute_stencil(p.x(), p.y(), ws.stencil);
+        compute_weights(p.x(), p.y(), ws.stencil, ws.weights);
         return interpolate(ws.stencil, ws.weights, input);
     }
 
@@ -290,8 +315,8 @@ public:
         insert_triplets(row, p.x(), p.y(), triplets, ws);
     }
 
-    void insert_triplets(const idx_t row, const double x, const double y, Triplets& triplets, WorkSpace& ws) const {
-        compute_horizontal_stencil_(x, y, ws.stencil);
+    void insert_triplets(const idx_t row, double x, double y, Triplets& triplets, WorkSpace& ws) const {
+        compute_stencil(x, y, ws.stencil);
         compute_weights(x, y, ws.stencil, ws.weights);
         const auto& wj = ws.weights.weights_j;
 

--- a/src/atlas/util/Config.cc
+++ b/src/atlas/util/Config.cc
@@ -109,9 +109,9 @@ std::vector<std::string> Config::keys() const {
     return result;
 }
 
-std::string Config::json() const {
+std::string Config::json(eckit::JSON::Formatting formatting) const {
     std::stringstream json;
-    eckit::JSON js(json);
+    eckit::JSON js(json,formatting);
     js << *this;
     return json.str();
 }

--- a/src/atlas/util/Config.h
+++ b/src/atlas/util/Config.h
@@ -13,6 +13,7 @@
 #include <string>
 
 #include "eckit/config/LocalConfiguration.h"
+#include "eckit/log/JSON.h"
 
 namespace eckit {
 class PathName;
@@ -77,7 +78,7 @@ public:
 
     std::vector<std::string> keys() const;
 
-    std::string json() const;
+    std::string json(eckit::JSON::Formatting = eckit::JSON::Formatting::indent()) const;
 };
 
 // ------------------------------------------------------------------

--- a/src/atlas/util/Polygon.cc
+++ b/src/atlas/util/Polygon.cc
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <iostream>
 #include <limits>
+#include <sstream>
 
 #include "eckit/types/FloatCompare.h"
 
@@ -278,6 +279,35 @@ Polygon::edge_set_t ExplicitPartitionPolygon::compute_edges(idx_t points_size) {
 
 void ExplicitPartitionPolygon::allGather(PartitionPolygons&) const {
     ATLAS_NOTIMPLEMENTED;
+}
+
+std::string PartitionPolygons::json(const eckit::Configuration& config) const {
+    std::ostringstream out;
+    out << "[\n";
+    for (size_t i=0; i<size(); ++i) {
+        out << at(i).json(config);
+        if (i<size()-1) {
+            out << ",\n";
+        }
+    }
+    out << "\n]";
+    return out.str();
+}
+
+
+std::string PartitionPolygon::json(const eckit::Configuration& ) const {
+    auto points = xy();
+    std::ostringstream out;
+    out << "[";
+    for (size_t i=0; i<points.size(); ++i) {
+        auto& p = points[i];
+        out << "["<< p[0] << "," << p[1] << "]";
+        if (i<points.size()-1) {
+            out << ",";
+        }
+    }
+    out << "]";
+    return out.str();
 }
 
 //------------------------------------------------------------------------------------------------------

--- a/src/atlas/util/Polygon.h
+++ b/src/atlas/util/Polygon.h
@@ -113,6 +113,9 @@ public:
     /// @brief Output a python script that plots the partition
     virtual void outputPythonScript(const eckit::PathName&, const eckit::Configuration& = util::NoConfig()) const {}
 
+    /// @brief Output a JSON file with partition polygons
+    virtual std::string json(const eckit::Configuration& = util::NoConfig()) const;
+
     /// @brief All (x,y) coordinates defining a polygon. Last point should match first.
     virtual PointsXY xy() const = 0;
 
@@ -152,7 +155,10 @@ private:
 
 //------------------------------------------------------------------------------------------------------
 
-class PartitionPolygons : public VectorOfAbstract<PartitionPolygon> {};
+class PartitionPolygons : public VectorOfAbstract<PartitionPolygon> {
+public:
+    std::string json(const eckit::Configuration& = util::NoConfig()) const;
+};
 
 //------------------------------------------------------------------------------------------------------
 

--- a/src/tests/interpolation/CMakeLists.txt
+++ b/src/tests/interpolation/CMakeLists.txt
@@ -102,6 +102,16 @@ ecbuild_add_test( TARGET atlas_test_interpolation_structured2D_to_unstructured
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )
 
+
+ecbuild_add_test( TARGET atlas_test_interpolation_structured2D_to_points
+  SOURCES  test_interpolation_structured2D_to_points.cc
+  LIBS     atlas
+  MPI      4
+  CONDITION eckit_HAVE_MPI
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
+
+
 ecbuild_add_test( TARGET atlas_test_interpolation_cubedsphere
   SOURCES  test_interpolation_cubedsphere.cc
   LIBS     atlas

--- a/src/tests/interpolation/test_interpolation_structured2D.cc
+++ b/src/tests/interpolation/test_interpolation_structured2D.cc
@@ -51,6 +51,7 @@ static Config scheme() {
         scheme.set("halo", 2);
     }
     scheme.set("name", scheme_str);
+    scheme.set("verbose",eckit::Resource<bool>("--verbose",false));
     return scheme;
 }
 

--- a/src/tests/interpolation/test_interpolation_structured2D_to_points.cc
+++ b/src/tests/interpolation/test_interpolation_structured2D_to_points.cc
@@ -1,0 +1,150 @@
+/*
+ * (C) Copyright 2013 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "atlas/array.h"
+#include "atlas/field/Field.h"
+#include "atlas/field/FieldSet.h"
+#include "atlas/functionspace/PointCloud.h"
+#include "atlas/functionspace/StructuredColumns.h"
+#include "atlas/grid/Grid.h"
+#include "atlas/grid/Iterator.h"
+#include "atlas/interpolation.h"
+#include "atlas/mesh/Mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/output/Gmsh.h"
+#include "atlas/util/CoordinateEnums.h"
+#include "atlas/util/function/VortexRollup.h"
+#include "atlas/util/PolygonXY.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using atlas::functionspace::PointCloud;
+using atlas::functionspace::StructuredColumns;
+using atlas::util::Config;
+
+namespace atlas {
+namespace test {
+
+//-----------------------------------------------------------------------------
+
+std::string input_gridname(const std::string& default_grid) {
+    return eckit::Resource<std::string>("--input-grid", default_grid);
+}
+
+FunctionSpace output_functionspace( const FunctionSpace& input_functionspace, bool expect_fail ) {
+
+    std::vector<PointXY> all_points {
+        {360., 90.},
+        {360., 0.},
+        {360., -90.},
+        {0.,0.},
+    };
+
+    // Only keep points that match the input partitioning.
+    // Note that with following implementation it could be that some points
+    // are present in two partitions, but it is not a problem for this test purpose.
+    std::vector<PointXY> points;
+    auto polygon = util::PolygonXY{input_functionspace.polygon()};
+    for (const auto& p : all_points ) {
+        if (polygon.contains(p)) {
+            points.emplace_back(p);
+        }
+    }
+    if( expect_fail && mpi::rank() == mpi::size() - 1 ) {
+        points.emplace_back(720,0.);
+    }
+    return PointCloud(points);
+}
+
+
+FieldSet create_source_fields(StructuredColumns& fs, idx_t nb_fields, idx_t nb_levels) {
+    using Value = double;
+    FieldSet fields_source;
+    auto lonlat = array::make_view<double, 2>(fs.xy());
+    for (idx_t f = 0; f < nb_fields; ++f) {
+        auto field_source = fields_source.add(fs.createField<Value>());
+        auto source       = array::make_view<Value, 2>(field_source);
+        for (idx_t n = 0; n < fs.size(); ++n) {
+            for (idx_t k = 0; k < nb_levels; ++k) {
+                source(n, k) = util::function::vortex_rollup(lonlat(n, LON), lonlat(n, LAT), 0.5 + double(k) / 2);
+            }
+        };
+    }
+    return fields_source;
+}
+FieldSet create_target_fields(FunctionSpace& fs, idx_t nb_fields, idx_t nb_levels) {
+    using Value = double;
+    FieldSet fields_target;
+    for (idx_t f = 0; f < nb_fields; ++f) {
+        fields_target.add(fs.createField<Value>(option::levels(nb_levels)));
+    }
+    return fields_target;
+}
+
+void do_test( std::string type, int input_halo, bool matrix_free, bool expect_failure ) {
+    idx_t nb_fields = 2;
+    idx_t nb_levels = 3;
+
+    Grid input_grid(input_gridname("O32"));
+    StructuredColumns input_fs(input_grid, option::levels(nb_levels) |
+        option::halo(input_halo));
+
+    FunctionSpace output_fs = output_functionspace(input_fs, expect_failure);
+
+    Interpolation interpolation(option::type(type) |
+        util::Config("matrix_free",matrix_free) |
+        util::Config("verbose",eckit::Resource<bool>("--verbose",false)),
+        input_fs, output_fs);
+
+    FieldSet fields_source = create_source_fields(input_fs, nb_fields, nb_levels);
+    FieldSet fields_target = create_target_fields(output_fs, nb_fields, nb_levels);
+
+    interpolation.execute(fields_source, fields_target);
+}
+
+CASE("test structured-bilinear, halo 2, with matrix") {
+    EXPECT_NO_THROW( do_test("structured-bilinear",2,false,false) );
+}
+
+CASE("test structured-bilinear, halo 2, without matrix") {
+    EXPECT_NO_THROW( do_test("structured-bilinear",2,true,false) );
+}
+
+CASE("test structured-bilinear, halo 2, with matrix, expected failure") {
+    EXPECT_THROWS_AS( do_test("structured-bilinear",2,false,true), eckit::Exception );
+}
+
+CASE("test structured-bilinear, halo 2, without matrix, expected failure") {
+    EXPECT_THROWS_AS( do_test("structured-bilinear",2,false,true), eckit::Exception );
+}
+
+CASE("test structured-bilinear, halo 1, with matrix, expected failure") {
+    EXPECT_THROWS_AS( do_test("structured-bilinear",1,false,false), eckit::Exception );
+}
+
+CASE("test structured-bilinear, halo 1, without matrix, expected failure") {
+    EXPECT_THROWS_AS( do_test("structured-bilinear",1,true,false), eckit::Exception );
+}
+
+CASE("test structured-bicubic, halo 3, with matrix") {
+    EXPECT_NO_THROW( do_test("structured-bicubic",3,false,false) );
+}
+
+CASE("test structured-bicubic, halo 2, with matrix") {
+    EXPECT_THROWS_AS( do_test("structured-bicubic",2,false,false), eckit::Exception );
+}
+
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}

--- a/src/tests/interpolation/test_interpolation_structured2D_to_unstructured.cc
+++ b/src/tests/interpolation/test_interpolation_structured2D_to_unstructured.cc
@@ -116,6 +116,9 @@ FieldSet create_target_fields(FunctionSpace& fs, idx_t nb_fields, idx_t nb_level
 
 
 CASE("test_match") {
+    if(mpi::size() > 2) {
+        return;
+    }
     idx_t nb_fields = 2;
     idx_t nb_levels = 3;
 
@@ -132,6 +135,10 @@ CASE("test_match") {
     interpolation.execute(fields_source, fields_target);
 }
 CASE("test_nomatch") {
+    if(mpi::size() > 2) {
+        return;
+    }
+
     idx_t nb_fields = 2;
     idx_t nb_levels = 3;
 
@@ -151,6 +158,29 @@ CASE("test_nomatch") {
     }
 }
 
+CASE("test_nomatch 2") {
+    if(mpi::size() > 2) {
+        return;
+    }
+
+    idx_t nb_fields = 2;
+    idx_t nb_levels = 3;
+
+    Grid input_grid(input_gridname("O32"));
+    StructuredColumns input_fs(input_grid, option::halo(1) | option::levels(nb_levels));
+
+    FunctionSpace output_fs = output_functionspace_nomatch();
+
+    if (false)  // expected to throw
+    {
+        Interpolation interpolation(option::type("structured-linear2D"), input_fs, output_fs);
+
+        FieldSet fields_source = create_source_fields(input_fs, nb_fields, nb_levels);
+        FieldSet fields_target = create_target_fields(output_fs, nb_fields, nb_levels);
+
+        interpolation.execute(fields_source, fields_target);
+    }
+}
 
 }  // namespace test
 }  // namespace atlas


### PR DESCRIPTION
A problem happens when interpolating to a point with (lon,lat) = (360,0) using StructuredInterpolation2D classes because the point gets normalised to the minimum longitude of the source grid domain, i.e. lon=0.

This PR fixes the issue and refactors the StructuredInterpolation2D completely, adding much better error reporting of failed points with nicer error messages and writing of output files containing debugging information to better analyse future issues.

Further noteworthy additions:
- StructuredColumns::polygon() to JSON with and without halo
