### PR TITLE
add a getter method for the interpolation matrix

### DIFF
--- a/src/atlas/interpolation/Interpolation.cc
+++ b/src/atlas/interpolation/Interpolation.cc
@@ -99,6 +99,10 @@ void Interpolation::print(std::ostream& out) const {
     get()->print(out);
 }
 
+const Interpolation::Matrix& Interpolation::matrix() const {
+    return get()->matrix();
+}
+
 const FunctionSpace& Interpolation::source() const {
     return get()->source();
 }

--- a/src/atlas/interpolation/Interpolation.h
+++ b/src/atlas/interpolation/Interpolation.h
@@ -12,6 +12,7 @@
 
 #include "atlas/interpolation/method/Method.h"
 #include "atlas/library/config.h"
+#include "eckit/linalg/SparseMatrix.h"
 #include "atlas/util/ObjectHandle.h"
 
 #include "atlas/interpolation/Cache.h"
@@ -35,6 +36,7 @@ namespace atlas {
 class Interpolation : DOXYGEN_HIDE(public util::ObjectHandle<interpolation::Method>) {
 public:
     using Config   = eckit::Parametrisation;
+    using Matrix   = eckit::linalg::SparseMatrix;
     using Cache    = interpolation::Cache;
     using Metadata = interpolation::Method::Metadata;
 
@@ -62,6 +64,8 @@ public:
     Metadata execute_adjoint(Field& source, const Field& target) const;
 
     void print(std::ostream& out) const;
+
+    const Matrix& matrix() const;
 
     const FunctionSpace& source() const;
     const FunctionSpace& target() const;

--- a/src/atlas/interpolation/method/Method.h
+++ b/src/atlas/interpolation/method/Method.h
@@ -41,6 +41,7 @@ class Method : public util::Object {
 public:
     using Config   = eckit::Parametrisation;
     using Metadata = util::Metadata;
+    using Matrix   = eckit::linalg::SparseMatrix;
 
     Method(const Config&);
     virtual ~Method() {}
@@ -71,6 +72,8 @@ public:
     Metadata execute_adjoint(FieldSet& source, const FieldSet& target) const;
     Metadata execute_adjoint(Field& source, const Field& target) const;
 
+    const Matrix& matrix() const { return *matrix_; }
+
     virtual void print(std::ostream&) const = 0;
 
     virtual const FunctionSpace& source() const = 0;
@@ -87,7 +90,6 @@ protected:
 
     using Triplet  = eckit::linalg::Triplet;
     using Triplets = std::vector<Triplet>;
-    using Matrix   = eckit::linalg::SparseMatrix;
 
     static void normalise(Triplets& triplets);
 
@@ -119,8 +121,6 @@ protected:
     }
 
     bool matrixAllocated() const { return matrix_shared_.use_count(); }
-
-    const Matrix& matrix() const { return *matrix_; }
 
     virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target) = 0;
     virtual void do_setup(const Grid& source, const Grid& target, const Cache&)     = 0;


### PR DESCRIPTION

## Description
<br>

This PR is intended to implement a 'getter' method that allows the access to the _interpolation matrix_.

A new procedure to perform the regridding from high to low resolution for the CS-LFR grid has been implemented. The procedure uses the Atlas library and in particular the classes `Interpolation` and `Method`.
Currently, the interpolation matrix defined in Atlas is hidden. The changes proposed in this PR will makes the interpolation matrix visible.
<br><br>

### Acceptance Criteria (Definition of Done)

All the tests pass.
<br><br>
