### PR TITLE
Feature/field for each gnu730

### DIFF
--- a/src/atlas/array/helpers/ArrayForEach.h
+++ b/src/atlas/array/helpers/ArrayForEach.h
@@ -9,6 +9,7 @@
 
 #include <tuple>
 #include <type_traits>
+#include <sstream>
 #include <string_view>
 
 #include "atlas/array/ArrayView.h"
@@ -167,6 +168,8 @@ auto makeSlices(const std::tuple<SlicerArgs...>& slicerArgs,
 
   constexpr auto Dim    = sizeof...(SlicerArgs);
   constexpr auto Rank   = ArrayView::rank();
+
+  static_assert (Dim <= Rank, "Error: number of slicer arguments exceeds the rank of ArrayView.");
   const auto paddedArgs = std::tuple_cat(slicerArgs, argPadding<Rank - Dim>());
 
   const auto slicer = [&arrayView](const auto&... args) {
@@ -217,31 +220,6 @@ struct ArrayForEachImpl<ExecutionPolicy, Dim, ItrDim, ItrDims...> {
           maskArgs);
     }
   }
-
-  template <typename ArrayViewTuple,typename Function, typename... SlicerArgs>
-  static void apply(ArrayViewTuple&& arrayViews,
-                    const Function& function,
-                    const std::tuple<SlicerArgs...>& slicerArgs) {
-    // Iterate over this dimension.
-    if constexpr(Dim == ItrDim) {
-
-      // Get size of iteration dimenion from first view argument.
-      const auto idxMax = std::get<0>(arrayViews).shape(ItrDim);
-
-      forEach<ExecutionPolicy>(idxMax, [&](idx_t idx) {
-          // Demote parallel execution policy to a non-parallel one in further recursion
-          ArrayForEachImpl<execution::demote_policy_t<ExecutionPolicy>, Dim + 1, ItrDims...>::apply(
-              std::forward<ArrayViewTuple>(arrayViews), function,
-              tuplePushBack(slicerArgs, idx));
-      });
-    }
-    // Add a RangeAll to arguments.
-    else {
-      ArrayForEachImpl<ExecutionPolicy, Dim + 1, ItrDim, ItrDims...>::apply(
-          std::forward<ArrayViewTuple>(arrayViews), function,
-          tuplePushBack(slicerArgs, Range::all()));
-    }
-  }
 };
 
 template <typename...>
