### PR TITLE
Optimise array::helpers::ForEach for small arrays.

### DIFF
--- a/src/atlas/array/helpers/ArrayForEach.h
+++ b/src/atlas/array/helpers/ArrayForEach.h
@@ -129,35 +129,24 @@ constexpr auto argPadding() {
   }
 }
 
-template<int Rank>
-struct GetRankImpl {
-  constexpr static int rank = Rank;
-};
-
 template<typename>
 struct GetRank;
 
 template<template <typename, int> typename View, typename Value, int Rank>
-struct GetRank<View<Value, Rank>> : GetRankImpl<Rank> {};
-template<template <typename, int> typename View, typename Value, int Rank>
-struct GetRank<View<Value, Rank>&> : GetRankImpl<Rank> {};
-template<template <typename, int> typename View, typename Value, int Rank>
-struct GetRank<const View<Value, Rank>&> : GetRankImpl<Rank> {};
-template<template <typename, int> typename View, typename Value, int Rank>
-struct GetRank<View<Value, Rank>&&> : GetRankImpl<Rank> {};
-template<template <typename, int> typename View, typename Value, int Rank>
-struct GetRank<const View<Value, Rank>&&> : GetRankImpl<Rank> {};
+struct GetRank<View<Value, Rank>> {
+  constexpr static int rank = Rank;
+};
 
 template <size_t ViewIdx = 0, typename... SlicerArgs, typename ArrayViewTuple>
 auto makeSlices(const std::tuple<SlicerArgs...>& slicerArgs,
                 ArrayViewTuple&& arrayViews) {
 
-  using ViewTupleType = std::decay_t<ArrayViewTuple>;
+  using ViewTupleType = std::remove_reference_t<ArrayViewTuple>;
 
   if constexpr(ViewIdx < std::tuple_size_v<ViewTupleType>) {
 
     auto&& view = std::get<ViewIdx>(arrayViews);
-    using View = std::tuple_element_t<ViewIdx, ViewTupleType>;
+    using View = std::decay_t<std::tuple_element_t<ViewIdx, ViewTupleType>>;
 
     constexpr auto Dim = sizeof...(SlicerArgs);
     constexpr auto Rank = GetRank<View>::rank;

--- a/src/atlas/array/helpers/ArrayForEach.h
+++ b/src/atlas/array/helpers/ArrayForEach.h
@@ -24,11 +24,10 @@ namespace atlas {
 namespace execution {
 
 // As in C++17 std::execution namespace. Note: unsequenced_policy is a C++20 addition.
-class policy_base {};
-class sequenced_policy : policy_base {};
-class unsequenced_policy : policy_base {};
-class parallel_unsequenced_policy : policy_base {};
-class parallel_policy : policy_base {};
+class sequenced_policy {};
+class unsequenced_policy {};
+class parallel_unsequenced_policy {};
+class parallel_policy {};
 
 // execution policy objects as in C++ std::execution namespace. Note: unseq is a C++20 addition.
 inline constexpr sequenced_policy            seq{ /*unspecified*/ };

--- a/src/atlas/array/helpers/ArrayForEach.h
+++ b/src/atlas/array/helpers/ArrayForEach.h
@@ -96,7 +96,7 @@ template <typename... Args>
 struct IsTupleImpl<std::tuple<Args...>> : std::true_type {};
 
 template <typename Tuple>
-constexpr auto IsTuple() {
+constexpr auto is_tuple() {
   return IsTupleImpl<Tuple>::value;
 }
 
@@ -252,7 +252,7 @@ struct ArrayForEach {
   ///         Note: The lowest ArrayView.rank() must be greater than or equal
   ///         to the highest dim in ItrDims. TODO: static checking for this.
   template <typename ArrayViewTuple, typename Mask, typename Function,
-            typename = std::enable_if_t<detail::IsTuple<ArrayViewTuple>()>>
+            typename = std::enable_if_t<detail::is_tuple<ArrayViewTuple>()>>
   static void apply(const eckit::Parametrisation& conf,
                     ArrayViewTuple&& arrayViews,
                     const Mask& mask, const Function& function) {
@@ -284,7 +284,7 @@ struct ArrayForEach {
   /// details As above, but Execution policy is determined at compile-time.
   template <typename ExecutionPolicy, typename ArrayViewTuple, typename Mask, typename Function,
             typename = std::enable_if_t<execution::is_execution_policy<ExecutionPolicy>()>,
-            typename = std::enable_if_t<detail::IsTuple<ArrayViewTuple>()>>
+            typename = std::enable_if_t<detail::is_tuple<ArrayViewTuple>()>>
   static void apply(ExecutionPolicy, ArrayViewTuple&& arrayViews, const Mask& mask, const Function& function) {
 
     detail::ArrayForEachImpl<ExecutionPolicy, 0, ItrDims...>::apply(
@@ -295,7 +295,7 @@ struct ArrayForEach {
   ///
   /// detials Apply ForEach with default execution policy.
   template <typename ArrayViewTuple, typename Mask, typename Function,
-            typename = std::enable_if_t<detail::IsTuple<ArrayViewTuple>()>>
+            typename = std::enable_if_t<detail::is_tuple<ArrayViewTuple>()>>
   static void apply(ArrayViewTuple&& arrayViews, const Mask& mask, const Function& function) {
       apply(std::forward<ArrayViewTuple>(arrayViews), mask, function);
   }
@@ -304,7 +304,7 @@ struct ArrayForEach {
   ///
   /// detials Apply ForEach with run-time determined execution policy and no mask.
   template <typename ArrayViewTuple, typename Function,
-            typename = std::enable_if_t<detail::IsTuple<ArrayViewTuple>()>>
+            typename = std::enable_if_t<detail::is_tuple<ArrayViewTuple>()>>
   static void apply(const eckit::Parametrisation& conf, ArrayViewTuple&& arrayViews, const Function& function) {
     constexpr auto no_mask = [](auto args...) { return 0; };
     apply(conf, std::forward<ArrayViewTuple>(arrayViews), no_mask, function);
@@ -314,7 +314,7 @@ struct ArrayForEach {
   ///
   /// detials Apply ForEach with compile-time determined execution policy and no mask.
   template <typename ExecutionPolicy, typename ArrayViewTuple, typename Function,
-            typename = std::enable_if_t<detail::IsTuple<ArrayViewTuple>()>,
+            typename = std::enable_if_t<detail::is_tuple<ArrayViewTuple>()>,
             typename = std::enable_if_t<execution::is_execution_policy<ExecutionPolicy>()>>
   static void apply(ExecutionPolicy executionPolicy, ArrayViewTuple&& arrayViews, const Function& function) {
     constexpr auto no_mask = [](auto args...) { return 0; };
@@ -325,7 +325,7 @@ struct ArrayForEach {
   ///
   /// detials Apply ForEach with default execution policy and no mask.
   template <typename ArrayViewTuple, typename Function,
-            typename = std::enable_if_t<detail::IsTuple<ArrayViewTuple>()>>
+            typename = std::enable_if_t<detail::is_tuple<ArrayViewTuple>()>>
   static void apply(ArrayViewTuple arrayViews, const Function& function) {
     apply(execution::par_unseq, std::forward<ArrayViewTuple>(arrayViews), function);
   }

--- a/src/atlas/array/helpers/ArrayForEach.h
+++ b/src/atlas/array/helpers/ArrayForEach.h
@@ -12,11 +12,9 @@
 #include <string_view>
 
 #include "atlas/array/ArrayView.h"
-#include "atlas/array/IndexView.h"
 #include "atlas/array/Range.h"
 #include "atlas/array/helpers/ArraySlicer.h"
 #include "atlas/parallel/omp/omp.h"
-#include "atlas/runtime/Exception.h"
 #include "atlas/util/Config.h"
 
 namespace atlas {

--- a/src/tests/array/test_array_foreach.cc
+++ b/src/tests/array/test_array_foreach.cc
@@ -33,20 +33,20 @@ CASE("test_array_foreach_1_view") {
     EXPECT_EQUAL(slice.rank(), 1);
     EXPECT_EQUAL(slice.shape(0), 3);
   };
-  ArrayForEach<0>::apply(std::make_tuple(view), loopFunctorDim0);
+  ArrayForEach<0>::apply(std::tie(view), loopFunctorDim0);
 
   const auto loopFunctorDim1 = [](auto& slice) {
     EXPECT_EQUAL(slice.rank(), 1);
     EXPECT_EQUAL(slice.shape(0), 2);
   };
-  ArrayForEach<1>::apply(std::make_tuple(view), loopFunctorDim1);
+  ArrayForEach<1>::apply(std::tie(view), loopFunctorDim1);
 
   // Test that slice resolves to double.
 
   const auto loopFunctorDimAll = [](auto& slice) {
     static_assert(std::is_convertible_v<decltype(slice), const double&>);
   };
-  ArrayForEach<0, 1>::apply(std::make_tuple(view), loopFunctorDimAll);
+  ArrayForEach<0, 1>::apply(std::tie(view), loopFunctorDimAll);
 
   // Test ghost functionality.
 
@@ -56,7 +56,7 @@ CASE("test_array_foreach_1_view") {
 
   auto count = int {};
   const auto countNonGhosts = [&count](auto&...) { ++count; };
-  ArrayForEach<0>::apply(execution::seq, std::make_tuple(view), ghostView, countNonGhosts);
+  ArrayForEach<0>::apply(execution::seq, std::tie(view), ghostView, countNonGhosts);
   EXPECT_EQ(count, 1);
 
   count = 0;
@@ -64,7 +64,7 @@ CASE("test_array_foreach_1_view") {
     // Wrap ghostView to use correct number of indices.
     return ghostView(idx);
   };
-  ArrayForEach<0, 1>::apply(execution::seq, std::make_tuple(view), ghostWrap, countNonGhosts);
+  ArrayForEach<0, 1>::apply(execution::seq, std::tie(view), ghostWrap, countNonGhosts);
   EXPECT_EQ(count, 3);
 }
 
@@ -86,7 +86,7 @@ CASE("test_array_foreach_2_views") {
     EXPECT_EQUAL(slice2.shape(0), 3);
     EXPECT_EQUAL(slice2.shape(1), 4);
   };
-  ArrayForEach<0>::apply(std::make_tuple(view1, view2), loopFunctorDim0);
+  ArrayForEach<0>::apply(std::tie(view1, view2), loopFunctorDim0);
 
   const auto loopFunctorDim1 = [](auto& slice1, auto& slice2) {
     EXPECT_EQUAL(slice1.rank(), 1);
@@ -96,14 +96,14 @@ CASE("test_array_foreach_2_views") {
     EXPECT_EQUAL(slice2.shape(0), 2);
     EXPECT_EQUAL(slice2.shape(1), 4);
   };
-  ArrayForEach<1>::apply(std::make_tuple(view1, view2), loopFunctorDim1);
+  ArrayForEach<1>::apply(std::tie(view1, view2), loopFunctorDim1);
 
   // Test that slice resolves to double.
 
   const auto loopFunctorDimAll = [](auto& slice2) {
     static_assert(std::is_convertible_v<decltype(slice2), const double&>);
   };
-  ArrayForEach<0, 1, 2>::apply(std::make_tuple(view2), loopFunctorDimAll);
+  ArrayForEach<0, 1, 2>::apply(std::tie(view2), loopFunctorDimAll);
 
   // Test ghost functionality.
 
@@ -113,7 +113,7 @@ CASE("test_array_foreach_2_views") {
 
   auto count = int {};
   const auto countNonGhosts = [&count](auto&...) { ++count; };
-  ArrayForEach<0>::apply(execution::seq, std::make_tuple(view2), ghostView, countNonGhosts);
+  ArrayForEach<0>::apply(execution::seq, std::tie(view2), ghostView, countNonGhosts);
   EXPECT_EQ(count, 1);
 
   count = 0;
@@ -121,11 +121,11 @@ CASE("test_array_foreach_2_views") {
     // Wrap ghostView to use correct number of indices.
     return ghostView(idx);
   };
-  ArrayForEach<0, 1>::apply(execution::seq, std::make_tuple(view2), ghostWrap, countNonGhosts);
+  ArrayForEach<0, 1>::apply(execution::seq, std::tie(view2), ghostWrap, countNonGhosts);
   EXPECT_EQ(count, 3);
 
   count = 0;
-  ArrayForEach<0, 1, 2>::apply(execution::seq, std::make_tuple(view2), ghostWrap, countNonGhosts);
+  ArrayForEach<0, 1, 2>::apply(execution::seq, std::tie(view2), ghostWrap, countNonGhosts);
   EXPECT_EQ(count, 12);
 }
 
@@ -155,7 +155,7 @@ CASE("test_array_foreach_3_views") {
     EXPECT_EQUAL(slice3.shape(1), 4);
     EXPECT_EQUAL(slice3.shape(2), 5);
   };
-  ArrayForEach<0>::apply(std::make_tuple(view1, view2, view3), loopFunctorDim0);
+  ArrayForEach<0>::apply(std::tie(view1, view2, view3), loopFunctorDim0);
 
   const auto loopFunctorDim1 = [](auto& slice1, auto& slice2, auto& slice3) {
     EXPECT_EQUAL(slice1.rank(), 1);
@@ -170,14 +170,14 @@ CASE("test_array_foreach_3_views") {
     EXPECT_EQUAL(slice3.shape(1), 4);
     EXPECT_EQUAL(slice3.shape(2), 5);
   };
-  ArrayForEach<1>::apply(std::make_tuple(view1, view2, view3), loopFunctorDim1);
+  ArrayForEach<1>::apply(std::tie(view1, view2, view3), loopFunctorDim1);
 
   // Test that slice resolves to double.
 
   const auto loopFunctorDimAll = [](auto& slice3) {
     static_assert(std::is_convertible_v<decltype(slice3), const double&>);
   };
-  ArrayForEach<0, 1, 2, 3>::apply(std::make_tuple(view3), loopFunctorDimAll);
+  ArrayForEach<0, 1, 2, 3>::apply(std::tie(view3), loopFunctorDimAll);
 
   // Test ghost functionality.
 
@@ -187,7 +187,7 @@ CASE("test_array_foreach_3_views") {
 
   auto count = int {};
   const auto countNonGhosts = [&count](auto&...) { ++count; };
-  ArrayForEach<0>::apply(execution::seq, std::make_tuple(view3), ghostView, countNonGhosts);
+  ArrayForEach<0>::apply(execution::seq, std::tie(view3), ghostView, countNonGhosts);
   EXPECT_EQ(count, 1);
 
   count = 0;
@@ -195,16 +195,39 @@ CASE("test_array_foreach_3_views") {
     // Wrap ghostView to use correct number of indices.
     return ghostView(idx);
   };
-  ArrayForEach<0, 1>::apply(execution::seq, std::make_tuple(view3), ghostWrap, countNonGhosts);
+  ArrayForEach<0, 1>::apply(execution::seq, std::tie(view3), ghostWrap, countNonGhosts);
   EXPECT_EQ(count, 3);
 
   count = 0;
-  ArrayForEach<0, 1, 2>::apply(execution::seq, std::make_tuple(view3), ghostWrap, countNonGhosts);
+  ArrayForEach<0, 1, 2>::apply(execution::seq, std::tie(view3), ghostWrap, countNonGhosts);
   EXPECT_EQ(count, 12);
 
   count = 0;
-  ArrayForEach<0, 1, 2, 3>::apply(execution::seq, std::make_tuple(view3), ghostWrap, countNonGhosts);
+  ArrayForEach<0, 1, 2, 3>::apply(execution::seq, std::tie(view3), ghostWrap, countNonGhosts);
   EXPECT_EQ(count, 60);
+}
+
+
+CASE("test_array_foreach_forwarding") {
+
+  const auto arr1 = ArrayT<double>(2, 3);
+  const auto view1 = make_view<double, 2>(arr1);
+
+  auto arr2 = ArrayT<double>(2, 3, 4);
+  auto view2 = make_view<double, 3>(arr2);
+
+  const auto loopFunctorDim0 = [](auto& slice1, auto& slice2) {
+    EXPECT_EQUAL(slice1.rank(), 1);
+    EXPECT_EQUAL(slice1.shape(0), 3);
+
+    EXPECT_EQUAL(slice2.rank(), 2);
+    EXPECT_EQUAL(slice2.shape(0), 3);
+    EXPECT_EQUAL(slice2.shape(1), 4);
+  };
+
+  ArrayForEach<0>::apply(std::make_tuple(view1, view2), loopFunctorDim0);
+  ArrayForEach<0>::apply(std::tie(view1, view2), loopFunctorDim0);
+  ArrayForEach<0>::apply(std::forward_as_tuple(view1, view2), loopFunctorDim0);
 }
 
 CASE("test_array_foreach_data_integrity") {
@@ -233,9 +256,9 @@ CASE("test_array_foreach_data_integrity") {
       static_assert(std::is_convertible_v<decltype(slice), double&>);
       slice *= 3.;
     };
-    ArrayForEach<0>::apply(execution::seq, std::make_tuple(slice2), scaleDataDim1);
+    ArrayForEach<0>::apply(execution::seq, std::tie(slice2), scaleDataDim1);
   };
-  ArrayForEach<0, 1>::apply(std::make_tuple(view1, view2), scaleDataDim0);
+  ArrayForEach<0, 1>::apply(std::tie(view1, view2), scaleDataDim0);
 
   for (auto idx = size_t{}; idx < arr1.size(); ++idx) {
     EXPECT_EQ(static_cast<double*>(arr1.data())[idx], 2. * idx);
@@ -345,7 +368,7 @@ CASE("test_array_foreach_performance") {
         operation(slice1(idx), slice2(idx), slice3(idx));
       }
     };
-    ArrayForEach<0>::apply(execution::seq, std::make_tuple(view1, view2, view3), function);
+    ArrayForEach<0>::apply(execution::seq, std::tie(view1, view2, view3), function);
   };
 
   const auto forEachLevel = [&](const auto& operation) {
@@ -355,18 +378,18 @@ CASE("test_array_foreach_performance") {
         operation(slice1(idx), slice2(idx), slice3(idx));
       }
     };
-    ArrayForEach<1>::apply(execution::seq, std::make_tuple(view1, view2, view3), function);
+    ArrayForEach<1>::apply(execution::seq, std::tie(view1, view2, view3), function);
   };
 
   const auto forEachAll = [&](const auto& operation) {
-    ArrayForEach<0, 1>::apply(execution::seq, std::make_tuple(view1, view2, view3), operation);
+    ArrayForEach<0, 1>::apply(execution::seq, std::tie(view1, view2, view3), operation);
   };
 
   const auto forEachNested = [&](const auto& operation) {
       const auto function = [&](auto& slice1, auto& slice2, auto& slice3) {
-          ArrayForEach<0>::apply(execution::seq, std::forward_as_tuple(slice1, slice2, slice3), operation);
+          ArrayForEach<0>::apply(execution::seq, std::tie(slice1, slice2, slice3), operation);
       };
-      ArrayForEach<0>::apply(execution::seq, std::forward_as_tuple(view1, view2, view3), function);
+      ArrayForEach<0>::apply(execution::seq, std::tie(view1, view2, view3), function);
   };
 
   double baseline;

--- a/src/tests/array/test_array_foreach.cc
+++ b/src/tests/array/test_array_foreach.cc
@@ -362,7 +362,12 @@ CASE("test_array_foreach_performance") {
     ArrayForEach<0, 1>::apply(execution::seq, std::make_tuple(view1, view2, view3), operation);
   };
 
-
+  const auto forEachNested = [&](const auto& operation) {
+      const auto function = [&](auto& slice1, auto& slice2, auto& slice3) {
+          ArrayForEach<0>::apply(execution::seq, std::forward_as_tuple(slice1, slice2, slice3), operation);
+      };
+      ArrayForEach<0>::apply(execution::seq, std::forward_as_tuple(view1, view2, view3), function);
+  };
 
   double baseline;
   baseline = timeLoop(rawPointer, num_iter, num_first, add, 0, "Addition; raw pointer             ");
@@ -371,6 +376,7 @@ CASE("test_array_foreach_performance") {
   timeLoop(forEachCol, num_iter, num_first, add, baseline, "Addition; for each (columns)      ");
   timeLoop(forEachLevel, num_iter, num_first, add, baseline, "Addition; for each (levels)       ");
   timeLoop(forEachAll, num_iter, num_first, add, baseline, "Addition; for each (all elements) ");
+  timeLoop(forEachNested, num_iter, num_first, add, baseline, "Addition; for each (nested)       ");
   Log::info() << std::endl;
 
   num_first = 2;
@@ -381,6 +387,7 @@ CASE("test_array_foreach_performance") {
   timeLoop(forEachCol, num_iter, num_first, trig, baseline, "Trig    ; for each (columns)      ");
   timeLoop(forEachLevel, num_iter, num_first, trig, baseline, "Trig    ; for each (levels)       ");
   timeLoop(forEachAll, num_iter, num_first, trig, baseline, "Trig    ; for each (all elements) ");
+  timeLoop(forEachNested, num_iter, num_first, trig, baseline, "Trig    ; for each (nested)       ");
 }
 
 }  // namespace test

--- a/src/tests/array/test_array_foreach.cc
+++ b/src/tests/array/test_array_foreach.cc
@@ -392,25 +392,34 @@ CASE("test_array_foreach_performance") {
       ArrayForEach<0>::apply(execution::seq, std::tie(view1, view2, view3), function);
   };
 
+  const auto forEachConf = [&](const auto& operation) {
+      const auto function = [&](auto& slice1, auto& slice2, auto& slice3) {
+          ArrayForEach<0>::apply(option::execution_policy(execution::seq), std::tie(slice1, slice2, slice3), operation);
+      };
+      ArrayForEach<0>::apply(option::execution_policy(execution::seq), std::tie(view1, view2, view3), function);
+  };
+
   double baseline;
-  baseline = timeLoop(rawPointer, num_iter, num_first, add, 0, "Addition; raw pointer             ");
-  timeLoop(ijLoop, num_iter, num_first, add, baseline, "Addition; for loop (i, j)         ");
-  timeLoop(jiLoop, num_iter, num_first, add, baseline, "Addition; for loop (j, i)         ");
-  timeLoop(forEachCol, num_iter, num_first, add, baseline, "Addition; for each (columns)      ");
-  timeLoop(forEachLevel, num_iter, num_first, add, baseline, "Addition; for each (levels)       ");
-  timeLoop(forEachAll, num_iter, num_first, add, baseline, "Addition; for each (all elements) ");
-  timeLoop(forEachNested, num_iter, num_first, add, baseline, "Addition; for each (nested)       ");
+  baseline = timeLoop(rawPointer, num_iter, num_first, add, 0, "Addition; raw pointer               ");
+  timeLoop(ijLoop, num_iter, num_first, add, baseline, "Addition; for loop (i, j)           ");
+  timeLoop(jiLoop, num_iter, num_first, add, baseline, "Addition; for loop (j, i)           ");
+  timeLoop(forEachCol, num_iter, num_first, add, baseline, "Addition; for each (columns)        ");
+  timeLoop(forEachLevel, num_iter, num_first, add, baseline, "Addition; for each (levels)         ");
+  timeLoop(forEachAll, num_iter, num_first, add, baseline, "Addition; for each (all elements)   ");
+  timeLoop(forEachNested, num_iter, num_first, add, baseline, "Addition; for each (nested)         ");
+  timeLoop(forEachConf, num_iter, num_first, add, baseline, "Addition; for each (nested, config) ");
   Log::info() << std::endl;
 
   num_first = 2;
   num_iter = 5;
-  baseline = timeLoop(rawPointer, num_iter, num_first, trig, 0, "Trig    ; raw pointer             ");
-  timeLoop(ijLoop, num_iter, num_first, trig, baseline, "Trig    ; for loop (i, j)         ");
-  timeLoop(jiLoop, num_iter, num_first, trig, baseline, "Trig    ; for loop (j, i)         ");
-  timeLoop(forEachCol, num_iter, num_first, trig, baseline, "Trig    ; for each (columns)      ");
-  timeLoop(forEachLevel, num_iter, num_first, trig, baseline, "Trig    ; for each (levels)       ");
-  timeLoop(forEachAll, num_iter, num_first, trig, baseline, "Trig    ; for each (all elements) ");
-  timeLoop(forEachNested, num_iter, num_first, trig, baseline, "Trig    ; for each (nested)       ");
+  baseline = timeLoop(rawPointer, num_iter, num_first, trig, 0, "Trig    ; raw pointer               ");
+  timeLoop(ijLoop, num_iter, num_first, trig, baseline, "Trig    ; for loop (i, j)           ");
+  timeLoop(jiLoop, num_iter, num_first, trig, baseline, "Trig    ; for loop (j, i)           ");
+  timeLoop(forEachCol, num_iter, num_first, trig, baseline, "Trig    ; for each (columns)        ");
+  timeLoop(forEachLevel, num_iter, num_first, trig, baseline, "Trig    ; for each (levels)         ");
+  timeLoop(forEachAll, num_iter, num_first, trig, baseline, "Trig    ; for each (all elements)   ");
+  timeLoop(forEachNested, num_iter, num_first, trig, baseline, "Trig    ; for each (nested)         ");
+  timeLoop(forEachConf, num_iter, num_first, trig, baseline, "Trig    ; for each (nested, config) ");
 }
 
 }  // namespace test


### PR DESCRIPTION
Hi @wdeconinck,

I've found that the array ForEach method is particularly slow when processing small arrays (tested on N = 100). I believe this is because processing `execution_policy` configs has a relatively high amount overhead.

I've done a couple of things to alleviate this:
1) allowed `constexpr` policy selection when you provide an `execution_policy` object.
2) implemented perfect forwarding on the ArrayView objects (I don't think this did much, but it was useful to learn how to do it!)

I've added two performance tests :
1) `nested` performs a `ForEach` over the 50000 columns and another ForEach over the 100 levels. Execution policy selection is `constexpr`.
2) `nested, config`. Does the same as above, but determines the policy via a config.

```
Elapsed time: Addition; raw pointer               = 0.0091302s
Elapsed time: Addition; for loop (i, j)           = 0.00921452s	;   relative to baseline : 100.924%
Elapsed time: Addition; for loop (j, i)           = 0.0478493s	;   relative to baseline : 524.077%
Elapsed time: Addition; for each (columns)        = 0.00907069s	;   relative to baseline : 99.3483%
Elapsed time: Addition; for each (levels)         = 0.0481194s	;   relative to baseline : 527.036%
Elapsed time: Addition; for each (all elements)   = 0.00914668s	;   relative to baseline : 100.181%
Elapsed time: Addition; for each (nested)         = 0.00920637s	;   relative to baseline : 100.834%
Elapsed time: Addition; for each (nested, config) = 0.118888s	;   relative to baseline : 1302.14%

Elapsed time: Trig    ; raw pointer               = 0.312925s
Elapsed time: Trig    ; for loop (i, j)           = 0.319474s	;   relative to baseline : 102.093%
Elapsed time: Trig    ; for loop (j, i)           = 0.502402s	;   relative to baseline : 160.55%
Elapsed time: Trig    ; for each (columns)        = 0.316493s	;   relative to baseline : 101.14%
Elapsed time: Trig    ; for each (levels)         = 0.435909s	;   relative to baseline : 139.301%
Elapsed time: Trig    ; for each (all elements)   = 0.315607s	;   relative to baseline : 100.857%
Elapsed time: Trig    ; for each (nested)         = 0.318103s	;   relative to baseline : 101.655%
Elapsed time: Trig    ; for each (nested, config) = 0.431594s	;   relative to baseline : 137.923%
```

As you can see, the benefit of using a `constexpr` execution policy is quite dramatic when performing a large number calls on small array sizes.

Thankfully, the config overhead is negligible when dealing with normal-sized NWP fields.

The only (intended) change to the interface is that you can now supply ArrayViews to the ForEach::Apply method using `std::tie` and `std::forward_as_tuple` as well as `std::make_tuple`.

closes #134 