### PR TITLE
MIR-632 added accessors for the GridBox class.

### DIFF
--- a/src/atlas/interpolation/method/knn/GridBox.h
+++ b/src/atlas/interpolation/method/knn/GridBox.h
@@ -50,6 +50,10 @@ public:
     double diagonal() const;
     bool intersects(GridBox&) const;
 
+    double north() const { return north_; }
+    double west() const { return west_; }
+    double south() const { return south_; }
+    double east() const { return east_; }
     // -- Overridden methods
     // None
 


### PR DESCRIPTION
MIR-632 Created accessors to the private data of the GridBox class. This modification allows to use GridBox in mir.