@@ -255,6 +233,7 @@ inline constexpr bool is_applicable_v = is_applicable<Function,Tuple>::value;
 
 template <typename ExecutionPolicy, int Dim>
 struct ArrayForEachImpl<ExecutionPolicy, Dim> {
+
   template <typename ArrayViewTuple, typename Mask, typename Function,
             typename... SlicerArgs, typename... MaskArgs>
   static void apply(ArrayViewTuple&& arrayViews,
@@ -262,27 +241,30 @@ struct ArrayForEachImpl<ExecutionPolicy, Dim> {
                     const Function& function,
                     const std::tuple<SlicerArgs...>& slicerArgs,
                     const std::tuple<MaskArgs...>& maskArgs) {
-    ATLAS_ASSERT((std::is_invocable_v<Mask,MaskArgs...>));
-    if constexpr (std::is_invocable_v<Mask,MaskArgs...>) {
-      if (std::apply(mask, maskArgs)) {
-        return;
-      }
-    }
-    apply( std::forward<ArrayViewTuple>(arrayViews), function, slicerArgs);
-  }
 
-  template <typename ArrayViewTuple, typename Function, typename... SlicerArgs>
-  static void apply(ArrayViewTuple&& arrayViews,
-                    const Function& function,
-                    const std::tuple<SlicerArgs...>& slicerArgs) {
+    constexpr auto maskPresent = !std::is_same_v<Mask, NoMask>;
+
+    if constexpr (maskPresent) {
+
+        constexpr auto invocableMask = std::is_invocable_r_v<int, Mask, MaskArgs...>;
+        static_assert (invocableMask,
+            "Cannot invoke mask function with given arguments.\n"
+            "Make sure you arguments are N integers (or auto...) "
+            "where N == sizeof...(ItrDims). Function must return an int."
+            );
+
+        if (std::apply(mask, maskArgs)) {
+            return;
+        }
+
+    }
+
     auto slices = makeSlices(slicerArgs, std::forward<ArrayViewTuple>(arrayViews));
 
     constexpr auto applicable = is_applicable_v<Function,decltype(slices)>;
     static_assert(applicable, "Cannot invoke function with given arguments. "
       "Make sure you the arguments are rvalue references (Slice&&) or const references (const Slice&) or regular value (Slice)" );
-    if constexpr (applicable) {
-      std::apply(function, std::move(slices));
-    }
+    std::apply(function, std::move(slices));
   }
 
 };
@@ -350,14 +332,8 @@ struct ArrayForEach {
   template <typename ExecutionPolicy, typename... ArrayView, typename Mask, typename Function,
             typename = std::enable_if_t<execution::is_execution_policy<ExecutionPolicy>()>>
   static void apply(ExecutionPolicy, std::tuple<ArrayView...>&& arrayViews, const Mask& mask, const Function& function) {
-    if constexpr (std::is_same_v<std::decay_t<Mask>,detail::NoMask>) {
       detail::ArrayForEachImpl<ExecutionPolicy, 0, ItrDims...>::apply(
-        std::move(arrayViews), function, std::make_tuple());
-    }
-    else {
-      detail::ArrayForEachImpl<ExecutionPolicy, 0, ItrDims...>::apply(
-        std::move(arrayViews), mask, function, std::make_tuple(), std::make_tuple());
-    }
+          std::move(arrayViews), mask, function, std::make_tuple(), std::make_tuple());
   }
 
   /// brief   Apply "For-Each" method

--- a/src/atlas/array/helpers/ArrayForEach.h
+++ b/src/atlas/array/helpers/ArrayForEach.h
@@ -9,7 +9,6 @@
 
 #include <tuple>
 #include <type_traits>
-#include <sstream>
 #include <string_view>
 
 #include "atlas/array/ArrayView.h"

--- a/src/atlas/field/for_each.h
+++ b/src/atlas/field/for_each.h
@@ -41,7 +41,7 @@ void for_each_value_masked(const eckit::Parametrisation& config, const Mask& mas
         if (h_dim.size() == 1) {
             ATLAS_ASSERT(h_dim[0] == 0);
             auto mask_view = array::make_view<const int,1>(mask);
-            auto mask_wrap = [mask_view](idx_t i, auto&&... ) { return mask_view(i); };
+            auto mask_wrap = [mask_view](idx_t i, auto&&... args) { return mask_view(i); };
             return for_each_value_masked(config, mask_wrap, std::move(fields), function);
         }
         else if (h_dim.size() == 2) {
@@ -50,24 +50,24 @@ void for_each_value_masked(const eckit::Parametrisation& config, const Mask& mas
                 auto mask_view_shape2d = array::make_shape(field_1.shape(h_dim[0]), field_1.shape(h_dim[1]));
                 auto mask_view         = array::View<const int,2>( mask_view_1d.data(), mask_view_shape2d );
                 if( h_dim[0] == 0 && h_dim[1] == 2) {
-                    auto mask_wrap = [mask_view](idx_t i, idx_t /*dummy*/, idx_t j, auto&&... ) { return mask_view(i,j); };
+                    auto mask_wrap = [mask_view](idx_t i, idx_t /*dummy*/, idx_t j, auto&&... args) { return mask_view(i,j); };
                     return for_each_value_masked(config, mask_wrap, std::move(fields), function);
                 }
                 else {
                     ATLAS_ASSERT(h_dim[0] == 0 && h_dim[1] == 1);
-                    auto mask_wrap = [mask_view](idx_t i, idx_t j, auto&&... ) { return mask_view(i,j); };
+                    auto mask_wrap = [mask_view](idx_t i, idx_t j, auto&&... args) { return mask_view(i,j); };
                     return for_each_value_masked(config, mask_wrap, std::move(fields), function);
                 }
             }
             else {
                 auto mask_view = array::make_view<const int,2>(mask);
                 if( h_dim[0] == 0 && h_dim[1] == 2) {
-                    auto mask_wrap = [mask_view](idx_t i, idx_t /*dummy*/, idx_t j, auto&&... ) { return mask_view(i,j); };
+                    auto mask_wrap = [mask_view](idx_t i, idx_t /*dummy*/, idx_t j, auto&&... args) { return mask_view(i,j); };
                     return for_each_value_masked(config, mask_wrap, std::move(fields), function);
                 }
                 else {
                     ATLAS_ASSERT(h_dim[0] == 0 && h_dim[1] == 1);
-                    auto mask_wrap = [mask_view](idx_t i, idx_t j, auto&&... ) { return mask_view(i,j); };
+                    auto mask_wrap = [mask_view](idx_t i, idx_t j, auto&&... args) { return mask_view(i,j); };
                     return for_each_value_masked(config, mask_wrap, std::move(fields), function);
                 }
             }


### PR DESCRIPTION
Hi @wdeconinck ,

Turns out the bug is with GCC 7.3, not Atlas.

This PR does a couple a couple of things. First it replaces the exception throws in `ArrayForEach` with static asserts (I initially thought the bug was Atlas related). This has the happy side effect of restoring the original `ArrayForEach` performance.

After *a lot* of reading, I managed to find [this bug report](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64095) for GCC 7. Basically, unnamed `auto` parameter packs in lambda expressions will fail if they received zero parameters when called. I've implemented a work around by naming them in `field/for_each`.

@DJDavies2, can you verify this works.

Cheers,
Olly