### PR TITLE
Feature/fixes

### DIFF
--- a/src/atlas/interpolation/Cache.h
+++ b/src/atlas/interpolation/Cache.h
@@ -108,7 +108,6 @@ public:
 public:
     MatrixCache() = default;
     MatrixCache(const Cache& c);
-    MatrixCache(const MatrixCache& c) : MatrixCache(Cache(c)) {}
     MatrixCache(Matrix&& m);
     MatrixCache(std::shared_ptr<const Matrix> m, const std::string& uid = "");
     MatrixCache(const Matrix* m);

--- a/src/atlas/redistribution/detail/RedistributeGeneric.cc
+++ b/src/atlas/redistribution/detail/RedistributeGeneric.cc
@@ -120,7 +120,6 @@ std::vector<IdxUid> getUidVec(const FunctionSpace& functionspace) {
 
     // Check UIDs are unique.
     if (ATLAS_BUILD_TYPE_DEBUG) {
-        const size_t vecSize = uidVec.size();
         auto first_duplicate = std::adjacent_find(
             uidVec.begin(), uidVec.end(), [](const IdxUid& a, const IdxUid& b) { return a.second == b.second; });
         ATLAS_ASSERT(uidVec.end() == first_duplicate, "Unique ID set has duplicate members");

--- a/src/atlas/redistribution/detail/RedistributeGeneric.cc
+++ b/src/atlas/redistribution/detail/RedistributeGeneric.cc
@@ -121,9 +121,9 @@ std::vector<IdxUid> getUidVec(const FunctionSpace& functionspace) {
     // Check UIDs are unique.
     if (ATLAS_BUILD_TYPE_DEBUG) {
         const size_t vecSize = uidVec.size();
-        std::unique(uidVec.begin(), uidVec.end(),
-                    [](const IdxUid& a, const IdxUid& b) { return a.second == b.second; });
-        ATLAS_ASSERT(uidVec.size() == vecSize, "Unique ID set has duplicate members");
+        auto first_duplicate = std::adjacent_find(
+            uidVec.begin(), uidVec.end(), [](const IdxUid& a, const IdxUid& b) { return a.second == b.second; });
+        ATLAS_ASSERT(uidVec.end() == first_duplicate, "Unique ID set has duplicate members");
     }
 
     return uidVec;


### PR DESCRIPTION
Fix compilation warning on handling interpolation matrices (MatrixCache is not fully implemeting the "rule of 5" so I've removed the triggering constructor, the others are sufficient)

Fix a logic error in the generic redistribution method, on detecting indices uniqueness.