### PR TITLE
Fix undefined reference due to CGAL dependency

### DIFF
--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -937,6 +937,7 @@ ecbuild_add_library( TARGET atlas
     eckit_mpi
     eckit_option
     atlas_io
+    $<TARGET_NAME_IF_EXISTS:CGAL::CGAL>
     $<${atlas_HAVE_EIGEN}:Eigen3::Eigen>
     $<${atlas_HAVE_OMP_CXX}:OpenMP::OpenMP_CXX>
     $<${atlas_HAVE_GRIDTOOLS_STORAGE}:GridTools::gridtools>


### PR DESCRIPTION
When atlas is built and installed as a standalone package, I would get undefined reference (for symbols associated with the CGAL dependency, e.g., symbols from libgmp, etc) when a subsequent package needs to link to `libatlas.so`. The fix seems to solve the issue, by adding the `CGAL::CGAL` target (if available) to the list of public libs dependency for `libatlas.so`.