### PR TITLE
Register and use non-default MPI communicators in Atlas objects

### DIFF
--- a/src/atlas/functionspace/CellColumns.cc
+++ b/src/atlas/functionspace/CellColumns.cc
@@ -95,7 +95,8 @@ private:
 
     static value_type* create(const Mesh& mesh) {
         value_type* value = new value_type();
-        value->setup(array::make_view<int, 1>(mesh.cells().partition()).data(),
+        value->setup(mesh.mpi_comm(),
+                     array::make_view<int, 1>(mesh.cells().partition()).data(),
                      array::make_view<idx_t, 1>(mesh.cells().remote_index()).data(), REMOTE_IDX_BASE,
                      mesh.cells().size());
         return value;
@@ -129,7 +130,8 @@ private:
 
     static value_type* create(const Mesh& mesh) {
         value_type* value = new value_type();
-        value->setup(array::make_view<int, 1>(mesh.cells().partition()).data(),
+        value->setup(mesh.mpi_comm(),
+                     array::make_view<int, 1>(mesh.cells().partition()).data(),
                      array::make_view<idx_t, 1>(mesh.cells().remote_index()).data(), REMOTE_IDX_BASE,
                      array::make_view<gidx_t, 1>(mesh.cells().global_index()).data(), mesh.cells().size());
         return value;
@@ -193,7 +195,6 @@ void CellColumns::set_field_metadata(const eckit::Configuration& config, Field& 
 }
 
 idx_t CellColumns::config_size(const eckit::Configuration& config) const {
-    const idx_t rank = mpi::rank();
     idx_t size       = nb_cells();
     bool global(false);
     if (config.get("global", global)) {
@@ -201,6 +202,7 @@ idx_t CellColumns::config_size(const eckit::Configuration& config) const {
             idx_t owner(0);
             config.get("owner", owner);
             idx_t _nb_cells_global(nb_cells_global());
+            const idx_t rank = mpi::comm(mpi_comm()).rank();
             size = (rank == owner ? _nb_cells_global : 0);
         }
     }
@@ -269,7 +271,7 @@ CellColumns::CellColumns(const Mesh& mesh, const eckit::Configuration& config):
         return nb_cells;
     };
 
-    mesh::actions::build_nodes_parallel_fields(mesh_.nodes());
+    mesh::actions::build_nodes_parallel_fields(mesh_);
     mesh::actions::build_cells_parallel_fields(mesh_);
     mesh::actions::build_periodic_boundaries(mesh_);
 

--- a/src/atlas/functionspace/CellColumns.h
+++ b/src/atlas/functionspace/CellColumns.h
@@ -99,6 +99,8 @@ public:
 
     Field partition() const override;
 
+    std::string mpi_comm() const override { return mesh_.mpi_comm(); }
+
 private:  // methods
     idx_t config_size(const eckit::Configuration& config) const;
     array::DataType config_datatype(const eckit::Configuration&) const;

--- a/src/atlas/functionspace/EdgeColumns.cc
+++ b/src/atlas/functionspace/EdgeColumns.cc
@@ -96,7 +96,8 @@ private:
 
     static value_type* create(const Mesh& mesh) {
         value_type* value = new value_type();
-        value->setup(array::make_view<int, 1>(mesh.edges().partition()).data(),
+        value->setup(mesh.mpi_comm(),
+                     array::make_view<int, 1>(mesh.edges().partition()).data(),
                      array::make_view<idx_t, 1>(mesh.edges().remote_index()).data(), REMOTE_IDX_BASE,
                      mesh.edges().size());
         return value;
@@ -130,7 +131,8 @@ private:
 
     static value_type* create(const Mesh& mesh) {
         value_type* value = new value_type();
-        value->setup(array::make_view<int, 1>(mesh.edges().partition()).data(),
+        value->setup(mesh.mpi_comm(),
+                     array::make_view<int, 1>(mesh.edges().partition()).data(),
                      array::make_view<idx_t, 1>(mesh.edges().remote_index()).data(), REMOTE_IDX_BASE,
                      array::make_view<gidx_t, 1>(mesh.edges().global_index()).data(), mesh.edges().size());
         return value;
@@ -194,7 +196,6 @@ void EdgeColumns::set_field_metadata(const eckit::Configuration& config, Field& 
 }
 
 idx_t EdgeColumns::config_size(const eckit::Configuration& config) const {
-    const idx_t rank = mpi::rank();
     idx_t size       = nb_edges();
     bool global(false);
     if (config.get("global", global)) {
@@ -202,6 +203,7 @@ idx_t EdgeColumns::config_size(const eckit::Configuration& config) const {
             idx_t owner(0);
             config.get("owner", owner);
             idx_t _nb_edges_global(nb_edges_global());
+            const idx_t rank = mpi::comm(mpi_comm()).rank();
             size = (rank == owner ? _nb_edges_global : 0);
         }
     }
@@ -266,7 +268,7 @@ EdgeColumns::EdgeColumns(const Mesh& mesh, const eckit::Configuration& config):
         return _nb_edges;
     };
 
-    mesh::actions::build_nodes_parallel_fields(mesh_.nodes());
+    mesh::actions::build_nodes_parallel_fields(mesh_);
     mesh::actions::build_periodic_boundaries(mesh_);
 
     if (halo_.size() > 0) {

--- a/src/atlas/functionspace/EdgeColumns.h
+++ b/src/atlas/functionspace/EdgeColumns.h
@@ -93,6 +93,8 @@ public:
 
     Field partition() const override;
 
+    std::string mpi_comm() const override { return mesh_.mpi_comm(); }
+
 private:  // methods
     idx_t config_size(const eckit::Configuration& config) const;
     array::DataType config_datatype(const eckit::Configuration&) const;

--- a/src/atlas/functionspace/FunctionSpace.cc
+++ b/src/atlas/functionspace/FunctionSpace.cc
@@ -118,6 +118,10 @@ const parallel::GatherScatter& FunctionSpace::scatter() const {
     return get()->scatter();
 }
 
+std::string FunctionSpace::mpi_comm() const {
+    return get()->mpi_comm();
+}
+
 const util::PartitionPolygon& FunctionSpace::polygon(idx_t halo) const {
     return get()->polygon(halo);
 }

--- a/src/atlas/functionspace/FunctionSpace.cc
+++ b/src/atlas/functionspace/FunctionSpace.cc
@@ -58,8 +58,12 @@ idx_t FunctionSpace::size() const {
     return get()->size();
 }
 
-idx_t FunctionSpace::nb_partitions() const {
-    return get()->nb_partitions();
+idx_t FunctionSpace::part() const {
+    return get()->part();
+}
+
+idx_t FunctionSpace::nb_parts() const {
+    return get()->nb_parts();
 }
 
 Field FunctionSpace::lonlat() const {

--- a/src/atlas/functionspace/FunctionSpace.h
+++ b/src/atlas/functionspace/FunctionSpace.h
@@ -79,7 +79,9 @@ public:
 
     const Projection& projection() const;
 
-    idx_t nb_partitions() const;
+    idx_t part() const;
+
+    idx_t nb_parts() const;
 
     idx_t size() const;
 

--- a/src/atlas/functionspace/FunctionSpace.h
+++ b/src/atlas/functionspace/FunctionSpace.h
@@ -97,6 +97,8 @@ public:
 
     const parallel::GatherScatter& gather() const;
     const parallel::GatherScatter& scatter() const;
+
+    std::string mpi_comm() const;
 };
 
 //------------------------------------------------------------------------------------------------------

--- a/src/atlas/functionspace/NodeColumns.h
+++ b/src/atlas/functionspace/NodeColumns.h
@@ -258,7 +258,9 @@ public:
 
     virtual idx_t size() const override { return nb_nodes_; }
 
-    idx_t nb_partitions() const override { return mesh_.nb_partitions(); }
+    idx_t part() const override { return mesh_.part(); }
+
+    idx_t nb_parts() const override { return mesh_.nb_parts(); }
 
     Field lonlat() const override { return nodes_.lonlat(); }
 

--- a/src/atlas/functionspace/NodeColumns.h
+++ b/src/atlas/functionspace/NodeColumns.h
@@ -278,6 +278,8 @@ public:
 
     const Projection& projection() const override { return mesh_.projection(); }
 
+    std::string mpi_comm() const override { return mesh_.mpi_comm(); }
+
 private:  // methods
     void constructor();
 

--- a/src/atlas/functionspace/PointCloud.cc
+++ b/src/atlas/functionspace/PointCloud.cc
@@ -46,7 +46,7 @@ namespace functionspace {
 namespace detail {
 
 template <>
-PointCloud::PointCloud(const std::vector<PointXY>& points) {
+PointCloud::PointCloud(const std::vector<PointXY>& points, const eckit::Configuration& config) {
     lonlat_     = Field("lonlat", array::make_datatype<double>(), array::make_shape(points.size(), 2));
     auto lonlat = array::make_view<double, 2>(lonlat_);
     for (idx_t j = 0, size = points.size(); j < size; ++j) {
@@ -56,7 +56,7 @@ PointCloud::PointCloud(const std::vector<PointXY>& points) {
 }
 
 template <>
-PointCloud::PointCloud(const std::vector<PointXYZ>& points) {
+PointCloud::PointCloud(const std::vector<PointXYZ>& points, const eckit::Configuration& config) {
     lonlat_       = Field("lonlat", array::make_datatype<double>(), array::make_shape(points.size(), 2));
     vertical_     = Field("vertical", array::make_datatype<double>(), array::make_shape(points.size()));
     auto lonlat   = array::make_view<double, 2>(lonlat_);
@@ -68,13 +68,13 @@ PointCloud::PointCloud(const std::vector<PointXYZ>& points) {
     }
 }
 
-PointCloud::PointCloud(const Field& lonlat): lonlat_(lonlat) {}
+PointCloud::PointCloud(const Field& lonlat, const eckit::Configuration& config): lonlat_(lonlat) {}
 
-PointCloud::PointCloud(const Field& lonlat, const Field& ghost): lonlat_(lonlat), ghost_(ghost) {
+PointCloud::PointCloud(const Field& lonlat, const Field& ghost, const eckit::Configuration& config): lonlat_(lonlat), ghost_(ghost) {
     setupHaloExchange();
 }
 
-PointCloud::PointCloud(const FieldSet & flds): lonlat_(flds["lonlat"]) {
+PointCloud::PointCloud(const FieldSet& flds, const eckit::Configuration& config): lonlat_(flds["lonlat"]) {
     if (flds.has("ghost")) {
         ghost_ = flds["ghost"];
     }

--- a/src/atlas/functionspace/PointCloud.h
+++ b/src/atlas/functionspace/PointCloud.h
@@ -43,10 +43,10 @@ namespace detail {
 class PointCloud : public functionspace::FunctionSpaceImpl {
 public:
     template <typename Point>
-    PointCloud(const std::vector<Point>&);
-    PointCloud(const Field& lonlat);
-    PointCloud(const Field& lonlat, const Field& ghost);
-    PointCloud(const FieldSet&);  // assuming lonlat ghost ridx and partition present
+    PointCloud(const std::vector<Point>&, const eckit::Configuration& = util::NoConfig());
+    PointCloud(const Field& lonlat, const eckit::Configuration& = util::NoConfig());
+    PointCloud(const Field& lonlat, const Field& ghost, const eckit::Configuration& = util::NoConfig());
+    PointCloud(const FieldSet&, const eckit::Configuration& = util::NoConfig());  // assuming lonlat ghost ridx and partition present
     PointCloud(const Grid&, const eckit::Configuration& = util::NoConfig());
     PointCloud(const Grid&, const grid::Partitioner&, const eckit::Configuration& = util::NoConfig());
     ~PointCloud() override {}

--- a/src/atlas/functionspace/PointCloud.h
+++ b/src/atlas/functionspace/PointCloud.h
@@ -61,7 +61,9 @@ public:
     Field global_index() const override { return global_index_; }
     Field partition() const override { return partition_; }
     idx_t size() const override { return lonlat_.shape(0); }
-    idx_t nb_partitions() const override { return nb_partitions_; }
+    idx_t part() const override { return part_; }
+    idx_t nb_parts() const override { return nb_partitions_; }
+    std::string mpi_comm() const override { return mpi_comm_; }
 
     using FunctionSpaceImpl::createField;
     Field createField(const eckit::Configuration&) const override;
@@ -166,7 +168,9 @@ private:
     idx_t max_glb_idx_{0};
     std::unique_ptr<parallel::HaloExchange> halo_exchange_;
     idx_t levels_{0};
+    idx_t part_{0};
     idx_t nb_partitions_{1};
+    std::string mpi_comm_;
 
     void setupHaloExchange();
 
@@ -181,12 +185,12 @@ private:
 class PointCloud : public FunctionSpace {
 public:
     PointCloud(const FunctionSpace&);
-    PointCloud(const Field& points);
-    PointCloud(const Field&, const Field&);
-    PointCloud(const FieldSet& flds);
-    PointCloud(const std::vector<PointXY>&);
-    PointCloud(const std::vector<PointXYZ>&);
-    PointCloud(const std::initializer_list<std::initializer_list<double>>&);
+    PointCloud(const Field& points, const eckit::Configuration& = util::NoConfig());
+    PointCloud(const Field&, const Field&, const eckit::Configuration& = util::NoConfig());
+    PointCloud(const FieldSet& flds, const eckit::Configuration& = util::NoConfig());
+    PointCloud(const std::vector<PointXY>&, const eckit::Configuration& = util::NoConfig());
+    PointCloud(const std::vector<PointXYZ>&, const eckit::Configuration& = util::NoConfig());
+    PointCloud(const std::initializer_list<std::initializer_list<double>>&, const eckit::Configuration& = util::NoConfig());
     PointCloud(const Grid&, const eckit::Configuration& = util::NoConfig());
     PointCloud(const Grid&, const grid::Partitioner&, const eckit::Configuration& = util::NoConfig());
 

--- a/src/atlas/functionspace/StructuredColumns.h
+++ b/src/atlas/functionspace/StructuredColumns.h
@@ -110,7 +110,8 @@ public:
         void operator()(const Functor& f) const {
             ATLAS_ASSERT(levels);
             if (global) {
-                if (owner == mpi::rank()) {
+                auto mpi_rank = mpi::comm(fs_.mpi_comm()).rank();
+                if (owner == mpi_rank) {
                     const idx_t ny = fs_.grid().ny();
                     std::vector<idx_t> offset(ny);
                     offset[0] = 0;
@@ -143,7 +144,8 @@ public:
         void operator()(const Functor& f) const {
             ATLAS_ASSERT(levels == 0);
             if (global) {
-                if (owner == mpi::rank()) {
+                auto mpi_rank = mpi::comm(fs_.mpi_comm()).rank();
+                if (owner == mpi_rank) {
                     const idx_t ny = fs_.grid().ny();
                     std::vector<idx_t> offset(ny);
                     offset[0] = 0;
@@ -172,7 +174,8 @@ public:
         void operator()(const Functor& f) const {
             ATLAS_ASSERT(levels);
             if (global) {
-                if (owner == mpi::rank()) {
+                auto mpi_rank = mpi::comm(fs_.mpi_comm()).rank();
+                if (owner == mpi_rank) {
                     const idx_t size = fs_.grid().size();
                     atlas_omp_parallel_for(idx_t n = 0; n < size; ++n) {
                         for (idx_t k = 0; k < levels; ++k) {
@@ -197,7 +200,8 @@ public:
         void operator()(const Functor& f) const {
             ATLAS_ASSERT(levels == 0);
             if (global) {
-                if (owner == mpi::rank()) {
+                auto mpi_rank = mpi::comm(fs_.mpi_comm()).rank();
+                if (owner == mpi_rank) {
                     const idx_t size = fs_.grid().size();
                     atlas_omp_parallel_for(idx_t n = 0; n < size; ++n) { f(n); }
                 }

--- a/src/atlas/functionspace/detail/BlockStructuredColumns.h
+++ b/src/atlas/functionspace/detail/BlockStructuredColumns.h
@@ -111,7 +111,8 @@ public:
     Field index_j() const { return structuredcolumns_->index_j(); }
     Field ghost() const override { return structuredcolumns_->ghost(); }
     size_t footprint() const override { return structuredcolumns_->footprint(); }
-    idx_t nb_partitions() const override { return structuredcolumns_->nb_partitions(); }
+    idx_t part() const override { return structuredcolumns_->part(); }
+    idx_t nb_parts() const override { return structuredcolumns_->nb_parts(); }
     const StructuredColumns& structuredcolumns() const { return *structuredcolumns_; }
     idx_t block_begin(idx_t jblk) const { return jblk * nproma_; }
     idx_t block_size(idx_t jblk) const { return (jblk != nblks_-1 ? nproma_ : endblk_size_); }

--- a/src/atlas/functionspace/detail/FunctionSpaceImpl.cc
+++ b/src/atlas/functionspace/detail/FunctionSpaceImpl.cc
@@ -95,7 +95,11 @@ Field FunctionSpaceImpl::createField() const {
     return createField(option::datatypeT<DATATYPE>());
 }
 
-idx_t FunctionSpaceImpl::nb_partitions() const {
+idx_t FunctionSpaceImpl::part() const {
+    ATLAS_NOTIMPLEMENTED;
+}
+
+idx_t FunctionSpaceImpl::nb_parts() const {
     ATLAS_NOTIMPLEMENTED;
 }
 

--- a/src/atlas/functionspace/detail/FunctionSpaceImpl.cc
+++ b/src/atlas/functionspace/detail/FunctionSpaceImpl.cc
@@ -13,6 +13,7 @@
 #include "atlas/option/Options.h"
 #include "atlas/runtime/Exception.h"
 #include "atlas/util/Metadata.h"
+#include "atlas/parallel/mpi/mpi.h"
 
 namespace atlas {
 namespace functionspace {
@@ -125,6 +126,10 @@ const parallel::GatherScatter& FunctionSpaceImpl::gather() const {
 
 const parallel::GatherScatter& FunctionSpaceImpl::scatter() const {
     ATLAS_NOTIMPLEMENTED;
+}
+
+std::string FunctionSpaceImpl::mpi_comm() const {
+    return mpi::comm().name();
 }
 
 

--- a/src/atlas/functionspace/detail/FunctionSpaceImpl.h
+++ b/src/atlas/functionspace/detail/FunctionSpaceImpl.h
@@ -113,6 +113,8 @@ public:
 
     virtual const Projection& projection() const;
 
+    virtual std::string mpi_comm() const;
+
 private:
     util::Metadata* metadata_;
 };

--- a/src/atlas/functionspace/detail/FunctionSpaceImpl.h
+++ b/src/atlas/functionspace/detail/FunctionSpaceImpl.h
@@ -93,7 +93,9 @@ public:
 
     virtual idx_t size() const = 0;
 
-    virtual idx_t nb_partitions() const;
+    virtual idx_t part() const;
+
+    virtual idx_t nb_parts() const;
 
     virtual const util::PartitionPolygon& polygon(idx_t halo = 0) const;
 

--- a/src/atlas/functionspace/detail/StructuredColumns.cc
+++ b/src/atlas/functionspace/detail/StructuredColumns.cc
@@ -129,7 +129,8 @@ private:
     static value_type* create(const detail::StructuredColumns* funcspace) {
         value_type* value = new value_type();
 
-        value->setup(array::make_view<int, 1>(funcspace->partition()).data(),
+        value->setup(funcspace->mpi_comm(),
+                     array::make_view<int, 1>(funcspace->partition()).data(),
                      array::make_view<idx_t, 1>(funcspace->remote_index()).data(), REMOTE_IDX_BASE,
                      funcspace->sizeHalo(), funcspace->sizeOwned());
         return value;
@@ -177,7 +178,8 @@ private:
     static value_type* create(const detail::StructuredColumns* funcspace) {
         value_type* value = new value_type();
 
-        value->setup(array::make_view<int, 1>(funcspace->partition()).data(),
+        value->setup(funcspace->mpi_comm(),
+                     array::make_view<int, 1>(funcspace->partition()).data(),
                      array::make_view<idx_t, 1>(funcspace->remote_index()).data(), REMOTE_IDX_BASE,
                      array::make_view<gidx_t, 1>(funcspace->global_index()).data(), funcspace->sizeOwned());
         return value;
@@ -383,7 +385,8 @@ idx_t StructuredColumns::config_size(const eckit::Configuration& config) const {
         if (global) {
             idx_t owner(0);
             config.get("owner", owner);
-            size = (mpi::rank() == owner ? grid_->size() : 0);
+            idx_t rank = mpi::comm(mpi_comm()).rank();
+            size = (rank == owner ? grid_->size() : 0);
         }
     }
     return size;
@@ -406,6 +409,15 @@ void StructuredColumns::throw_outofbounds(idx_t i, idx_t j) const {
     throw_Exception(ss.str(), Here());
 }
 
+namespace {
+    static std::string extract_mpi_comm(const eckit::Configuration& config) {
+        if(config.has("mpi_comm")){
+            return config.getString("mpi_comm");
+        }
+        return mpi::comm().name();
+    }
+}
+
 // ----------------------------------------------------------------------------
 // Constructor
 // ----------------------------------------------------------------------------
@@ -421,7 +433,7 @@ StructuredColumns::StructuredColumns(const Grid& grid, const grid::Distribution&
 
 StructuredColumns::StructuredColumns(const Grid& grid, const grid::Distribution& distribution, const Vertical& vertical,
                                      const eckit::Configuration& config):
-    vertical_(vertical), nb_levels_(vertical_.size()), grid_(new StructuredGrid(grid)) {
+    vertical_(vertical), nb_levels_(vertical_.size()), grid_(new StructuredGrid(grid)), mpi_comm_(extract_mpi_comm(config)) {
     setup(distribution, config);
 }
 
@@ -430,26 +442,29 @@ StructuredColumns::StructuredColumns(const Grid& grid, const Vertical& vertical,
 
 StructuredColumns::StructuredColumns(const Grid& grid, const Vertical& vertical, const grid::Partitioner& p,
                                      const eckit::Configuration& config):
-    vertical_(vertical), nb_levels_(vertical_.size()), grid_(new StructuredGrid(grid)) {
+    vertical_(vertical), nb_levels_(vertical_.size()), grid_(new StructuredGrid(grid)), mpi_comm_(extract_mpi_comm(config)) {
     ATLAS_TRACE("StructuredColumns constructor");
 
-    grid::Partitioner partitioner(p);
-    if (not partitioner) {
-        if (config.has("partitioner")) {
-            partitioner = grid::Partitioner(config.getSubConfiguration("partitioner"));
-        }
-        else {
-            if (grid_->domain().global()) {
-                partitioner = grid::Partitioner("equal_regions");
+    grid::Distribution distribution;
+
+    {
+        mpi::Scope mpi_scope(mpi_comm_);
+        grid::Partitioner partitioner(p);
+        if (not partitioner) {
+            if (config.has("partitioner")) {
+                partitioner = grid::Partitioner(config.getSubConfiguration("partitioner"));
             }
             else {
-                partitioner = grid::Partitioner("checkerboard");
+                if (grid_->domain().global()) {
+                    partitioner = grid::Partitioner("equal_regions");
+                }
+                else {
+                    partitioner = grid::Partitioner("checkerboard");
+                }
             }
         }
+        ATLAS_TRACE_SCOPE("Partitioning grid") { distribution = grid::Distribution(grid, partitioner); }
     }
-
-    grid::Distribution distribution;
-    ATLAS_TRACE_SCOPE("Partitioning grid") { distribution = grid::Distribution(grid, partitioner); }
 
     setup(distribution, config);
 }

--- a/src/atlas/functionspace/detail/StructuredColumns.h
+++ b/src/atlas/functionspace/detail/StructuredColumns.h
@@ -167,7 +167,8 @@ public:
 
     const util::PartitionPolygons& polygons() const override;
 
-    idx_t nb_partitions() const override { return nb_partitions_; }
+    idx_t part() const override { return part_; }
+    idx_t nb_parts() const override { return nb_partitions_; }
 
 
 private:  // methods
@@ -312,6 +313,7 @@ private:  // data
     idx_t south_pole_included_;
     idx_t ny_;
 
+    idx_t part_;
     idx_t nb_partitions_;
 
     friend struct StructuredColumnsFortranAccess;

--- a/src/atlas/functionspace/detail/StructuredColumns.h
+++ b/src/atlas/functionspace/detail/StructuredColumns.h
@@ -169,7 +169,7 @@ public:
 
     idx_t part() const override { return part_; }
     idx_t nb_parts() const override { return nb_partitions_; }
-
+    std::string mpi_comm() const override { return mpi_comm_; }
 
 private:  // methods
     idx_t config_size(const eckit::Configuration& config) const;
@@ -315,6 +315,7 @@ private:  // data
 
     idx_t part_;
     idx_t nb_partitions_;
+    std::string mpi_comm_;
 
     friend struct StructuredColumnsFortranAccess;
     friend struct BlockStructuredColumnsFortranAccess;

--- a/src/atlas/functionspace/detail/StructuredColumns_create_remote_index.cc
+++ b/src/atlas/functionspace/detail/StructuredColumns_create_remote_index.cc
@@ -42,7 +42,7 @@ void StructuredColumns::create_remote_index() const {
 
     ATLAS_TRACE_SCOPE("Parallelisation ...") {
         auto build_partition_graph = [this]() -> std::unique_ptr<Mesh::PartitionGraph> {
-            const eckit::mpi::Comm& comm = mpi::comm();
+            const eckit::mpi::Comm& comm = mpi::comm(mpi_comm());
             const int mpi_size           = int(comm.size());
             const int mpi_rank           = int(comm.rank());
 
@@ -80,7 +80,7 @@ void StructuredColumns::create_remote_index() const {
             auto p = array::make_view<int, 1>(partition());
             auto g = array::make_view<gidx_t, 1>(global_index());
 
-            const eckit::mpi::Comm& comm = mpi::comm();
+            const eckit::mpi::Comm& comm = mpi::comm(mpi_comm());
             const int mpi_rank           = int(comm.rank());
 
             auto neighbours           = graph.nearestNeighbours(mpi_rank);

--- a/src/atlas/grid/Partitioner.h
+++ b/src/atlas/grid/Partitioner.h
@@ -76,7 +76,7 @@ public:
 public:
     using Handle::Handle;
     Partitioner() = default;
-    Partitioner(const std::string& type);
+    explicit Partitioner(const std::string& type);
     Partitioner(const std::string& type, const idx_t nb_partitions);
     Partitioner(const Config&);
     Partitioner(const std::string& type, const Config&);

--- a/src/atlas/grid/Partitioner.h
+++ b/src/atlas/grid/Partitioner.h
@@ -88,6 +88,8 @@ public:
     idx_t nb_partitions() const;
 
     std::string type() const;
+
+    std::string mpi_comm() const;
 };
 
 // ------------------------------------------------------------------

--- a/src/atlas/grid/StructuredPartitionPolygon.cc
+++ b/src/atlas/grid/StructuredPartitionPolygon.cc
@@ -342,9 +342,9 @@ size_t StructuredPartitionPolygon::footprint() const {
 void StructuredPartitionPolygon::outputPythonScript(const eckit::PathName& filepath,
                                                     const eckit::Configuration& config) const {
     ATLAS_TRACE("Output PartitionPolygon");
-    const eckit::mpi::Comm& comm = atlas::mpi::comm();
-    int mpi_rank                 = int(comm.rank());
-    int mpi_size                 = int(comm.size());
+    const auto& comm = atlas::mpi::comm(fs_.mpi_comm());
+    int mpi_rank     = int(comm.rank());
+    int mpi_size     = int(comm.size());
 
     auto xy = array::make_view<double, 2>(dynamic_cast<const functionspace::detail::StructuredColumns&>(fs_).xy());
 
@@ -449,11 +449,11 @@ util::PartitionPolygon::PointsXY StructuredPartitionPolygon::lonlat() const {
 void StructuredPartitionPolygon::allGather(util::PartitionPolygons& polygons_) const {
     ATLAS_TRACE();
 
-    polygons_.clear();
-    polygons_.reserve(mpi::size());
+    const auto& comm   = mpi::comm(fs_.mpi_comm());
+    const int mpi_size = int(comm.size());
 
-    const mpi::Comm& comm = mpi::comm();
-    const int mpi_size    = int(comm.size());
+    polygons_.clear();
+    polygons_.reserve(mpi_size);
 
     auto& poly = *this;
 

--- a/src/atlas/grid/detail/distribution/SerialDistribution.cc
+++ b/src/atlas/grid/detail/distribution/SerialDistribution.cc
@@ -21,15 +21,20 @@ namespace grid {
 namespace detail {
 namespace distribution {
 
-SerialDistribution::SerialDistribution(const Grid& grid): DistributionFunctionT<SerialDistribution>(grid) {
+SerialDistribution::SerialDistribution(const Grid& grid):
+    SerialDistribution(grid, mpi::rank()) {
+}
+
+SerialDistribution::SerialDistribution(const Grid& grid, int part): DistributionFunctionT<SerialDistribution>(grid) {
     type_          = "serial";
     nb_partitions_ = 1;
-    rank_          = mpi::rank();
     size_          = grid.size();
     nb_pts_.resize(nb_partitions_, grid.size());
     max_pts_ = *std::max_element(nb_pts_.begin(), nb_pts_.end());
     min_pts_ = *std::min_element(nb_pts_.begin(), nb_pts_.end());
+    part_          = part;
 }
+
 
 }  // namespace distribution
 }  // namespace detail

--- a/src/atlas/grid/detail/distribution/SerialDistribution.h
+++ b/src/atlas/grid/detail/distribution/SerialDistribution.h
@@ -20,11 +20,12 @@ namespace distribution {
 class SerialDistribution : public DistributionFunctionT<SerialDistribution> {
 public:
     SerialDistribution(const Grid& grid);
+    SerialDistribution(const Grid& grid, int part);
 
-    ATLAS_ALWAYS_INLINE int function(gidx_t gidx) const { return rank_; }
+    ATLAS_ALWAYS_INLINE int function(gidx_t gidx) const { return part_; }
 
 private:
-    int rank_{0};
+    int part_{0};
 };
 
 }  // namespace distribution

--- a/src/atlas/grid/detail/partitioner/BandsPartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/BandsPartitioner.cc
@@ -33,9 +33,9 @@ size_t BandsPartitioner::blocksize(const Grid& grid) const {
     return size_t(blocksize_);
 }
 
-BandsPartitioner::BandsPartitioner(): Partitioner(), blocksize_{1} {}
+BandsPartitioner::BandsPartitioner( const eckit::Parametrisation& config): Partitioner(config), blocksize_{1} {}
 
-BandsPartitioner::BandsPartitioner(int N, int blocksize): Partitioner(N), blocksize_(blocksize) {}
+BandsPartitioner::BandsPartitioner(int N, int blocksize, const eckit::Parametrisation& config): Partitioner(N, config), blocksize_(blocksize) {}
 
 Distribution BandsPartitioner::partition(const Partitioner::Grid& grid) const {
     if (not distribution::BandsDistribution<int32_t>::detectOverflow(grid.size(), nb_partitions(), blocksize((grid)))) {

--- a/src/atlas/grid/detail/partitioner/BandsPartitioner.h
+++ b/src/atlas/grid/detail/partitioner/BandsPartitioner.h
@@ -35,10 +35,9 @@ protected:
     static constexpr int BLOCKSIZE_NX{-1};
 
 public:
-    BandsPartitioner();
-    BandsPartitioner(int N): BandsPartitioner(N, 1) {}
-    BandsPartitioner(int N, int blocksize);
-    BandsPartitioner(int N, const eckit::Parametrisation& config): BandsPartitioner(N, extract_blocksize(config)) {}
+    BandsPartitioner(const eckit::Parametrisation& config = util::NoConfig());
+    BandsPartitioner(int N, const eckit::Parametrisation& config): BandsPartitioner(N, extract_blocksize(config), config) {}
+    BandsPartitioner(int N, int blocksize, const eckit::Parametrisation& config = util::NoConfig());
 
     std::string type() const override { return static_type(); }
     static std::string static_type() { return "bands"; }

--- a/src/atlas/grid/detail/partitioner/CheckerboardPartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/CheckerboardPartitioner.cc
@@ -33,17 +33,24 @@ namespace partitioner {
 
 CheckerboardPartitioner::CheckerboardPartitioner(): Partitioner() {}
 
-CheckerboardPartitioner::CheckerboardPartitioner(int N): Partitioner(N) {}
+// CheckerboardPartitioner::CheckerboardPartitioner(int N): Partitioner(N) {}
 
-CheckerboardPartitioner::CheckerboardPartitioner(int N, const eckit::Parametrisation& config): Partitioner(N) {
+CheckerboardPartitioner::CheckerboardPartitioner(int N, const eckit::Parametrisation& config):
+    Partitioner(N, config) {
     config.get("bands", nbands_);
     config.get("regular", regular_);
 }
 
-CheckerboardPartitioner::CheckerboardPartitioner(int N, int nbands): Partitioner(N), nbands_{nbands} {}
+CheckerboardPartitioner::CheckerboardPartitioner(const eckit::Parametrisation& config) :
+    Partitioner(config) {
+    config.get("bands", nbands_);
+    config.get("regular", regular_);
+}
 
-CheckerboardPartitioner::CheckerboardPartitioner(int N, int nbands, bool checkerboard):
-    Partitioner(N), nbands_{nbands} {}
+// CheckerboardPartitioner::CheckerboardPartitioner(int N, int nbands): Partitioner(N), nbands_{nbands} {}
+
+// CheckerboardPartitioner::CheckerboardPartitioner(int N, int nbands, bool checkerboard):
+    // Partitioner(N), nbands_{nbands} {}
 
 CheckerboardPartitioner::Checkerboard CheckerboardPartitioner::checkerboard(const Grid& grid) const {
     // grid dimensions

--- a/src/atlas/grid/detail/partitioner/CheckerboardPartitioner.h
+++ b/src/atlas/grid/detail/partitioner/CheckerboardPartitioner.h
@@ -23,11 +23,13 @@ class CheckerboardPartitioner : public Partitioner {
 public:
     CheckerboardPartitioner();
 
-    CheckerboardPartitioner(int N);  // N is the number of parts (aka MPI tasks)
+    // CheckerboardPartitioner(int N);  // N is the number of parts (aka MPI tasks)
     CheckerboardPartitioner(int N, const eckit::Parametrisation&);
 
     CheckerboardPartitioner(int N, int nbands);
     CheckerboardPartitioner(int N, int nbands, bool checkerboard);
+
+    CheckerboardPartitioner(const eckit::Parametrisation&);
 
     // Node struct that holds the x and y indices (for global, it's longitude and
     // latitude in millidegrees (integers))

--- a/src/atlas/grid/detail/partitioner/CubedSpherePartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/CubedSpherePartitioner.cc
@@ -19,7 +19,6 @@
 #include <vector>
 
 #include "atlas/grid/CubedSphereGrid.h"
-#include "atlas/parallel/mpi/mpi.h"
 #include "atlas/runtime/Exception.h"
 #include "atlas/runtime/Log.h"
 

--- a/src/atlas/grid/detail/partitioner/CubedSpherePartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/CubedSpherePartitioner.cc
@@ -76,10 +76,21 @@ std::vector<std::vector<atlas::idx_t>> createOffset(const std::array<std::size_t
 
 CubedSpherePartitioner::CubedSpherePartitioner(): Partitioner() {}
 
-CubedSpherePartitioner::CubedSpherePartitioner(int N): Partitioner(N), regular_{true} {}
+CubedSpherePartitioner::CubedSpherePartitioner(int N): Partitioner(N, util::NoConfig()), regular_{true} {}
+
+CubedSpherePartitioner::CubedSpherePartitioner(const eckit::Parametrisation& config):
+    Partitioner(config), regular_{isConfigSufficient(config)} {
+    if (config.has("starting rank on tile") && config.has("final rank on tile") && config.has("nprocx") &&
+        config.has("nprocy")) {
+        config.get("starting rank on tile", globalProcStartPE_);
+        config.get("final rank on tile", globalProcEndPE_);
+        config.get("nprocx", nprocx_);
+        config.get("nprocy", nprocy_);
+    }
+}
 
 CubedSpherePartitioner::CubedSpherePartitioner(int N, const eckit::Parametrisation& config):
-    Partitioner(N), regular_{isConfigSufficient(config)} {
+    Partitioner(N, config), regular_{isConfigSufficient(config)} {
     if (config.has("starting rank on tile") && config.has("final rank on tile") && config.has("nprocx") &&
         config.has("nprocy")) {
         config.get("starting rank on tile", globalProcStartPE_);
@@ -92,7 +103,7 @@ CubedSpherePartitioner::CubedSpherePartitioner(int N, const eckit::Parametrisati
 CubedSpherePartitioner::CubedSpherePartitioner(const int N, const std::vector<int>& globalProcStartPE,
                                                const std::vector<int>& globalProcEndPE, const std::vector<int>& nprocx,
                                                const std::vector<int>& nprocy):
-    Partitioner(N),
+    Partitioner(N, util::NoConfig()),
     globalProcStartPE_(globalProcStartPE.begin(), globalProcStartPE.end()),
     globalProcEndPE_(globalProcEndPE.begin(), globalProcEndPE.end()),
     nprocx_{nprocx.begin(), nprocx.end()},

--- a/src/atlas/grid/detail/partitioner/CubedSpherePartitioner.h
+++ b/src/atlas/grid/detail/partitioner/CubedSpherePartitioner.h
@@ -26,6 +26,7 @@ public:
 
     CubedSpherePartitioner(int N);  // N is the number of parts (aka MPI tasks)
     CubedSpherePartitioner(int N, const eckit::Parametrisation&);
+    CubedSpherePartitioner(const eckit::Parametrisation&);
 
     CubedSpherePartitioner(const int N, const std::vector<int>& globalProcStartPE,
                            const std::vector<int>& globalProcEndPE, const std::vector<int>& nprocx,

--- a/src/atlas/grid/detail/partitioner/EqualBandsPartitioner.h
+++ b/src/atlas/grid/detail/partitioner/EqualBandsPartitioner.h
@@ -22,7 +22,8 @@ namespace partitioner {
 class EqualBandsPartitioner : public BandsPartitioner {
 public:
     EqualBandsPartitioner();
-    EqualBandsPartitioner(int N, const eckit::Parametrisation& config = util::NoConfig()): BandsPartitioner(N, 1) {}
+    EqualBandsPartitioner(const eckit::Parametrisation& config): BandsPartitioner(extract_nb_partitions(config), config) {}
+    EqualBandsPartitioner(int N, const eckit::Parametrisation& config = util::NoConfig()): BandsPartitioner(N, 1, config) {}
     std::string type() const override { return static_type(); }
     static std::string static_type() { return "equal_bands"; }
 };

--- a/src/atlas/grid/detail/partitioner/EqualRegionsPartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/EqualRegionsPartitioner.cc
@@ -441,6 +441,7 @@ void eq_regions(int N, double xmin[], double xmax[], double ymin[], double ymax[
 }
 
 void EqualRegionsPartitioner::init() {
+    N_ = nb_partitions();
     std::vector<double> s_cap;
     eq_caps(N_, sectors_, s_cap);
     bands_.resize(s_cap.size());
@@ -449,22 +450,35 @@ void EqualRegionsPartitioner::init() {
     }
 }
 
-EqualRegionsPartitioner::EqualRegionsPartitioner(): Partitioner(), N_(nb_partitions()) {
+EqualRegionsPartitioner::EqualRegionsPartitioner(): 
+    Partitioner() {
     init();
 }
 
-EqualRegionsPartitioner::EqualRegionsPartitioner(int N): Partitioner(N), N_(N) {
-    init();
+EqualRegionsPartitioner::EqualRegionsPartitioner(int N): 
+    EqualRegionsPartitioner(N, util::NoConfig()) {
 }
 
 EqualRegionsPartitioner::EqualRegionsPartitioner(int N, const eckit::Parametrisation& config):
-    EqualRegionsPartitioner(N) {
+    Partitioner(N,config) {
     std::string crds;
     if (config.get("coordinates", crds)) {
         if (crds == "lonlat") {
             coordinates_ = Coordinates::LONLAT;
         }
     }
+    init();
+}
+
+EqualRegionsPartitioner::EqualRegionsPartitioner(const eckit::Parametrisation& config):
+    Partitioner(config) {
+    std::string crds;
+    if (config.get("coordinates", crds)) {
+        if (crds == "lonlat") {
+            coordinates_ = Coordinates::LONLAT;
+        }
+    }
+    init();
 }
 
 int EqualRegionsPartitioner::partition(const double& x, const double& y) const {

--- a/src/atlas/grid/detail/partitioner/EqualRegionsPartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/EqualRegionsPartitioner.cc
@@ -619,7 +619,7 @@ void EqualRegionsPartitioner::partition(const Grid& grid, int part[]) const {
 
         ATLAS_ASSERT(grid.projection().units() == "degrees");
 
-        const auto& comm = mpi::comm();
+        const auto& comm = mpi::comm(mpi_comm());
         int mpi_rank     = static_cast<int>(comm.rank());
         int mpi_size     = static_cast<int>(comm.size());
 

--- a/src/atlas/grid/detail/partitioner/EqualRegionsPartitioner.h
+++ b/src/atlas/grid/detail/partitioner/EqualRegionsPartitioner.h
@@ -81,6 +81,7 @@ public:
 
     EqualRegionsPartitioner(int N);
     EqualRegionsPartitioner(int N, const eckit::Parametrisation& config);
+    EqualRegionsPartitioner(const eckit::Parametrisation& config);
 
     void where(int partition, int& band, int& sector) const;
     int nb_bands() const { return bands_.size(); }

--- a/src/atlas/grid/detail/partitioner/MatchingFunctionSpacePartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/MatchingFunctionSpacePartitioner.cc
@@ -28,7 +28,7 @@ MatchingFunctionSpacePartitioner::MatchingFunctionSpacePartitioner(const idx_t n
 }
 
 MatchingFunctionSpacePartitioner::MatchingFunctionSpacePartitioner(const FunctionSpace& functionspace):
-    Partitioner(functionspace.nb_partitions()), partitioned_(functionspace) {}
+    Partitioner(functionspace.nb_parts()), partitioned_(functionspace) {}
 
 }  // namespace partitioner
 }  // namespace detail

--- a/src/atlas/grid/detail/partitioner/MatchingFunctionSpacePartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/MatchingFunctionSpacePartitioner.cc
@@ -22,13 +22,13 @@ MatchingFunctionSpacePartitioner::MatchingFunctionSpacePartitioner(): Partitione
     ATLAS_NOTIMPLEMENTED;
 }
 
-MatchingFunctionSpacePartitioner::MatchingFunctionSpacePartitioner(const idx_t nb_partitions):
-    Partitioner(nb_partitions) {
-    ATLAS_NOTIMPLEMENTED;
-}
+// MatchingFunctionSpacePartitioner::MatchingFunctionSpacePartitioner(const idx_t nb_partitions):
+//     Partitioner(nb_partitions) {
+//     ATLAS_NOTIMPLEMENTED;
+// }
 
-MatchingFunctionSpacePartitioner::MatchingFunctionSpacePartitioner(const FunctionSpace& functionspace):
-    Partitioner(functionspace.nb_parts()), partitioned_(functionspace) {}
+MatchingFunctionSpacePartitioner::MatchingFunctionSpacePartitioner(const FunctionSpace& functionspace, const eckit::Parametrisation&):
+    Partitioner(functionspace.nb_parts(),util::Config("mpi_comm",functionspace.mpi_comm())), partitioned_(functionspace) {}
 
 }  // namespace partitioner
 }  // namespace detail

--- a/src/atlas/grid/detail/partitioner/MatchingFunctionSpacePartitioner.h
+++ b/src/atlas/grid/detail/partitioner/MatchingFunctionSpacePartitioner.h
@@ -24,9 +24,9 @@ class MatchingFunctionSpacePartitioner : public Partitioner {
 public:
     MatchingFunctionSpacePartitioner();
 
-    MatchingFunctionSpacePartitioner(const idx_t nb_partitions);
+    // MatchingFunctionSpacePartitioner(const idx_t nb_partitions);
 
-    MatchingFunctionSpacePartitioner(const FunctionSpace&);
+    MatchingFunctionSpacePartitioner(const FunctionSpace&, const eckit::Parametrisation&);
 
     virtual ~MatchingFunctionSpacePartitioner() override {}
 

--- a/src/atlas/grid/detail/partitioner/MatchingFunctionSpacePartitionerLonLatPolygon.h
+++ b/src/atlas/grid/detail/partitioner/MatchingFunctionSpacePartitionerLonLatPolygon.h
@@ -23,10 +23,10 @@ public:
 
 public:
     MatchingFunctionSpacePartitionerLonLatPolygon(): MatchingFunctionSpacePartitioner() {}
-    MatchingFunctionSpacePartitionerLonLatPolygon(const size_t nb_partitions):
-        MatchingFunctionSpacePartitioner(nb_partitions) {}
-    MatchingFunctionSpacePartitionerLonLatPolygon(const FunctionSpace& FunctionSpace):
-        MatchingFunctionSpacePartitioner(FunctionSpace) {}
+    // MatchingFunctionSpacePartitionerLonLatPolygon(const size_t nb_partitions):
+    //     MatchingFunctionSpacePartitioner(nb_partitions) {}
+    MatchingFunctionSpacePartitionerLonLatPolygon(const FunctionSpace& FunctionSpace, const eckit::Parametrisation& config):
+        MatchingFunctionSpacePartitioner(FunctionSpace, config) {}
 
     using MatchingFunctionSpacePartitioner::partition;
     /**

--- a/src/atlas/grid/detail/partitioner/MatchingMeshPartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/MatchingMeshPartitioner.cc
@@ -25,7 +25,7 @@ MatchingMeshPartitioner::MatchingMeshPartitioner(const idx_t nb_partitions): Par
 }
 
 MatchingMeshPartitioner::MatchingMeshPartitioner(const Mesh& mesh):
-    Partitioner(mesh.nb_partitions()), prePartitionedMesh_(mesh) {}
+    Partitioner(mesh.nb_parts()), prePartitionedMesh_(mesh) {}
 
 }  // namespace partitioner
 }  // namespace detail

--- a/src/atlas/grid/detail/partitioner/MatchingMeshPartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/MatchingMeshPartitioner.cc
@@ -20,12 +20,12 @@ MatchingMeshPartitioner::MatchingMeshPartitioner(): Partitioner() {
     ATLAS_NOTIMPLEMENTED;
 }
 
-MatchingMeshPartitioner::MatchingMeshPartitioner(const idx_t nb_partitions): Partitioner(nb_partitions) {
-    ATLAS_NOTIMPLEMENTED;
-}
+// MatchingMeshPartitioner::MatchingMeshPartitioner(const idx_t nb_partitions): Partitioner(nb_partitions) {
+    // ATLAS_NOTIMPLEMENTED;
+// }
 
-MatchingMeshPartitioner::MatchingMeshPartitioner(const Mesh& mesh):
-    Partitioner(mesh.nb_parts()), prePartitionedMesh_(mesh) {}
+MatchingMeshPartitioner::MatchingMeshPartitioner(const Mesh& mesh, const eckit::Parametrisation&):
+    Partitioner(mesh.nb_parts(),util::Config("mpi_comm",mesh.mpi_comm())), prePartitionedMesh_(mesh) {}
 
 }  // namespace partitioner
 }  // namespace detail

--- a/src/atlas/grid/detail/partitioner/MatchingMeshPartitioner.h
+++ b/src/atlas/grid/detail/partitioner/MatchingMeshPartitioner.h
@@ -24,9 +24,9 @@ class MatchingMeshPartitioner : public Partitioner {
 public:
     MatchingMeshPartitioner();
 
-    MatchingMeshPartitioner(const idx_t nb_partitions);
+    // MatchingMeshPartitioner(const idx_t nb_partitions);
 
-    MatchingMeshPartitioner(const Mesh&);
+    MatchingMeshPartitioner(const Mesh&, const eckit::Parametrisation&);
 
     virtual ~MatchingMeshPartitioner() override {}
 

--- a/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerBruteForce.cc
+++ b/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerBruteForce.cc
@@ -75,9 +75,9 @@ bool point_in_quadrilateral(const PointLonLat& P, const PointLonLat& A, const Po
 void MatchingMeshPartitionerBruteForce::partition(const Grid& grid, int partitioning[]) const {
     ATLAS_TRACE("MatchingMeshPartitionerBruteForce::partition");
 
-
-    eckit::mpi::Comm& comm = eckit::mpi::comm();
-    const int mpi_rank     = int(comm.rank());
+    const auto& comm   = mpi::comm(prePartitionedMesh_.mpi_comm());
+    const int mpi_rank = int(comm.rank());
+    const int mpi_size = int(comm.size());
 
     // Point coordinates
     // - use a bounding box to quickly discard points,

--- a/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerBruteForce.h
+++ b/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerBruteForce.h
@@ -22,11 +22,14 @@ public:
     static std::string static_type() { return "brute-force"; }
 
 public:
+    MatchingMeshPartitionerBruteForce(const Mesh& mesh, const eckit::Parametrisation& config): MatchingMeshPartitioner(mesh, config) {}
+
+
     MatchingMeshPartitionerBruteForce(): MatchingMeshPartitioner() {}
-    MatchingMeshPartitionerBruteForce(const idx_t nb_partitions): MatchingMeshPartitioner(nb_partitions) {}
+    MatchingMeshPartitionerBruteForce(const eckit::Parametrisation&): MatchingMeshPartitioner() {}
+    MatchingMeshPartitionerBruteForce(const idx_t nb_partitions): MatchingMeshPartitioner() {}
     MatchingMeshPartitionerBruteForce(const idx_t nb_partitions, const eckit::Parametrisation&):
-        MatchingMeshPartitioner(nb_partitions) {}
-    MatchingMeshPartitionerBruteForce(const Mesh& mesh): MatchingMeshPartitioner(mesh) {}
+        MatchingMeshPartitioner() {}
 
     using MatchingMeshPartitioner::partition;
     virtual void partition(const Grid& grid, int partitioning[]) const;

--- a/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerCubedSphere.h
+++ b/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerCubedSphere.h
@@ -21,10 +21,10 @@ public:
 
 public:
     MatchingMeshPartitionerCubedSphere(): MatchingMeshPartitioner() {}
-    MatchingMeshPartitionerCubedSphere(const idx_t nb_partitions): MatchingMeshPartitioner(nb_partitions) {}
-    MatchingMeshPartitionerCubedSphere(const idx_t nb_partitions, const eckit::Parametrisation&):
-        MatchingMeshPartitioner(nb_partitions) {}
-    MatchingMeshPartitionerCubedSphere(const Mesh& mesh): MatchingMeshPartitioner(mesh) {}
+    // MatchingMeshPartitionerCubedSphere(const idx_t nb_partitions): MatchingMeshPartitioner(nb_partitions) {}
+    // MatchingMeshPartitionerCubedSphere(const idx_t nb_partitions, const eckit::Parametrisation&):
+    //     MatchingMeshPartitioner(nb_partitions) {}
+    MatchingMeshPartitionerCubedSphere(const Mesh& mesh, const eckit::Parametrisation& config): MatchingMeshPartitioner(mesh, config) {}
 
     using MatchingMeshPartitioner::partition;
     virtual void partition(const Grid& grid, int partitioning[]) const;

--- a/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerLonLatPolygon.cc
+++ b/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerLonLatPolygon.cc
@@ -38,9 +38,9 @@ PartitionerBuilder<MatchingMeshPartitionerLonLatPolygon> __builder("lonlat-polyg
 }
 
 void MatchingMeshPartitionerLonLatPolygon::partition(const Grid& grid, int partitioning[]) const {
-    const eckit::mpi::Comm& comm = atlas::mpi::comm();
-    const int mpi_rank           = int(comm.rank());
-    const int mpi_size           = int(comm.size());
+    const auto& comm   = mpi::comm(prePartitionedMesh_.mpi_comm());
+    const int mpi_rank = int(comm.rank());
+    const int mpi_size = int(comm.size());
 
     ATLAS_TRACE("MatchingMeshPartitionerLonLatPolygon::partition");
 

--- a/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerLonLatPolygon.h
+++ b/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerLonLatPolygon.h
@@ -22,11 +22,14 @@ public:
     static std::string static_type() { return "lonlat-polygon"; }
 
 public:
+    MatchingMeshPartitionerLonLatPolygon(const Mesh& mesh, const eckit::Parametrisation& config): MatchingMeshPartitioner(mesh, config) {}
+
+
     MatchingMeshPartitionerLonLatPolygon(): MatchingMeshPartitioner() {}
-    MatchingMeshPartitionerLonLatPolygon(const size_t nb_partitions): MatchingMeshPartitioner(nb_partitions) {}
+    MatchingMeshPartitionerLonLatPolygon(const eckit::Parametrisation&): MatchingMeshPartitioner() {}
+    MatchingMeshPartitionerLonLatPolygon(const size_t nb_partitions): MatchingMeshPartitioner() {}
     MatchingMeshPartitionerLonLatPolygon(const size_t nb_partitions, const eckit::Parametrisation& config):
-        MatchingMeshPartitioner(nb_partitions) {}
-    MatchingMeshPartitionerLonLatPolygon(const Mesh& mesh): MatchingMeshPartitioner(mesh) {}
+        MatchingMeshPartitioner() {}
 
     using Partitioner::partition;
 

--- a/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerSphericalPolygon.cc
+++ b/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerSphericalPolygon.cc
@@ -34,9 +34,9 @@ PartitionerBuilder<MatchingMeshPartitionerSphericalPolygon> __builder("spherical
 }
 
 void MatchingMeshPartitionerSphericalPolygon::partition(const Grid& grid, int partitioning[]) const {
-    const eckit::mpi::Comm& comm = atlas::mpi::comm();
-    const int mpi_rank           = int(comm.rank());
-    const int mpi_size           = int(comm.size());
+    const auto& comm   = mpi::comm(prePartitionedMesh_.mpi_comm());
+    const int mpi_rank = int(comm.rank());
+    const int mpi_size = int(comm.size());
 
     ATLAS_TRACE("MatchingMeshPartitionerSphericalPolygon::partition");
 

--- a/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerSphericalPolygon.h
+++ b/src/atlas/grid/detail/partitioner/MatchingMeshPartitionerSphericalPolygon.h
@@ -22,11 +22,14 @@ public:
     static std::string static_type() { return "spherical-polygon"; }
 
 public:
+    MatchingMeshPartitionerSphericalPolygon(const Mesh& mesh, const eckit::Parametrisation& config): MatchingMeshPartitioner(mesh, config) {}
+
+    // Following throw ATLAS_NOT_IMPLEMENTED
     MatchingMeshPartitionerSphericalPolygon(): MatchingMeshPartitioner() {}
-    MatchingMeshPartitionerSphericalPolygon(const idx_t nb_partitions): MatchingMeshPartitioner(nb_partitions) {}
+    MatchingMeshPartitionerSphericalPolygon(const idx_t nb_partitions): MatchingMeshPartitioner() {}
     MatchingMeshPartitionerSphericalPolygon(const idx_t nb_partitions, const eckit::Parametrisation& config):
-        MatchingMeshPartitioner(nb_partitions) {}
-    MatchingMeshPartitionerSphericalPolygon(const Mesh& mesh): MatchingMeshPartitioner(mesh) {}
+        MatchingMeshPartitioner() {}
+    MatchingMeshPartitionerSphericalPolygon(const eckit::Parametrisation&): MatchingMeshPartitioner() {}
 
     using MatchingMeshPartitioner::partition;
     /**

--- a/src/atlas/grid/detail/partitioner/Partitioner.h
+++ b/src/atlas/grid/detail/partitioner/Partitioner.h
@@ -36,7 +36,9 @@ public:
 
 public:
     Partitioner();
-    Partitioner(const idx_t nb_partitions);
+    Partitioner(const idx_t nb_partitions, const eckit::Parametrisation&);
+    Partitioner(const eckit::Parametrisation&);
+
     virtual ~Partitioner();
 
     virtual void partition(const Grid& grid, int part[]) const = 0;
@@ -47,8 +49,14 @@ public:
 
     virtual std::string type() const = 0;
 
+    std::string mpi_comm() const;
+
+    static int extract_nb_partitions(const eckit::Parametrisation&);
+    static std::string extract_mpi_comm(const eckit::Parametrisation&);
+
 private:
     idx_t nb_partitions_;
+    std::string mpi_comm_;
 };
 
 // ------------------------------------------------------------------
@@ -65,6 +73,7 @@ public:
     static Partitioner* build(const std::string&);
     static Partitioner* build(const std::string&, const idx_t nb_partitions);
     static Partitioner* build(const std::string&, const idx_t nb_partitions, const eckit::Parametrisation&);
+    static Partitioner* build(const std::string&, const eckit::Parametrisation&);
 
     /*!
    * \brief list all registered partioner builders
@@ -77,6 +86,7 @@ private:
     virtual Partitioner* make()                                                         = 0;
     virtual Partitioner* make(const idx_t nb_partitions)                                = 0;
     virtual Partitioner* make(const idx_t nb_partitions, const eckit::Parametrisation&) = 0;
+    virtual Partitioner* make(const eckit::Parametrisation&) = 0;
 
 protected:
     PartitionerFactory(const std::string&);
@@ -89,9 +99,12 @@ template <class T>
 class PartitionerBuilder : public PartitionerFactory {
     virtual Partitioner* make() { return new T(); }
 
-    virtual Partitioner* make(const idx_t nb_partitions) { return new T(nb_partitions); }
+    virtual Partitioner* make(const idx_t nb_partitions) { return new T(nb_partitions, util::NoConfig()); }
     virtual Partitioner* make(const idx_t nb_partitions, const eckit::Parametrisation& config) {
         return new T(nb_partitions, config);
+    }
+    virtual Partitioner* make(const eckit::Parametrisation& config) {
+        return new T(config);
     }
 
 public:
@@ -102,8 +115,8 @@ public:
 
 class MatchingPartitionerFactory {
 public:
-    static Partitioner* build(const std::string& type, const Mesh& partitioned);
-    static Partitioner* build(const std::string& type, const FunctionSpace& partitioned);
+    static Partitioner* build(const std::string& type, const Mesh& partitioned, const eckit::Parametrisation& config);
+    static Partitioner* build(const std::string& type, const FunctionSpace& partitioned, const eckit::Parametrisation& config);
 };
 
 // ------------------------------------------------------------------

--- a/src/atlas/grid/detail/partitioner/RegularBandsPartitioner.h
+++ b/src/atlas/grid/detail/partitioner/RegularBandsPartitioner.h
@@ -22,7 +22,9 @@ class RegularBandsPartitioner : public BandsPartitioner {
 public:
     RegularBandsPartitioner();
     RegularBandsPartitioner(int N, const eckit::Parametrisation& config = util::NoConfig()):
-        BandsPartitioner(N, BLOCKSIZE_NX) {}
+        BandsPartitioner(N, BLOCKSIZE_NX, config) {}
+    RegularBandsPartitioner(const eckit::Parametrisation& config):
+        RegularBandsPartitioner(extract_nb_partitions(config), config) {}
     std::string type() const override { return static_type(); }
     static std::string static_type() { return "regular_bands"; }
 };

--- a/src/atlas/grid/detail/partitioner/SerialPartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/SerialPartitioner.cc
@@ -11,9 +11,26 @@
 
 #include "SerialPartitioner.h"
 
+#include "atlas/parallel/mpi/mpi.h"
+
 namespace {
 atlas::grid::detail::partitioner::PartitionerBuilder<atlas::grid::detail::partitioner::SerialPartitioner> __Serial(
     atlas::grid::detail::partitioner::SerialPartitioner::static_type());
 }
 
-atlas::grid::detail::partitioner::SerialPartitioner::SerialPartitioner(): Partitioner(1) {}
+namespace atlas {
+namespace grid {
+namespace detail {
+namespace partitioner {
+
+SerialPartitioner::SerialPartitioner(const eckit::Parametrisation& config): 
+    Partitioner(config) {
+    part_ = mpi::comm(mpi_comm()).rank();
+    config.get("part", part_);
+    config.get("partition", part_);
+}
+
+}
+}
+}
+}

--- a/src/atlas/grid/detail/partitioner/SerialPartitioner.h
+++ b/src/atlas/grid/detail/partitioner/SerialPartitioner.h
@@ -22,24 +22,32 @@ namespace partitioner {
 
 class SerialPartitioner : public Partitioner {
 public:
-    SerialPartitioner();
-    SerialPartitioner(int N, const eckit::Parametrisation& config): Partitioner(1) {}
-
-    SerialPartitioner(int N): Partitioner(N) {}
+    SerialPartitioner():
+        Partitioner(1, util::NoConfig()) {
+    }
+    SerialPartitioner(int /*N*/): 
+        SerialPartitioner() {
+    }
+    SerialPartitioner(int /*N*/, const eckit::Parametrisation& config): 
+        SerialPartitioner(config) {
+    }
+    SerialPartitioner(const eckit::Parametrisation& config);
 
     std::string type() const override { return static_type(); }
     static std::string static_type() { return "serial"; }
 
     Distribution partition(const Grid& grid) const override {
-        return Distribution{new distribution::SerialDistribution{grid}};
+        return Distribution{new distribution::SerialDistribution{grid, part_}};
     }
 
     void partition(const Grid& grid, int part[]) const override {
         gidx_t gridsize = grid.size();
         for (gidx_t n = 0; n < gridsize; ++n) {
-            part[n] = 0.;
+            part[n] = part_;
         }
     }
+private:
+    int part_{0};
 };
 
 

--- a/src/atlas/grid/detail/partitioner/TransPartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/TransPartitioner.cc
@@ -33,7 +33,16 @@ TransPartitioner::TransPartitioner(): Partitioner() {
     }
 }
 
-TransPartitioner::TransPartitioner(const idx_t N, const eckit::Parametrisation&): Partitioner(N) {
+TransPartitioner::TransPartitioner(const eckit::Parametrisation& config): Partitioner(config) {
+    EqualRegionsPartitioner eqreg(config);
+    nbands_ = eqreg.nb_bands();
+    nregions_.resize(nbands_);
+    for (size_t b = 0; b < nbands_; ++b) {
+        nregions_[b] = eqreg.nb_regions(b);
+    }
+}
+
+TransPartitioner::TransPartitioner(const idx_t N, const eckit::Parametrisation& config): Partitioner(N,config) {
     EqualRegionsPartitioner eqreg(nb_partitions());
     nbands_ = eqreg.nb_bands();
     nregions_.resize(nbands_);

--- a/src/atlas/grid/detail/partitioner/TransPartitioner.h
+++ b/src/atlas/grid/detail/partitioner/TransPartitioner.h
@@ -30,6 +30,8 @@ public:
     /// @brief Constructor
     TransPartitioner();
 
+    TransPartitioner(const eckit::Parametrisation&);
+
     TransPartitioner(const idx_t nb_partitions, const eckit::Parametrisation& = util::NoConfig());
 
     virtual ~TransPartitioner();

--- a/src/atlas/interpolation/method/structured/StructuredInterpolation2D.tcc
+++ b/src/atlas/interpolation/method/structured/StructuredInterpolation2D.tcc
@@ -193,7 +193,7 @@ namespace {
                 src_fs_config.set("source.grid",src_fs.grid().spec());
                 src_fs_config.set("source.halo",src_fs.halo());
                 src_fs_config.set("source.distribution",src_fs.distribution());
-                src_fs_config.set("source.partitions",src_fs.nb_partitions());
+                src_fs_config.set("source.partitions",src_fs.nb_parts());
                 src_fs_config.set("interpolation","StructuredInterpolation2D<"+interpolation.kernel().className()+">");
                 f << src_fs_config.json();
             }

--- a/src/atlas/mesh/Mesh.cc
+++ b/src/atlas/mesh/Mesh.cc
@@ -40,14 +40,14 @@ Mesh::Mesh(const Grid& grid, const eckit::Configuration& config):
 
 Mesh::Mesh(const Grid& grid, const grid::Partitioner& partitioner, const eckit::Configuration& config):
     Handle([&]() {
+        std::string mpi_comm = partitioner.mpi_comm();
         if(config.has("mpi_comm")) {
-            mpi::push(config.getString("mpi_comm"));
+            mpi_comm = config.getString("mpi_comm");
+            ATLAS_ASSERT(mpi_comm == partitioner.mpi_comm());
         }
+        mpi::Scope mpi_scope(mpi_comm);
         auto meshgenerator = MeshGenerator{grid.meshgenerator()|config};
         auto mesh          = meshgenerator.generate(grid, partitioner);
-        if(config.has("mpi_comm")) {
-            mpi::pop();
-        }
         mesh.get()->attach();
         return mesh.get();
     }()) {

--- a/src/atlas/mesh/Mesh.cc
+++ b/src/atlas/mesh/Mesh.cc
@@ -13,6 +13,7 @@
 #include "atlas/grid/Grid.h"
 #include "atlas/grid/Partitioner.h"
 #include "atlas/meshgenerator/MeshGenerator.h"
+#include "atlas/parallel/mpi/mpi.h"
 
 namespace atlas {
 
@@ -20,20 +21,33 @@ namespace atlas {
 
 Mesh::Mesh(): Handle(new Implementation()) {}
 
-Mesh::Mesh(const Grid& grid):
+Mesh::Mesh(const Grid& grid, const eckit::Configuration& config):
     Handle([&]() {
-        auto meshgenerator = MeshGenerator{grid.meshgenerator()};
-        auto mesh          = meshgenerator.generate(grid, grid::Partitioner(grid.partitioner()));
+        if(config.has("mpi_comm")) {
+            mpi::push(config.getString("mpi_comm"));
+        }
+        util::Config cfg = grid.meshgenerator()|util::Config(config);
+        auto meshgenerator = MeshGenerator{grid.meshgenerator()|config};
+        auto mesh          = meshgenerator.generate(grid, grid::Partitioner(grid.partitioner()|config));
+        if(config.has("mpi_comm")) {
+            mpi::pop();
+        }
         mesh.get()->attach();
         return mesh.get();
     }()) {
     get()->detach();
 }
 
-Mesh::Mesh(const Grid& grid, const grid::Partitioner& partitioner):
+Mesh::Mesh(const Grid& grid, const grid::Partitioner& partitioner, const eckit::Configuration& config):
     Handle([&]() {
-        auto meshgenerator = MeshGenerator{grid.meshgenerator()};
+        if(config.has("mpi_comm")) {
+            mpi::push(config.getString("mpi_comm"));
+        }
+        auto meshgenerator = MeshGenerator{grid.meshgenerator()|config};
         auto mesh          = meshgenerator.generate(grid, partitioner);
+        if(config.has("mpi_comm")) {
+            mpi::pop();
+        }
         mesh.get()->attach();
         return mesh.get();
     }()) {

--- a/src/atlas/mesh/Mesh.h
+++ b/src/atlas/mesh/Mesh.h
@@ -76,9 +76,9 @@ public:
     operator bool() const;
 
     /// @brief Generate a mesh from a Grid with recommended mesh generator and partitioner strategy
-    Mesh(const Grid&);
+    Mesh(const Grid&, const eckit::Configuration& = util::NoConfig());
 
-    Mesh(const Grid&, const grid::Partitioner&);
+    Mesh(const Grid&, const grid::Partitioner&, const eckit::Configuration& = util::NoConfig());
 
     /// @brief Construct a mesh from a Stream (serialization)
     explicit Mesh(eckit::Stream&);

--- a/src/atlas/mesh/Mesh.h
+++ b/src/atlas/mesh/Mesh.h
@@ -112,9 +112,9 @@ public:
     /// @brief Return the memory footprint of the mesh
     size_t footprint() const { return get()->footprint(); }
 
-    idx_t partition() const { return get()->partition(); }
+    idx_t part() const { return get()->part(); }
 
-    idx_t nb_partitions() const { return get()->nb_partitions(); }
+    idx_t nb_parts() const { return get()->nb_parts(); }
 
     std::string mpi_comm() const { return get()->mpi_comm(); }
 

--- a/src/atlas/mesh/Mesh.h
+++ b/src/atlas/mesh/Mesh.h
@@ -116,6 +116,8 @@ public:
 
     idx_t nb_partitions() const { return get()->nb_partitions(); }
 
+    std::string mpi_comm() const { return get()->mpi_comm(); }
+
     void updateDevice() const { get()->updateDevice(); }
 
     void updateHost() const { get()->updateHost(); }

--- a/src/atlas/mesh/MeshBuilder.cc
+++ b/src/atlas/mesh/MeshBuilder.cc
@@ -164,9 +164,10 @@ Mesh MeshBuilder::operator()(size_t nb_nodes, const double lons[], const double 
     auto mpi_comm_name = [](const auto& config) {
         return config.getString("mpi_comm", atlas::mpi::comm().name());
     };
-    const eckit::mpi::Comm& comm = eckit::mpi::comm(mpi_comm_name(config).c_str());
 
     Mesh mesh{};
+    mesh.metadata().set("mpi_comm", mpi_comm_name(config));
+    auto& comm = mpi::comm(mesh.mpi_comm());
 
     // Setup a grid, if requested via config argument
     if (config.has("grid")) {

--- a/src/atlas/mesh/PartitionPolygon.cc
+++ b/src/atlas/mesh/PartitionPolygon.cc
@@ -81,9 +81,9 @@ size_t PartitionPolygon::footprint() const {
 }
 
 void PartitionPolygon::outputPythonScript(const eckit::PathName& filepath, const eckit::Configuration& config) const {
-    const eckit::mpi::Comm& comm = atlas::mpi::comm();
-    int mpi_rank                 = int(comm.rank());
-    int mpi_size                 = int(comm.size());
+    const auto& comm = mpi::comm(mesh_.mpi_comm());
+    int mpi_rank     = int(comm.rank());
+    int mpi_size     = int(comm.size());
 
     std::string coordinates = config.getString("coordinates", "xy");
     if (coordinates == "ij") {
@@ -254,11 +254,11 @@ void PartitionPolygon::outputPythonScript(const eckit::PathName& filepath, const
 void PartitionPolygon::allGather(util::PartitionPolygons& polygons) const {
     ATLAS_TRACE();
 
-    polygons.clear();
-    polygons.reserve(mpi::size());
+    const auto& comm   = mpi::comm(mesh_.mpi_comm());
+    const int mpi_size = int(comm.size());
 
-    const mpi::Comm& comm = mpi::comm();
-    const int mpi_size    = int(comm.size());
+    polygons.clear();
+    polygons.reserve(mpi_size);
 
     auto& poly = *this;
 

--- a/src/atlas/mesh/actions/BuildEdges.cc
+++ b/src/atlas/mesh/actions/BuildEdges.cc
@@ -326,6 +326,8 @@ void build_edges(Mesh& mesh) {
 void build_edges(Mesh& mesh, const eckit::Configuration& config) {
     ATLAS_TRACE("BuildEdges");
 
+    mpi::Scope mpi_scope(mesh.mpi_comm());
+
     int mesh_halo(0);
     mesh.metadata().get("halo", mesh_halo);
 

--- a/src/atlas/mesh/actions/BuildHalo.cc
+++ b/src/atlas/mesh/actions/BuildHalo.cc
@@ -1374,6 +1374,8 @@ BuildHalo::BuildHalo(Mesh& mesh): mesh_(mesh), periodic_cells_local_index_(mesh.
 void BuildHalo::operator()(int nb_elems) {
     ATLAS_TRACE("BuildHalo");
 
+    mpi::Scope mpi_scope(mesh_.mpi_comm());
+
     int halo = 0;
     mesh_.metadata().get("halo", halo);
 

--- a/src/atlas/mesh/actions/BuildParallelFields.cc
+++ b/src/atlas/mesh/actions/BuildParallelFields.cc
@@ -94,10 +94,15 @@ struct Node {
 
 void build_parallel_fields(Mesh& mesh) {
     ATLAS_TRACE();
-    build_nodes_parallel_fields(mesh.nodes());
+    build_nodes_parallel_fields(mesh);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
+
+void build_nodes_parallel_fields(Mesh& mesh) {
+    mpi::Scope mpi_scope(mesh.mpi_comm());
+    build_nodes_parallel_fields(mesh.nodes());
+}
 
 void build_nodes_parallel_fields(mesh::Nodes& nodes) {
     ATLAS_TRACE();
@@ -115,6 +120,7 @@ void build_nodes_parallel_fields(mesh::Nodes& nodes) {
 
 void build_edges_parallel_fields(Mesh& mesh) {
     ATLAS_TRACE();
+    mpi::Scope mpi_scope(mesh.mpi_comm());
     build_edges_partition(mesh);
     build_edges_remote_idx(mesh);
     /*
@@ -140,6 +146,11 @@ Field& build_nodes_global_idx(mesh::Nodes& nodes) {
         }
     }
     return nodes.global_index();
+}
+
+void renumber_nodes_glb_idx(Mesh& mesh) {
+    mpi::Scope mpi_scope(mesh.mpi_comm());
+    renumber_nodes_glb_idx(mesh.nodes());
 }
 
 void renumber_nodes_glb_idx(mesh::Nodes& nodes) {
@@ -1117,6 +1128,8 @@ Field& build_cells_remote_idx(mesh::Cells& cells, const mesh::Nodes& nodes) {
 }
 
 void build_cells_parallel_fields(Mesh& mesh) {
+    mpi::Scope mpi_scope(mesh.mpi_comm());
+
     bool parallel = false;
     mesh.cells().metadata().get("parallel", parallel);
     if (!parallel) {

--- a/src/atlas/mesh/actions/BuildParallelFields.h
+++ b/src/atlas/mesh/actions/BuildParallelFields.h
@@ -39,7 +39,8 @@ void build_parallel_fields(Mesh& mesh);
  * - partition:  set to mpi::rank() for negative values
  * - remote_idx: rebuild from scratch
  */
-void build_nodes_parallel_fields(mesh::Nodes& nodes);
+void build_nodes_parallel_fields(Mesh& mesh);
+void build_nodes_parallel_fields(mesh::Nodes& nodes); // deprecated (WARNING: does not change MPI scope)
 
 /*
  * Build parallel fields for the "edges" function space if they don't exist.
@@ -57,7 +58,8 @@ void build_edges_parallel_fields(Mesh& mesh);
 
 void build_cells_parallel_fields(Mesh& mesh);
 
-void renumber_nodes_glb_idx(mesh::Nodes& nodes);
+void renumber_nodes_glb_idx(Mesh& mesh);
+void renumber_nodes_glb_idx(mesh::Nodes& nodes); // deprecated (WARNING: does not change MPI scope)
 
 // ------------------------------------------------------------------
 // C wrapper interfaces to C++ routines

--- a/src/atlas/mesh/actions/BuildPeriodicBoundaries.cc
+++ b/src/atlas/mesh/actions/BuildPeriodicBoundaries.cc
@@ -38,11 +38,12 @@ void build_periodic_boundaries(Mesh& mesh) {
     ATLAS_TRACE();
     bool periodic = false;
     mesh.metadata().get("periodic", periodic);
-
-    auto mpi_size = mpi::size();
-    auto mypart   = mpi::rank();
-
     if (!periodic) {
+        mpi::Scope mpi_scope(mesh.mpi_comm());
+
+        auto mpi_size = mpi::size();
+        auto mypart   = mpi::rank();
+
         mesh::Nodes& nodes = mesh.nodes();
 
         auto flags = array::make_view<int, 1>(nodes.flags());

--- a/src/atlas/mesh/detail/MeshImpl.cc
+++ b/src/atlas/mesh/detail/MeshImpl.cc
@@ -117,7 +117,7 @@ void MeshImpl::setGrid(const Grid& grid) {
     }
 }
 
-idx_t MeshImpl::nb_partitions() const {
+idx_t MeshImpl::nb_parts() const {
     idx_t n;
     if (not metadata().get("nb_parts", n)) {
         n = mpi::comm(mpi_comm()).size();
@@ -125,7 +125,7 @@ idx_t MeshImpl::nb_partitions() const {
     return n;
 }
 
-idx_t MeshImpl::partition() const {
+idx_t MeshImpl::part() const {
     idx_t p;
     if (not metadata().get("part", p)) {
         p = mpi::comm(mpi_comm()).rank();
@@ -200,7 +200,7 @@ const PartitionGraph& MeshImpl::partitionGraph() const {
 }
 
 PartitionGraph::Neighbours MeshImpl::nearestNeighbourPartitions() const {
-    return partitionGraph().nearestNeighbours(partition());
+    return partitionGraph().nearestNeighbours(part());
 }
 
 const PartitionPolygon& MeshImpl::polygon(idx_t halo) const {

--- a/src/atlas/mesh/detail/MeshImpl.cc
+++ b/src/atlas/mesh/detail/MeshImpl.cc
@@ -117,12 +117,29 @@ void MeshImpl::setGrid(const Grid& grid) {
 }
 
 idx_t MeshImpl::nb_partitions() const {
-    return mpi::size();
+    idx_t n;
+    if (not metadata().get("nb_parts", n)) {
+        n = mpi::comm(mpi_comm()).size();
+    }
+    return n;
 }
 
 idx_t MeshImpl::partition() const {
-    return mpi::rank();
+    idx_t p;
+    if (not metadata().get("part", p)) {
+        p = mpi::comm(mpi_comm()).rank();
+    }
+    return p;
 }
+
+std::string MeshImpl::mpi_comm() const {
+    std::string name;
+    if (not metadata().get("mpi_comm",name)) {
+        name = mpi::comm().name();
+    } 
+    return name;
+}
+
 
 void MeshImpl::updateDevice() const {
     if (nodes_) {

--- a/src/atlas/mesh/detail/MeshImpl.cc
+++ b/src/atlas/mesh/detail/MeshImpl.cc
@@ -39,6 +39,7 @@ void MeshImpl::encode(eckit::Stream&) const {
 }
 
 MeshImpl::MeshImpl(): nodes_(new mesh::Nodes()), dimensionality_(2) {
+    metadata_.set("mpi_comm",mpi::comm().name());
     createElements();
 }
 
@@ -133,11 +134,7 @@ idx_t MeshImpl::partition() const {
 }
 
 std::string MeshImpl::mpi_comm() const {
-    std::string name;
-    if (not metadata().get("mpi_comm",name)) {
-        name = mpi::comm().name();
-    } 
-    return name;
+    return metadata().getString("mpi_comm");
 }
 
 

--- a/src/atlas/mesh/detail/MeshImpl.h
+++ b/src/atlas/mesh/detail/MeshImpl.h
@@ -94,8 +94,8 @@ public:  // methods
     /// @brief Return the memory footprint of the mesh
     size_t footprint() const;
 
-    idx_t partition() const;
-    idx_t nb_partitions() const;
+    idx_t part() const;
+    idx_t nb_parts() const;
     std::string mpi_comm() const;
 
     void updateDevice() const;

--- a/src/atlas/mesh/detail/MeshImpl.h
+++ b/src/atlas/mesh/detail/MeshImpl.h
@@ -96,6 +96,7 @@ public:  // methods
 
     idx_t partition() const;
     idx_t nb_partitions() const;
+    std::string mpi_comm() const;
 
     void updateDevice() const;
 

--- a/src/atlas/mesh/detail/PartitionGraph.cc
+++ b/src/atlas/mesh/detail/PartitionGraph.cc
@@ -30,8 +30,8 @@ namespace detail {
 
 PartitionGraph* build_partition_graph(const MeshImpl& mesh) {
     ATLAS_TRACE("build_partition_graph...");
-    const eckit::mpi::Comm& comm = mpi::comm();
-    const int mpi_size           = int(comm.size());
+    const auto& comm   = mpi::comm(mesh.mpi_comm());
+    const int mpi_size = int(comm.size());
 
     const util::Polygon& poly = mesh.polygon();
 

--- a/src/atlas/meshgenerator/detail/DelaunayMeshGenerator.h
+++ b/src/atlas/meshgenerator/detail/DelaunayMeshGenerator.h
@@ -39,6 +39,7 @@ private:  // methods
     virtual void generate(const Grid&, const grid::Distribution&, Mesh&) const override;
     virtual void generate(const Grid&, Mesh&) const override;
 
+    std::string mpi_comm_;
     int part_;
     bool remove_duplicate_points_;
     bool reshuffle_;

--- a/src/atlas/meshgenerator/detail/StructuredMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/StructuredMeshGenerator.cc
@@ -101,6 +101,17 @@ StructuredMeshGenerator::StructuredMeshGenerator(const eckit::Parametrisation& p
         options.set("three_dimensional", three_dimensional);
     }
 
+    std::string mpi_comm_name = mpi::comm().name();
+    p.get("mpi_comm", mpi_comm_name);
+    options.set("mpi_comm",mpi_comm_name);
+    auto& comm = mpi::comm(mpi_comm_name);
+
+    // This option sets number of parts the mesh will be split in
+    options.set("nb_parts", comm.size());
+
+    // This option sets the part that will be generated
+    options.set("part", comm.rank());
+
     size_t nb_parts;
     if (p.get("nb_parts", nb_parts)) {
         options.set("nb_parts", nb_parts);
@@ -160,12 +171,6 @@ void StructuredMeshGenerator::configure_defaults() {
     // false
     options.set("three_dimensional", false);
 
-    // This option sets number of parts the mesh will be split in
-    options.set("nb_parts", mpi::size());
-
-    // This option sets the part that will be generated
-    options.set("part", mpi::rank());
-
     // Experimental option. This is what makes tripolar grid patched with quads
     options.set("patch_quads", false);
 
@@ -204,9 +209,11 @@ void StructuredMeshGenerator::generate(const Grid& grid, Mesh& mesh) const {
     if (nb_parts == 1) {
         partitioner_type = "serial";
     }
-
+    std::string save_mpi_comm = mpi::comm().name();
+    eckit::mpi::setCommDefault(options.getString("mpi_comm").c_str());
     grid::Partitioner partitioner(partitioner_type, nb_parts);
     grid::Distribution distribution(partitioner.partition(grid));
+    eckit::mpi::setCommDefault(save_mpi_comm.c_str());
     generate(grid, distribution, mesh);
 }
 
@@ -257,6 +264,10 @@ void StructuredMeshGenerator::generate(const Grid& grid, const grid::Distributio
     Region region;
     generate_region(rg, distribution, mypart, region);
 
+
+    mesh.metadata().set("nb_parts",options.getInt("nb_parts"));
+    mesh.metadata().set("part",options.getInt("part"));
+    mesh.metadata().set("mpi_comm",options.getString("mpi_comm"));
     generate_mesh(rg, distribution, region, mesh);
 }
 

--- a/src/atlas/meshgenerator/detail/StructuredMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/StructuredMeshGenerator.cc
@@ -209,11 +209,10 @@ void StructuredMeshGenerator::generate(const Grid& grid, Mesh& mesh) const {
     if (nb_parts == 1) {
         partitioner_type = "serial";
     }
-    std::string save_mpi_comm = mpi::comm().name();
-    eckit::mpi::setCommDefault(options.getString("mpi_comm").c_str());
+    mpi::push(options.getString("mpi_comm"));
     grid::Partitioner partitioner(partitioner_type, nb_parts);
     grid::Distribution distribution(partitioner.partition(grid));
-    eckit::mpi::setCommDefault(save_mpi_comm.c_str());
+    mpi::pop();
     generate(grid, distribution, mesh);
 }
 
@@ -223,7 +222,7 @@ void StructuredMeshGenerator::hash(eckit::Hash& h) const {
 }
 
 void StructuredMeshGenerator::generate(const Grid& grid, const grid::Distribution& distribution, Mesh& mesh) const {
-    ATLAS_TRACE();
+    ATLAS_TRACE("structuredmeshgenerator(grid,dist,mesh)");
     Log::debug() << "StructuredMeshGenerator generating mesh from " << grid.name() << std::endl;
 
     const StructuredGrid rg = StructuredGrid(grid);

--- a/src/atlas/meshgenerator/detail/StructuredMeshGenerator.h
+++ b/src/atlas/meshgenerator/detail/StructuredMeshGenerator.h
@@ -55,6 +55,7 @@ public:
 private:
     virtual void hash(eckit::Hash&) const override;
 
+
     void configure_defaults();
 
     void generate_region(const StructuredGrid&, const grid::Distribution& distribution, int mypart,

--- a/src/atlas/output/detail/GmshIO.cc
+++ b/src/atlas/output/detail/GmshIO.cc
@@ -896,6 +896,7 @@ void GmshIO::read(const PathName& file_path, Mesh& mesh) const {
 }
 
 void GmshIO::write(const Mesh& mesh, const PathName& file_path) const {
+    mpi::Scope scope(mesh.mpi_comm());
     int part           = mesh.metadata().has("part") ? mesh.metadata().get<size_t>("part") : mpi::rank();
     bool include_ghost = options.get<bool>("ghost") && options.get<bool>("elements");
 
@@ -1420,6 +1421,7 @@ void GmshIO::write_delegate(const FieldSet& fieldset, const functionspace::Struc
 // ----------------------------------------------------------------------------
 void GmshIO::write(const FieldSet& fieldset, const FunctionSpace& funcspace, const eckit::PathName& file_path,
                    openmode mode) const {
+    mpi::Scope scope(funcspace.mpi_comm());
     if (functionspace::NodeColumns(funcspace)) {
         write_delegate(fieldset, functionspace::NodeColumns(funcspace), file_path, mode);
     }
@@ -1441,6 +1443,7 @@ void GmshIO::write(const FieldSet& fieldset, const FunctionSpace& funcspace, con
 // ----------------------------------------------------------------------------
 void GmshIO::write(const Field& field, const FunctionSpace& funcspace, const eckit::PathName& file_path,
                    openmode mode) const {
+    mpi::Scope scope(funcspace.mpi_comm());
     if (functionspace::NodeColumns(funcspace)) {
         write_delegate(field, functionspace::NodeColumns(funcspace), file_path, mode);
     }

--- a/src/atlas/parallel/Checksum.cc
+++ b/src/atlas/parallel/Checksum.cc
@@ -23,20 +23,30 @@ Checksum::Checksum(const std::string& name): name_(name) {
     is_setup_ = false;
 }
 
-void Checksum::setup(const int part[], const idx_t remote_idx[], const int base, const gidx_t glb_idx[],
+void Checksum::setup(const std::string& mpi_comm, const int part[], const idx_t remote_idx[], const int base, const gidx_t glb_idx[],
                      const int parsize) {
     parsize_ = parsize;
     gather_  = util::ObjectHandle<GatherScatter>(new GatherScatter());
-    gather_->setup(part, remote_idx, base, glb_idx, parsize);
+    gather_->setup(mpi_comm, part, remote_idx, base, glb_idx, parsize);
+    is_setup_ = true;
+}
+
+void Checksum::setup(const int part[], const idx_t remote_idx[], const int base, const gidx_t glb_idx[],
+                     const int parsize) {
+    setup(mpi::comm().name(), part, remote_idx, base, glb_idx, parsize);
+}
+
+void Checksum::setup(const std::string& mpi_comm, const int part[], const idx_t remote_idx[], const int base, const gidx_t glb_idx[],
+                     const int mask[], const int parsize) {
+    parsize_ = parsize;
+    gather_  = util::ObjectHandle<GatherScatter>(new GatherScatter());
+    gather_->setup(mpi_comm, part, remote_idx, base, glb_idx, mask, parsize);
     is_setup_ = true;
 }
 
 void Checksum::setup(const int part[], const idx_t remote_idx[], const int base, const gidx_t glb_idx[],
                      const int mask[], const int parsize) {
-    parsize_ = parsize;
-    gather_  = util::ObjectHandle<GatherScatter>(new GatherScatter());
-    gather_->setup(part, remote_idx, base, glb_idx, mask, parsize);
-    is_setup_ = true;
+    setup(mpi::comm().name(), part, remote_idx, base, glb_idx, mask, parsize);
 }
 
 void Checksum::setup(const util::ObjectHandle<GatherScatter>& gather) {

--- a/src/atlas/parallel/GatherScatter.h
+++ b/src/atlas/parallel/GatherScatter.h
@@ -103,12 +103,33 @@ public:  // methods
     std::string name() const { return name_; }
 
     /// @brief Setup
+    /// @param [in] mpi_comm     Name of mpi communicator
+    /// @param [in] part         List of partitions
+    /// @param [in] remote_idx   List of local indices on remote partitions
+    /// @param [in] base         values of remote_idx start at "base"
+    /// @param [in] glb_idx      List of global indices
+    /// @param [in] parsize      size of given lists
+    void setup(const std::string& mpi_comm, const int part[], const idx_t remote_idx[], const int base, const gidx_t glb_idx[], const idx_t parsize);
+
+    /// @brief Setup
     /// @param [in] part         List of partitions
     /// @param [in] remote_idx   List of local indices on remote partitions
     /// @param [in] base         values of remote_idx start at "base"
     /// @param [in] glb_idx      List of global indices
     /// @param [in] parsize      size of given lists
     void setup(const int part[], const idx_t remote_idx[], const int base, const gidx_t glb_idx[], const idx_t parsize);
+
+    /// @brief Setup
+    /// @param [in] mpi_comm     Name of mpi communicator
+    /// @param [in] part         List of partitions
+    /// @param [in] remote_idx   List of local indices on remote partitions
+    /// @param [in] base         values of remote_idx start at "base"
+    /// @param [in] glb_idx      List of global indices
+    /// @param [in] parsize      size of given lists
+    /// @param [in] mask         Mask indices not to include in the communication
+    ///                          pattern (0=include,1=exclude)
+    void setup(const std::string& mpi_comm, const int part[], const idx_t remote_idx[], const int base, const gidx_t glb_idx[], const int mask[],
+               const idx_t parsize);
 
     /// @brief Setup
     /// @param [in] part         List of partitions
@@ -163,6 +184,8 @@ public:  // methods
 
     idx_t loc_dof() const { return loccnt_; }
 
+    const mpi::Comm& comm() const { return *comm_; }
+
 private:  // methods
     template <typename DATA_TYPE>
     void pack_send_buffer(const parallel::Field<DATA_TYPE const>& field, const std::vector<int>& sendmap,
@@ -185,6 +208,7 @@ private:  // data
     std::vector<int> locmap_;
     std::vector<int> glbmap_;
 
+    const mpi::Comm* comm_;
     idx_t nproc;
     idx_t myproc;
 
@@ -231,7 +255,7 @@ void GatherScatter::gather(parallel::Field<DATA_TYPE const> lfields[], parallel:
         /// Gather
 
         ATLAS_TRACE_MPI(GATHER) {
-            mpi::comm().gatherv(loc_buffer, glb_buffer, glb_counts, glb_displs, root);
+            comm().gatherv(loc_buffer, glb_buffer, glb_counts, glb_displs, root);
         }
 
         /// Unpack
@@ -282,8 +306,8 @@ void GatherScatter::scatter(parallel::Field<DATA_TYPE const> gfields[], parallel
         /// Scatter
 
         ATLAS_TRACE_MPI(SCATTER) {
-            mpi::comm().scatterv(glb_buffer.begin(), glb_buffer.end(), glb_counts, glb_displs, loc_buffer.begin(),
-                                 loc_buffer.end(), root);
+            comm().scatterv(glb_buffer.begin(), glb_buffer.end(), glb_counts, glb_displs, loc_buffer.begin(),
+                            loc_buffer.end(), root);
         }
 
         /// Unpack

--- a/src/atlas/parallel/mpi/mpi.cc
+++ b/src/atlas/parallel/mpi/mpi.cc
@@ -10,6 +10,7 @@
 
 #include "atlas/parallel/mpi/mpi.h"
 #include "atlas/runtime/Log.h"
+#include "atlas/runtime/Exception.h"
 
 namespace atlas {
 namespace mpi {
@@ -20,6 +21,51 @@ void finalize() {
 void finalise() {
     Log::debug() << "atlas::mpi::finalize() --> Finalizing MPI" << std::endl;
     eckit::mpi::finaliseAllComms();
+}
+
+void CommStack::push(std::string_view name) {
+    if (stack_.size() == size_) {
+        stack_.resize(2 * size_);
+    }
+    stack_[size_++] = name;
+    eckit::mpi::setCommDefault(name.data());
+}
+
+void CommStack::pop(std::string_view _name) {
+    ATLAS_ASSERT(_name == name());
+    pop();
+}
+
+void CommStack::pop() {
+    --size_;
+    eckit::mpi::setCommDefault(name().c_str());
+}
+
+const std::string& CommStack::name() const {
+    return stack_[size_-1];
+}
+
+const mpi::Comm& CommStack::comm() const {
+    return mpi::comm(name());
+}
+
+CommStack::CommStack(): stack_(64){
+        stack_[size_++] = mpi::comm().name();
+    };
+
+void push(std::string_view name) {
+    Log::debug() << "atlas::mpi::push("<<name<<")" << std::endl;
+    CommStack::instance().push(name);
+}
+
+void pop(std::string_view name) {
+    Log::debug() << "atlas::mpi::pop("<<mpi::comm().name()<<")" << std::endl;
+    CommStack::instance().pop(name);
+}
+
+void pop() {
+    Log::debug() << "atlas::mpi::pop("<<mpi::comm().name()<<")" << std::endl;
+    CommStack::instance().pop();
 }
 
 }  // namespace mpi

--- a/src/atlas/parallel/mpi/mpi.h
+++ b/src/atlas/parallel/mpi/mpi.h
@@ -39,5 +39,45 @@ inline int size() {
 void finalize();
 void finalise();
 
+class CommStack {
+public:
+    using const_iterator = std::vector<std::string>::const_iterator;
+
+public:
+    void push(std::string_view name);
+    void pop();
+    void pop(std::string_view name); // verifies name matches compared to version above
+    const std::string& name() const;
+    const mpi::Comm& comm() const;
+
+    const_iterator begin() const { return stack_.begin(); }
+    const_iterator end() const { return stack_.begin() + size_; }
+
+    size_t size() const { return size_; }
+
+    static CommStack& instance() {
+        static CommStack instance;
+        return instance;
+    }
+
+private:
+    CommStack();
+private:
+    std::vector<std::string> stack_;
+    size_t size_{0};
+};
+void push(std::string_view name);
+void pop(std::string_view name);
+void pop();
+struct Scope {
+    Scope(std::string_view name) : name_(name) {
+        push(name_);
+    }
+    ~Scope() {
+        pop(name_);
+    }
+    std::string name_;
+};
+
 }  // namespace mpi
 }  // namespace atlas

--- a/src/atlas/parallel/mpi/mpi.h
+++ b/src/atlas/parallel/mpi/mpi.h
@@ -10,8 +10,9 @@
 
 #pragma once
 
-#include "eckit/mpi/Comm.h"
+#include <string_view>
 
+#include "eckit/mpi/Comm.h"
 #include "atlas/parallel/mpi/Statistics.h"
 
 namespace atlas {
@@ -21,6 +22,10 @@ using Comm = eckit::mpi::Comm;
 
 inline const Comm& comm() {
     return eckit::mpi::comm();
+}
+
+inline const Comm& comm(std::string_view name) {
+    return eckit::mpi::comm(name.data());
 }
 
 inline idx_t rank() {

--- a/src/atlas/redistribution/detail/RedistributeGeneric.h
+++ b/src/atlas/redistribution/detail/RedistributeGeneric.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "atlas/redistribution/detail/RedistributionImpl.h"
 
 namespace atlas {
@@ -46,6 +48,8 @@ private:
 
     // Partial sum of number of columns to receive from each PE.
     std::vector<int> targetDisps_{};
+
+    std::string mpi_comm_;
 };
 
 }  // namespace detail

--- a/src/atlas/redistribution/detail/RedistributeStructuredColumns.h
+++ b/src/atlas/redistribution/detail/RedistributeStructuredColumns.h
@@ -92,6 +92,8 @@ private:
     std::vector<int> sendDisplacements_{};
     std::vector<int> recvCounts_{};
     std::vector<int> recvDisplacements_{};
+
+    std::string mpi_comm_;
 };
 
 /// \brief    Helper class for function space intersections.
@@ -116,12 +118,16 @@ public:
     template <typename functorType>
     void forEach(const functorType&) const;
 
+    const std::string& mpi_comm() const { return mpi_comm_; }
+
 private:
     // Begin and end of j range.
     idxPair jBeginEnd_{};
 
     // Begin and end of i range for each j.
     idxPairVector iBeginEnd_{};
+
+    std::string mpi_comm_;
 };
 
 }  // namespace detail

--- a/src/tests/functionspace/CMakeLists.txt
+++ b/src/tests/functionspace/CMakeLists.txt
@@ -39,6 +39,15 @@ ecbuild_add_test( TARGET atlas_test_functionspace
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )
 
+ecbuild_add_test( TARGET atlas_test_functionspace_splitcomm
+  MPI         4
+  CONDITION   eckit_HAVE_MPI
+  SOURCES     test_functionspace_splitcomm.cc
+  LIBS        atlas
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
+
+
 ecbuild_add_test( TARGET atlas_test_cellcolumns
   SOURCES  test_cellcolumns.cc
   LIBS     atlas

--- a/src/tests/functionspace/test_functionspace_splitcomm.cc
+++ b/src/tests/functionspace/test_functionspace_splitcomm.cc
@@ -1,0 +1,150 @@
+/*
+ * (C) Copyright 2013 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "atlas/array.h"
+#include "atlas/grid.h"
+#include "atlas/mesh/Mesh.h"
+#include "atlas/output/Gmsh.h"
+#include "tests/AtlasTestEnvironment.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/functionspace/StructuredColumns.h"
+#include "atlas/field/for_each.h"
+
+namespace atlas {
+namespace test {
+
+//-----------------------------------------------------------------------------
+
+namespace option {
+    struct mpi_split_comm : public util::Config {
+        mpi_split_comm() {
+            set("mpi_comm","split");
+        }
+    };
+}
+
+int color() {
+    static int c = mpi::comm("world").rank()%2;
+    return c;
+}
+
+Grid grid() {
+    static Grid g (color() == 0 ? "O32" : "N32" );
+    return g;
+}
+
+std::string expected_checksum() {
+    if (grid().name()=="O32") {
+        return "75e913d400755a0d2782fc65e2035e97";
+    }
+    else if (grid().name()=="N32") {
+        return "bcb344196d20becbb66f098d91f83abb";
+    }
+    else {
+        return "unknown";
+    }
+}
+
+struct Fixture {
+    Fixture() {
+        mpi::comm().split(color(),"split");
+    }
+    ~Fixture() {
+        if (eckit::mpi::hasComm("split")) {
+            eckit::mpi::deleteComm("split");
+        }
+    }
+};
+
+
+void field_init(Field& field) {
+    auto fs = field.functionspace();
+    auto f = array::make_view<double,1>(field);
+    auto g = array::make_view<gidx_t,1>(fs.global_index());
+    for( idx_t j=0; j<f.size(); ++j ) {
+        f(j) = g(j);
+    }
+}
+
+CASE("test FunctionSpace NodeColumns") {
+    Fixture fixture;
+
+    auto mesh = Mesh(grid(), option::mpi_split_comm());
+    auto fs = functionspace::NodeColumns(mesh,atlas::option::halo(1));
+    EXPECT_EQUAL(fs.part(),mpi::comm("split").rank());
+    EXPECT_EQUAL(fs.nb_parts(),mpi::comm("split").size());
+    EXPECT_EQUAL(fs.mpi_comm(),"split");
+
+    auto field  = fs.createField<double>();
+    field_init(field);
+
+    // HaloExchange
+    field.haloExchange();
+    // TODO CHECK
+
+    // Gather
+    auto fieldg = fs.createField<double>(atlas::option::global());
+    fs.gather(field,fieldg);
+
+    if (fieldg.size()) {
+        idx_t g{0};
+        field::for_each_value(fieldg,[&](double x) {
+            EXPECT_EQ(++g,x);
+        });
+    }
+
+    // Checksum
+    auto checksum = fs.checksum(field);
+    EXPECT_EQ(checksum, expected_checksum());
+
+    // Output
+    output::Gmsh gmsh(grid().name()+".msh");
+    gmsh.write(mesh);
+    gmsh.write(field);
+}
+
+CASE("test FunctionSpace StructuredColumns") {
+    Fixture fixture;
+
+    auto fs   = functionspace::StructuredColumns(grid(),atlas::option::halo(1)|option::mpi_split_comm());
+    EXPECT_EQUAL(fs.part(),mpi::comm("split").rank());
+    EXPECT_EQUAL(fs.nb_parts(),mpi::comm("split").size());
+
+    auto field  = fs.createField<double>();
+    field_init(field);
+
+    // HaloExchange
+    field.haloExchange();
+    // TODO CHECK
+
+    // Gather
+    auto fieldg = fs.createField<double>(atlas::option::global());
+    fs.gather(field,fieldg);
+
+    if (fieldg.size()) {
+        idx_t g{0};
+        field::for_each_value(fieldg,[&](double x) {
+            EXPECT_EQ(++g,x);
+        });
+    }
+
+    // Checksum
+    auto checksum = fs.checksum(field);
+    EXPECT_EQ(checksum, expected_checksum());
+}
+
+//-----------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}

--- a/src/tests/functionspace/test_functionspace_splitcomm.cc
+++ b/src/tests/functionspace/test_functionspace_splitcomm.cc
@@ -15,6 +15,7 @@
 #include "tests/AtlasTestEnvironment.h"
 #include "atlas/functionspace/NodeColumns.h"
 #include "atlas/functionspace/StructuredColumns.h"
+#include "atlas/grid/Partitioner.h"
 #include "atlas/field/for_each.h"
 
 namespace atlas {
@@ -138,6 +139,17 @@ CASE("test FunctionSpace StructuredColumns") {
     // Checksum
     auto checksum = fs.checksum(field);
     EXPECT_EQ(checksum, expected_checksum());
+}
+
+//-----------------------------------------------------------------------------
+
+CASE("test FunctionSpace StructuredColumns with MatchingPartitioner") {
+    Fixture fixture;
+
+    auto fs_A = functionspace::StructuredColumns(grid(), option::mpi_split_comm());
+    auto fs_B = functionspace::StructuredColumns(grid(), grid::MatchingPartitioner(fs_A), option::mpi_split_comm());
+    fs_A.polygon().outputPythonScript("fs_A_polygons.py");
+    fs_B.polygon().outputPythonScript("fs_B_polygons.py");
 }
 
 //-----------------------------------------------------------------------------

--- a/src/tests/functionspace/test_functionspace_splitcomm.cc
+++ b/src/tests/functionspace/test_functionspace_splitcomm.cc
@@ -15,6 +15,7 @@
 #include "tests/AtlasTestEnvironment.h"
 #include "atlas/functionspace/NodeColumns.h"
 #include "atlas/functionspace/StructuredColumns.h"
+#include "atlas/functionspace/BlockStructuredColumns.h"
 #include "atlas/grid/Partitioner.h"
 #include "atlas/field/for_each.h"
 
@@ -63,7 +64,6 @@ struct Fixture {
         }
     }
 };
-
 
 void field_init(Field& field) {
     auto fs = field.functionspace();
@@ -139,6 +139,36 @@ CASE("test FunctionSpace StructuredColumns") {
     // Checksum
     auto checksum = fs.checksum(field);
     EXPECT_EQ(checksum, expected_checksum());
+}
+
+CASE("test FunctionSpace BlockStructuredColumns") {
+    Fixture fixture;
+
+    auto fs   = functionspace::BlockStructuredColumns(grid(),atlas::option::halo(1)|option::mpi_split_comm());
+    EXPECT_EQUAL(fs.part(),mpi::comm("split").rank());
+    EXPECT_EQUAL(fs.nb_parts(),mpi::comm("split").size());
+
+    auto field  = fs.createField<double>();
+    // field_init(field);
+
+    // HaloExchange
+    // field.haloExchange();
+    // TODO CHECK
+
+    // Gather
+    auto fieldg = fs.createField<double>(atlas::option::global());
+    // fs.gather(field,fieldg);
+
+    // if (fieldg.size()) {
+    //     idx_t g{0};
+    //     field::for_each_value(fieldg,[&](double x) {
+    //         EXPECT_EQ(++g,x);
+    //     });
+    // }
+
+    // // Checksum
+    // auto checksum = fs.checksum(field);
+    // EXPECT_EQ(checksum, expected_checksum());
 }
 
 //-----------------------------------------------------------------------------

--- a/src/tests/mesh/CMakeLists.txt
+++ b/src/tests/mesh/CMakeLists.txt
@@ -87,6 +87,13 @@ ecbuild_add_test( TARGET atlas_test_mesh_node2cell
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )
 
+ecbuild_add_test( TARGET atlas_test_meshgen_splitcomm
+  MPI         4
+  CONDITION   eckit_HAVE_MPI
+  SOURCES     test_meshgen_splitcomm.cc
+  LIBS        atlas
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
 
 foreach( test connectivity stream_connectivity elements ll meshgen3d rgg )
   ecbuild_add_test( TARGET atlas_test_${test}

--- a/src/tests/mesh/test_meshgen_splitcomm.cc
+++ b/src/tests/mesh/test_meshgen_splitcomm.cc
@@ -39,8 +39,17 @@ Grid grid() {
     return g;
 }
 
+Grid grid_A() {
+    return grid();
+}
+
 Grid grid_B() {
     static Grid g (color() == 0 ? "F64" : "O64" );
+    return g;
+}
+
+Grid grid_CS() {
+    static Grid g (color() == 0 ? "CS-LFR-C-8" : "CS-LFR-C-16" );
     return g;
 }
 
@@ -74,7 +83,7 @@ CASE("Partitioners") {
 CASE("StructuredMeshGenerator") {
     Fixture fixture;
 
-    StructuredMeshGenerator meshgen{option::mpi_comm("split")};
+    MeshGenerator meshgen{"structured", option::mpi_comm("split")};
     Mesh mesh = meshgen.generate(grid());
     EXPECT_EQUAL(mesh.nb_parts(),mpi::comm("split").size());
     EXPECT_EQUAL(mesh.part(),mpi::comm("split").rank());
@@ -88,6 +97,33 @@ CASE("StructuredMeshGenerator") {
     EXPECT_NO_THROW(mesh.polygons());
     mesh.polygon().outputPythonScript(grid().name()+"_polygons_1.py");
 }
+
+CASE("CubedSphereDualMeshGenerator") {
+    Fixture fixture;
+
+    MeshGenerator meshgen{"cubedsphere_dual", option::mpi_comm("split")};
+    Mesh mesh = meshgen.generate(grid_CS());
+    EXPECT_EQUAL(mesh.nb_parts(),mpi::comm("split").size());
+    EXPECT_EQUAL(mesh.part(),mpi::comm("split").rank());
+    EXPECT_EQUAL(mesh.mpi_comm(),"split");
+    EXPECT_EQUAL(mpi::comm().name(),"world");
+    output::Gmsh gmsh(grid_CS().name()+"_1.msh");
+    gmsh.write(mesh);
+}
+
+CASE("CubedSphereMeshGenerator") {
+    Fixture fixture;
+
+    MeshGenerator meshgen{"cubedsphere", option::mpi_comm("split")};
+    Mesh mesh = meshgen.generate(grid_CS());
+    EXPECT_EQUAL(mesh.nb_parts(),mpi::comm("split").size());
+    EXPECT_EQUAL(mesh.part(),mpi::comm("split").rank());
+    EXPECT_EQUAL(mesh.mpi_comm(),"split");
+    EXPECT_EQUAL(mpi::comm().name(),"world");
+    output::Gmsh gmsh(grid_CS().name()+"_2.msh");
+    gmsh.write(mesh);
+}
+
 
 CASE("Mesh constructor") {
     Fixture fixture;
@@ -128,7 +164,7 @@ CASE("Mesh constructor with partitioner") {
 CASE("MatchingPartitioner") {
     Fixture fixture;
 
-    auto mesh_A = Mesh(grid(), option::mpi_comm("split"));
+    auto mesh_A = Mesh(grid_A(), option::mpi_comm("split"));
     auto mesh_B = Mesh(grid_B(), grid::MatchingPartitioner(mesh_A), option::mpi_comm("split"));
 
     output::Gmsh gmsh_B(grid_B().name()+"_3.msh");

--- a/src/tests/mesh/test_meshgen_splitcomm.cc
+++ b/src/tests/mesh/test_meshgen_splitcomm.cc
@@ -53,6 +53,16 @@ Grid grid_CS() {
     return g;
 }
 
+Grid grid_Regular() {
+    static Grid g (color() == 0 ? "S8" : "L16" );
+    return g;
+}
+
+Grid grid_healpix() {
+    static Grid g (color() == 0 ? "H8" : "H16" );
+    return g;
+}
+
 struct Fixture {
     Fixture() {
         mpi::comm().split(color(),"split");
@@ -96,6 +106,24 @@ CASE("StructuredMeshGenerator") {
     EXPECT_NO_THROW(mesh.partitionGraph());
     EXPECT_NO_THROW(mesh.polygons());
     mesh.polygon().outputPythonScript(grid().name()+"_polygons_1.py");
+}
+
+CASE("RegularMeshGenerator") {
+    Fixture fixture;
+
+    MeshGenerator meshgen{"regular", option::mpi_comm("split")};
+    Mesh mesh = meshgen.generate(grid_Regular());
+    EXPECT_EQUAL(mesh.nb_parts(),mpi::comm("split").size());
+    EXPECT_EQUAL(mesh.part(),mpi::comm("split").rank());
+    EXPECT_EQUAL(mesh.mpi_comm(),"split");
+    EXPECT_EQUAL(mpi::comm().name(),"world");
+    output::Gmsh gmsh(grid().name()+"_regular.msh");
+    gmsh.write(mesh);
+
+    // partitioning graph and polygon output
+    EXPECT_NO_THROW(mesh.partitionGraph());
+    EXPECT_NO_THROW(mesh.polygons());
+    mesh.polygon().outputPythonScript(grid().name()+"_regular_polygons_1.py");
 }
 
 CASE("DelaunayMeshGenerator") {
@@ -193,7 +221,6 @@ CASE("MatchingPartitioner") {
     EXPECT_NO_THROW(mesh_B.polygons());
     mesh_B.polygon().outputPythonScript(grid_B().name()+"_polygons_3.py");
 }
-
 
 }  // namespace test
 }  // namespace atlas

--- a/src/tests/mesh/test_meshgen_splitcomm.cc
+++ b/src/tests/mesh/test_meshgen_splitcomm.cc
@@ -90,6 +90,24 @@ CASE("Mesh constructor") {
     mesh.polygon().outputPythonScript(grid().name()+"_polygons_2.py");
 }
 
+CASE("Mesh constructor with partitioner") {
+    Fixture fixture;
+    auto partitioner = grid::Partitioner("equal_regions", option::mpi_comm("split"));
+    auto mesh = Mesh(grid(), partitioner);
+    EXPECT_EQUAL(mesh.nb_parts(),mpi::comm("split").size());
+    EXPECT_EQUAL(mesh.part(),mpi::comm("split").rank());
+    EXPECT_EQUAL(mesh.mpi_comm(),"split");
+    EXPECT_EQUAL(mpi::comm().name(),"world");
+    output::Gmsh gmsh(grid().name()+"_2.msh");
+    gmsh.write(mesh);
+
+    // partitioning graph and polygon output
+    EXPECT_NO_THROW(mesh.partitionGraph());
+    EXPECT_NO_THROW(mesh.polygons());
+    mesh.polygon().outputPythonScript(grid().name()+"_polygons_2.py");
+}
+
+
 CASE("MatchingPartitioner") {
     Fixture fixture;
 

--- a/src/tests/mesh/test_meshgen_splitcomm.cc
+++ b/src/tests/mesh/test_meshgen_splitcomm.cc
@@ -1,0 +1,110 @@
+/*
+ * (C) Copyright 2013 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "atlas/array.h"
+#include "atlas/grid.h"
+#include "atlas/mesh/Mesh.h"
+#include "atlas/mesh/Nodes.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/option/Options.h"
+#include "atlas/output/Gmsh.h"
+#include "tests/AtlasTestEnvironment.h"
+
+using namespace atlas::output;
+using namespace atlas::meshgenerator;
+using namespace atlas::grid;
+
+namespace atlas {
+namespace test {
+
+class CommStack {
+public:
+    using const_iterator = std::vector<std::string>::const_iterator;
+
+public:
+    void push(std::string_view name) {
+        if (stack_.size() == size_) {
+            stack_.resize(2 * size_);
+        }
+        stack_[size_++] = name;
+        eckit::mpi::setCommDefault(name.data());
+    }
+
+    void pop() {
+        --size_;
+        eckit::mpi::setCommDefault(name().c_str());
+    }
+
+    const std::string& name() const {
+        return stack_[size_-1];
+    }
+
+    const mpi::Comm& comm() const {
+        return mpi::comm(name());
+    }
+
+    const_iterator begin() const { return stack_.begin(); }
+    const_iterator end() const { return stack_.begin() + size_; }
+
+    size_t size() const { return size_; }
+
+public:
+    CommStack(): stack_(64){
+        stack_[size_++] = mpi::comm().name();
+    };
+
+private:
+    std::vector<std::string> stack_;
+    size_t size_{0};
+};
+
+
+//-----------------------------------------------------------------------------
+
+namespace option {
+    struct mpi_comm : public util::Config {
+        mpi_comm(const atlas::mpi::Comm& comm) {
+            set("mpi_comm",comm.name());
+        }
+        mpi_comm(std::string_view name) {
+            set("mpi_comm",std::string(name));
+        }
+    };
+}
+
+CASE("test StructuredMeshGenerator directly") {
+    CommStack comms;
+
+    auto& mpi_comm_world = mpi::comm("world");
+    int color = mpi_comm_world.rank()%2;
+    Grid grid;
+    Mesh mesh;
+    if (color == 0) {
+        grid = Grid("O32");
+    }
+    else {
+        grid = Grid("N32");
+    }
+    mpi_comm_world.split(color,"split");
+    StructuredMeshGenerator meshgen{option::mpi_comm("split")};
+    mesh = meshgen.generate(grid);
+    EXPECT_EQUAL(mesh.nb_partitions(),2);
+    EXPECT_EQUAL(mpi::comm().name(),"world");
+    eckit::mpi::deleteComm("split");
+}
+
+//-----------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}

--- a/src/tests/mesh/test_meshgen_splitcomm.cc
+++ b/src/tests/mesh/test_meshgen_splitcomm.cc
@@ -126,6 +126,24 @@ CASE("RegularMeshGenerator") {
     mesh.polygon().outputPythonScript(grid().name()+"_regular_polygons_1.py");
 }
 
+CASE("HealpixMeshGenerator") {
+    Fixture fixture;
+
+    MeshGenerator meshgen{"healpix", option::mpi_comm("split")};
+    Mesh mesh = meshgen.generate(grid_healpix());
+    EXPECT_EQUAL(mesh.nb_parts(),mpi::comm("split").size());
+    EXPECT_EQUAL(mesh.part(),mpi::comm("split").rank());
+    EXPECT_EQUAL(mesh.mpi_comm(),"split");
+    EXPECT_EQUAL(mpi::comm().name(),"world");
+    output::Gmsh gmsh(grid().name()+"_regular.msh");
+    gmsh.write(mesh);
+
+    // partitioning graph and polygon output
+    EXPECT_NO_THROW(mesh.partitionGraph());
+    EXPECT_NO_THROW(mesh.polygons());
+    mesh.polygon().outputPythonScript(grid().name()+"_regular_polygons_1.py");
+}
+
 CASE("DelaunayMeshGenerator") {
 if( ATLAS_HAVE_TESSELATION ) {
     Fixture fixture;

--- a/src/tests/mesh/test_meshgen_splitcomm.cc
+++ b/src/tests/mesh/test_meshgen_splitcomm.cc
@@ -59,6 +59,11 @@ CASE("StructuredMeshGenerator") {
     EXPECT_EQUAL(mpi::comm().name(),"world");
     output::Gmsh gmsh(grid().name()+"_1.msh");
     gmsh.write(mesh);
+
+    // partitioning graph and polygon output
+    EXPECT_NO_THROW(mesh.partitionGraph());
+    EXPECT_NO_THROW(mesh.polygons());
+    mesh.polygon().outputPythonScript(grid().name()+"_polygons_1.py");
 }
 
 CASE("Mesh constructor") {
@@ -71,6 +76,11 @@ CASE("Mesh constructor") {
     EXPECT_EQUAL(mpi::comm().name(),"world");
     output::Gmsh gmsh(grid().name()+"_2.msh");
     gmsh.write(mesh);
+
+    // partitioning graph and polygon output
+    EXPECT_NO_THROW(mesh.partitionGraph());
+    EXPECT_NO_THROW(mesh.polygons());
+    mesh.polygon().outputPythonScript(grid().name()+"_polygons_2.py");
 }
 
 }  // namespace test

--- a/src/tests/mesh/test_meshgen_splitcomm.cc
+++ b/src/tests/mesh/test_meshgen_splitcomm.cc
@@ -24,7 +24,6 @@ using namespace atlas::grid;
 namespace atlas {
 namespace test {
 
-
 //-----------------------------------------------------------------------------
 
 namespace option {
@@ -38,7 +37,7 @@ namespace option {
     };
 }
 
-CASE("test StructuredMeshGenerator directly") {
+CASE("test StructuredMeshGenerator") {
     auto& mpi_comm_world = mpi::comm("world");
     int color = mpi_comm_world.rank()%2;
     Grid grid;
@@ -52,7 +51,7 @@ CASE("test StructuredMeshGenerator directly") {
     mpi_comm_world.split(color,"split");
     StructuredMeshGenerator meshgen{option::mpi_comm("split")};
     mesh = meshgen.generate(grid);
-    EXPECT_EQUAL(mesh.nb_partitions(),2);
+    EXPECT_EQUAL(mesh.nb_parts(),2);
     EXPECT_EQUAL(mpi::comm().name(),"world");
     eckit::mpi::deleteComm("split");
 }
@@ -69,7 +68,7 @@ CASE("test Mesh") {
     }
     mpi_comm_world.split(color,"split");
     auto mesh = Mesh(grid,option::mpi_comm("split"));
-    EXPECT_EQUAL(mesh.nb_partitions(),2);
+    EXPECT_EQUAL(mesh.nb_parts(),2);
     EXPECT_EQUAL(mpi::comm().name(),"world");
     eckit::mpi::deleteComm("split");
     

--- a/src/tests/mesh/test_meshgen_splitcomm.cc
+++ b/src/tests/mesh/test_meshgen_splitcomm.cc
@@ -98,6 +98,24 @@ CASE("StructuredMeshGenerator") {
     mesh.polygon().outputPythonScript(grid().name()+"_polygons_1.py");
 }
 
+CASE("DelaunayMeshGenerator") {
+if( ATLAS_HAVE_TESSELATION ) {
+    Fixture fixture;
+
+    MeshGenerator meshgen{"delaunay", option::mpi_comm("split")};
+    Mesh mesh = meshgen.generate(grid_CS());
+    EXPECT_EQUAL(mesh.nb_parts(),mpi::comm("split").size());
+    EXPECT_EQUAL(mesh.part(),mpi::comm("split").rank());
+    EXPECT_EQUAL(mesh.mpi_comm(),"split");
+    EXPECT_EQUAL(mpi::comm().name(),"world");
+    output::Gmsh gmsh(grid_CS().name()+"_delaunay.msh",util::Config("coordinates","xyz"));
+    gmsh.write(mesh);
+}
+else {
+    Log::warning() << "Not testing DelaunayMeshGenerator as TESSELATION feature is OFF" << std::endl;
+}
+}
+
 CASE("CubedSphereDualMeshGenerator") {
     Fixture fixture;
 
@@ -175,7 +193,6 @@ CASE("MatchingPartitioner") {
     EXPECT_NO_THROW(mesh_B.polygons());
     mesh_B.polygon().outputPythonScript(grid_B().name()+"_polygons_3.py");
 }
-
 
 
 }  // namespace test

--- a/src/tests/mesh/test_meshgen_splitcomm.cc
+++ b/src/tests/mesh/test_meshgen_splitcomm.cc
@@ -55,6 +55,22 @@ struct Fixture {
     }
 };
 
+CASE("Partitioners") {
+    Fixture fixture;
+    SECTION("default") {
+        auto partitioner = grid::Partitioner("equal_regions");
+        EXPECT_EQ(partitioner.mpi_comm(),mpi::comm().name());
+        auto distribution = partitioner.partition(Grid("O8"));
+        EXPECT_EQ(distribution.nb_partitions(), mpi::comm().size());
+    }
+    SECTION("split") {
+        auto partitioner = grid::Partitioner("equal_regions", option::mpi_comm("split"));
+        EXPECT_EQ(partitioner.mpi_comm(),"split");
+        auto distribution = partitioner.partition(Grid("O8"));
+        EXPECT_EQ(distribution.nb_partitions(), mpi::comm("split").size());
+    }
+}
+
 CASE("StructuredMeshGenerator") {
     Fixture fixture;
 
@@ -93,6 +109,7 @@ CASE("Mesh constructor") {
 CASE("Mesh constructor with partitioner") {
     Fixture fixture;
     auto partitioner = grid::Partitioner("equal_regions", option::mpi_comm("split"));
+
     auto mesh = Mesh(grid(), partitioner);
     EXPECT_EQUAL(mesh.nb_parts(),mpi::comm("split").size());
     EXPECT_EQUAL(mesh.part(),mpi::comm("split").rank());

--- a/src/tests/mesh/test_meshgen_splitcomm.cc
+++ b/src/tests/mesh/test_meshgen_splitcomm.cc
@@ -11,6 +11,7 @@
 #include "atlas/grid.h"
 #include "atlas/mesh/Mesh.h"
 #include "atlas/meshgenerator.h"
+#include "atlas/output/Gmsh.h"
 #include "tests/AtlasTestEnvironment.h"
 
 namespace atlas {
@@ -56,6 +57,8 @@ CASE("StructuredMeshGenerator") {
     EXPECT_EQUAL(mesh.part(),mpi::comm("split").rank());
     EXPECT_EQUAL(mesh.mpi_comm(),"split");
     EXPECT_EQUAL(mpi::comm().name(),"world");
+    output::Gmsh gmsh(grid().name()+"_1.msh");
+    gmsh.write(mesh);
 }
 
 CASE("Mesh constructor") {
@@ -66,6 +69,8 @@ CASE("Mesh constructor") {
     EXPECT_EQUAL(mesh.part(),mpi::comm("split").rank());
     EXPECT_EQUAL(mesh.mpi_comm(),"split");
     EXPECT_EQUAL(mpi::comm().name(),"world");
+    output::Gmsh gmsh(grid().name()+"_2.msh");
+    gmsh.write(mesh);
 }
 
 }  // namespace test

--- a/src/tests/parallel/test_setcomm.cc
+++ b/src/tests/parallel/test_setcomm.cc
@@ -38,6 +38,23 @@ CASE("test_setcomm") {
     std::cout << "----- STOP -----" << std::endl;
 }
 
+CASE("test_split") {
+    int irank = mpi::comm("world").rank();
+    auto& split_comm = mpi::comm("world").split(irank%2, "test_split");
+
+    EXPECT_EQ(mpi::comm("world").name(), "world");
+    EXPECT_EQ(split_comm.name(), "test_split");
+
+    if( mpi::comm("world").size()%2 == 0) { // even number
+       EXPECT_EQ( split_comm.size() , mpi::comm("world").size()/2);
+    }
+
+    auto& split_comm_by_name = mpi::comm("test_split");
+    EXPECT_EQ( &split_comm, &split_comm_by_name);
+}
+
+
+
 }  // namespace test
 }  // namespace atlas
 


### PR DESCRIPTION
# The problem we want to solve:
Atlas components currently rely on the default communicator registered in eckit and accessed as `eckit::mpi::comm()`.
A Mesh or FunctionSpace which is then generated usually relies on the default communicator as present at its construction time.
When the default communicator is then changed outside of the Atlas context, and e.g. a halo exchange is performed on fields on these meshes or function spaces, then the results are unpredictable and most likely wrong, or the program will just crash or hang.
Alternatively there may be a use case for atlas in different model components with each different MPI communicators. This naturally does not work. A current solution for this would be to context-switch the eckit default communicator to the correct one before each invocation. This is tedious, error-prone, and ugly boiler-plate code.

# The solution
The MPI communicators are stored internally in eckit in a `map<name,Comm>`. Communicators can be inserted and deleted in this map. This mechanism could allow to define model, or mesh/functionspace-specific communicators, which are referable by name.
Without changing Atlas API's we can then pass these communicators as configuration option "mpi_comm", referring to the name registered in eckit. The Mesh or FunctionSpace must then upon construction inspect for this configuration option and keep track of the chosen communicator. If the option is not set the present default communicator is used and kept track of (e.g. "world").

# Plan

- Add `atlas::mpi::comm(std::string_view)` method to access the Comm
- Add mechanism to push/pop the default Comm to cleanly change the default communicator in a certain scope. This is useful to port routines incrementally to use a custom communicator instead.
- Register mpi_comm via configuration in several data structure related components: MeshGenerator, Mesh, FunctionSpace, MatchingPartitioner
- Register mpi_comm via configuration in parallel communication patterns: HaloExchange, GatherScatter, Checksum, Redistribution
- Add tests to verify the functionality

Objects that need to be adapted

- [x] Mesh
- [x] MeshBuilder
- [x] StructuredMeshGenerator
- [x] DelaunayMeshGenerator 
- [x] CubedSphereMeshGenerator
- [x] CubedSphereDualMeshGenerator
- [x] HealpixMeshGenerator
- [x] RegularMeshGenerator 
- [x] PartitionGraph
- [x] PartitionPolygons
- [x] Partitioner
- [x] MatchingPartitioner 
- [x] parallel::HaloExchange
- [x] parallel::GatherScatter
- [x] parallel::Checksum
- [x] functionspace::NodeColumns
- [x] functionspace::CellColumns
- [x] functionspace::EdgeColumns
- [x] functionspace::StructuredColumns
- [x] functionspace::BlockStructuredColumns
- [x] functionspace::CubedSphere...
- [x] functionspace::PointCloud
- [x] Redistribution
- [x] output::Gmsh
- [x] mesh::action::BuildParallelFields
- [x] mesh::action::BuildPeriodicBoundary
- [x] mesh::action::BuildEdges
- [x] mesh::action::BuildHalo

Cannot be done:

- TransPartitioner (underlying ectrans only works with a single communicator)
-  functionspace::Spectral (underlying ectrans only works with a single communicator)

Follow up PR, possibly

- ... other mesh actions ...
- Verify Interpolation, likely working
