### PR TITLE
Enable latitude normalisation in KDTree coordinate transform

### DIFF
--- a/src/atlas/util/Geometry.h
+++ b/src/atlas/util/Geometry.h
@@ -72,7 +72,7 @@ class GeometrySphere : public GeometryBase {
 public:
     GeometrySphere(double radius): radius_(radius) {}
     void lonlat2xyz(const Point2& lonlat, Point3& xyz) const override {
-        Sphere::convertSphericalToCartesian(radius_, lonlat, xyz);
+        Sphere::convertSphericalToCartesian(radius_, lonlat, xyz, 0., true);
     }
     void xyz2lonlat(const Point3& xyz, Point2& lonlat) const override {
         Sphere::convertCartesianToSpherical(radius_, xyz, lonlat);


### PR DESCRIPTION
Depends on https://github.com/ecmwf/eckit/pull/68

Similar changes could be made in many places where `convertSphericalToCartesian` is called, but I wanted to start modest: this is the call that prevents an atlas KDTree from being constructed with an atlas Gaussian grid + structured mesh halo points.