### PR TITLE
CI fix package modules input syntax

### DIFF
--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -21,8 +21,7 @@ jobs:
           ecbuild
           ninja
         --modules-package: |
-          fftw
-          eigen
+          atlas:fftw,eigen
         --dependencies: |
           ${{ inputs.eckit || 'ecmwf/eckit@develop' }}
         --parallel: 64


### PR DESCRIPTION
Fixes `--modules-package` input syntax for build-package-hpc. 