### PR TITLE
Fix partitioner config exception message

### DIFF
--- a/src/atlas/meshgenerator/detail/CubedSphereDualMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/CubedSphereDualMeshGenerator.cc
@@ -63,9 +63,7 @@ CubedSphereDualMeshGenerator::CubedSphereDualMeshGenerator(const eckit::Parametr
 
     // Get partitioner.
     std::string partitioner;
-    try { p.get("partitioner.type", partitioner); } catch( std::exception& ) {}
-    p.get("partitioner", partitioner);
-    if( partitioner.size() ) {
+    if (p.get("partitioner", partitioner) && partitioner.size()) {
         options.set("partitioner", partitioner);
     }
 }

--- a/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
@@ -73,9 +73,7 @@ CubedSphereMeshGenerator::CubedSphereMeshGenerator(const eckit::Parametrisation&
 
     // Get partitioner.
     std::string partitioner;
-    try { p.get("partitioner.type", partitioner); } catch( std::exception& ) {}
-    p.get("partitioner", partitioner);
-    if( partitioner.size() ) {
+    if (p.get("partitioner", partitioner) && partitioner.size()) {
         options.set("partitioner", partitioner);
     }
 }


### PR DESCRIPTION
Improve logic to eliminate config exception message. This change uses the return `bool` value of `p.get` to detect success/failure.

In a downstream application, we have been seeing error messages like these (but the messages don't result in failures):

```
Exception: Bad operator: cubedsphere (String) method 'contains' not implemented ...
```

This change fixes this. I no longer see these error messages in the downstream application.