### PR TITLE
Fix triangulations for stripack and qhull

### DIFF
--- a/src/atlas/mesh/actions/BuildConvexHull3D.cc
+++ b/src/atlas/mesh/actions/BuildConvexHull3D.cc
@@ -258,6 +258,7 @@ void BuildConvexHull3D::operator()(Mesh& mesh) const {
 
 
     if( local_index.size() == mesh.nodes().size() or local_index.empty() ) {
+        local_index.clear();
         auto lonlat = array::make_view<double,2>(mesh.nodes().lonlat());
         if( backend == "stripack" ) {
             ATLAS_TRACE("stripack");
@@ -272,7 +273,6 @@ void BuildConvexHull3D::operator()(Mesh& mesh) const {
         else {
             ATLAS_THROW_EXCEPTION("backend" << backend << "not supported");
         }
-        local_index.clear();
     }
     else {
         auto lonlat_view = array::make_view<double,2>(mesh.nodes().lonlat());

--- a/src/atlas/mesh/actions/BuildConvexHull3D.cc
+++ b/src/atlas/mesh/actions/BuildConvexHull3D.cc
@@ -241,7 +241,6 @@ void BuildConvexHull3D::operator()(Mesh& mesh) const {
 
         Log::debug() << "Inserting triags (" << eckit::BigNum(nb_triags) << ")" << std::endl;
 
-        idx_t tidx = 0;
         for (idx_t tidx = 0; tidx<nb_triags; ++tidx) {
             auto& t = triangles[tidx];
             std::array<idx_t,3> idx{t[0],t[1],t[2]};


### PR DESCRIPTION
Before commit 0c1fdd66, the `local_indices.clear()` was called _before_ the work of adding the triangles. Commit 0c1fdd66 introduced the `add_triangles` lambda and this moved the code so the clear is called _after_ adding the triangles. 

This change in the order of execution affects the lambda's check of `local_indices.size()` and subsequent logic, producing bad meshes:
<img width="603" alt="CS_tile_stripack" src="https://github.com/ecmwf/atlas/assets/881747/4e6c0883-d9a7-418e-b6a9-fbbb7e0b3e80">

This PR restores the original order, and fixes the meshes:
<img width="590" alt="CS_tile_stripack_orig" src="https://github.com/ecmwf/atlas/assets/881747/c020f5e1-24a5-43d2-beba-f709fe2fabc3">
