### PR TITLE
Update `SphericalVector` to work with StructuredColumns as source functionspace.

### DIFF
--- a/src/atlas/interpolation/method/sphericalvector/SphericalVector.cc
+++ b/src/atlas/interpolation/method/sphericalvector/SphericalVector.cc
@@ -78,7 +78,6 @@ void SphericalVector::do_setup(const FunctionSpace& source,
                                                    option::variables(2));
   auto targetLonLats = target_.createField<double>(option::name("lonlat") |
                                                    option::variables(2));
-
   const auto sourceLonLatsView = array::make_view<double, 2>(source_.lonlat());
   const auto targetLonLatsView = array::make_view<double, 2>(target_.lonlat());
 

--- a/src/atlas/interpolation/method/sphericalvector/SphericalVector.cc
+++ b/src/atlas/interpolation/method/sphericalvector/SphericalVector.cc
@@ -78,13 +78,9 @@ void SphericalVector::do_setup(const FunctionSpace& source,
                                                    option::variables(2));
   auto targetLonLats = target_.createField<double>(option::name("lonlat") |
                                                    option::variables(2));
-  sourceLonLats.array().copy(source_.lonlat());
-  targetLonLats.array().copy(target_.lonlat());
-  sourceLonLats.haloExchange();
-  targetLonLats.haloExchange();
 
-  const auto sourceLonLatsView = array::make_view<double, 2>(sourceLonLats);
-  const auto targetLonLatsView = array::make_view<double, 2>(targetLonLats);
+  const auto sourceLonLatsView = array::make_view<double, 2>(source_.lonlat());
+  const auto targetLonLatsView = array::make_view<double, 2>(target_.lonlat());
 
   const auto unitSphere = geometry::UnitSphere{};
 

--- a/src/atlas/util/Geometry.cc
+++ b/src/atlas/util/Geometry.cc
@@ -3,9 +3,9 @@
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
- * In applying this licence, ECMWF does not waive the privileges and
- * immGeometryies granted to it by virtue of its status as an intergovernmental
- * organisation nor does it submit to any jurisdiction.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
  */
 
 #include "atlas/util/Geometry.h"

--- a/src/atlas/util/Geometry.cc
+++ b/src/atlas/util/Geometry.cc
@@ -15,8 +15,6 @@
 #include "atlas/library/config.h"
 #include "atlas/runtime/Exception.h"
 #include "atlas/util/Constants.h"
-#include "eckit/geometry/Point2.h"
-#include "eckit/geometry/Point3.h"
 
 namespace atlas {
 

--- a/src/atlas/util/Geometry.cc
+++ b/src/atlas/util/Geometry.cc
@@ -3,21 +3,20 @@
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
- * In applying this licence, ECMWF does not waive the privileges and immGeometryies
- * granted to it by virtue of its status as an intergovernmental organisation
- * nor does it submit to any jurisdiction.
+ * In applying this licence, ECMWF does not waive the privileges and
+ * immGeometryies granted to it by virtue of its status as an intergovernmental
+ * organisation nor does it submit to any jurisdiction.
  */
 
 #include "atlas/util/Geometry.h"
 
 #include <cmath>
 
-#include "eckit/geometry/Point2.h"
-#include "eckit/geometry/Point3.h"
-
 #include "atlas/library/config.h"
 #include "atlas/runtime/Exception.h"
 #include "atlas/util/Constants.h"
+#include "eckit/geometry/Point2.h"
+#include "eckit/geometry/Point3.h"
 
 namespace atlas {
 
@@ -25,15 +24,14 @@ namespace geometry {
 namespace detail {
 void GeometrySphere::lonlat2xyz(const Point2& lonlat, Point3& xyz) const {
 #if ATLAS_ECKIT_VERSION_AT_LEAST(1, 24, 0)
-    Sphere::convertSphericalToCartesian(radius_, lonlat, xyz, 0., true);
+  Sphere::convertSphericalToCartesian(radius_, lonlat, xyz, 0., true);
 #else
-    Sphere::convertSphericalToCartesian(radius_, lonlat, xyz);
+  Sphere::convertSphericalToCartesian(radius_, lonlat, xyz);
 #endif
 }
 void GeometrySphere::xyz2lonlat(const Point3& xyz, Point2& lonlat) const {
-    Sphere::convertCartesianToSpherical(radius_, xyz, lonlat);
+  Sphere::convertCartesianToSpherical(radius_, xyz, lonlat);
 }
-
 
 /// @brief   Calculate great-cricle course between points
 ///
@@ -45,7 +43,10 @@ void GeometrySphere::xyz2lonlat(const Point3& xyz, Point2& lonlat) const {
 /// @ref     https://en.wikipedia.org/wiki/Great-circle_navigation
 ///
 std::pair<double, double> greatCircleCourse(const Point2& lonLat1,
-                                                   const Point2& lonLat2) {
+                                            const Point2& lonLat2) {
+  if (lonLat1 == lonLat2) {
+    return std::make_pair(0., 0.);
+  }
 
   const auto lambda1 = lonLat1[0] * util::Constants::degreesToRadians();
   const auto lambda2 = lonLat2[0] * util::Constants::degreesToRadians();
@@ -71,71 +72,76 @@ std::pair<double, double> greatCircleCourse(const Point2& lonLat1,
                         alpha2 * util::Constants::radiansToDegrees());
 };
 
-
-} // namespace detail
-} // namespace geometry
+}  // namespace detail
+}  // namespace geometry
 
 extern "C" {
 // ------------------------------------------------------------------
 // C wrapper interfaces to C++ routines
 Geometry::Implementation* atlas__Geometry__new_name(const char* name) {
-    Geometry::Implementation* geometry;
-    {
-        Geometry handle{std::string{name}};
-        geometry = handle.get();
-        geometry->attach();
-    }
-    geometry->detach();
-    return geometry;
+  Geometry::Implementation* geometry;
+  {
+    Geometry handle{std::string{name}};
+    geometry = handle.get();
+    geometry->attach();
+  }
+  geometry->detach();
+  return geometry;
 }
-geometry::detail::GeometryBase* atlas__Geometry__new_radius(const double radius) {
-    Geometry::Implementation* geometry;
-    {
-        Geometry handle{radius};
-        geometry = handle.get();
-        geometry->attach();
-    }
-    geometry->detach();
-    return geometry;
+geometry::detail::GeometryBase* atlas__Geometry__new_radius(
+    const double radius) {
+  Geometry::Implementation* geometry;
+  {
+    Geometry handle{radius};
+    geometry = handle.get();
+    geometry->attach();
+  }
+  geometry->detach();
+  return geometry;
 }
 void atlas__Geometry__delete(Geometry::Implementation* This) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Geometry");
-    delete This;
+  ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Geometry");
+  delete This;
 }
-void atlas__Geometry__xyz2lonlat(Geometry::Implementation* This, const double x, const double y, const double z,
-                                 double& lon, double& lat) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Geometry");
-    PointLonLat lonlat;
-    This->xyz2lonlat(PointXYZ{x, y, z}, lonlat);
-    lon = lonlat.lon();
-    lat = lonlat.lat();
+void atlas__Geometry__xyz2lonlat(Geometry::Implementation* This, const double x,
+                                 const double y, const double z, double& lon,
+                                 double& lat) {
+  ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Geometry");
+  PointLonLat lonlat;
+  This->xyz2lonlat(PointXYZ{x, y, z}, lonlat);
+  lon = lonlat.lon();
+  lat = lonlat.lat();
 }
-void atlas__Geometry__lonlat2xyz(Geometry::Implementation* This, const double lon, const double lat, double& x,
+void atlas__Geometry__lonlat2xyz(Geometry::Implementation* This,
+                                 const double lon, const double lat, double& x,
                                  double& y, double& z) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Geometry");
-    PointXYZ xyz;
-    This->lonlat2xyz(PointLonLat{lon, lat}, xyz);
-    x = xyz.x();
-    y = xyz.y();
-    z = xyz.z();
+  ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Geometry");
+  PointXYZ xyz;
+  This->lonlat2xyz(PointLonLat{lon, lat}, xyz);
+  x = xyz.x();
+  y = xyz.y();
+  z = xyz.z();
 }
-double atlas__Geometry__distance_lonlat(Geometry::Implementation* This, const double lon1, const double lat1,
+double atlas__Geometry__distance_lonlat(Geometry::Implementation* This,
+                                        const double lon1, const double lat1,
                                         const double lon2, const double lat2) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Geometry");
-    return This->distance(PointLonLat{lon1, lat1}, PointLonLat{lon2, lat2});
+  ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Geometry");
+  return This->distance(PointLonLat{lon1, lat1}, PointLonLat{lon2, lat2});
 }
-double atlas__Geometry__distance_xyz(Geometry::Implementation* This, const double x1, const double y1, const double z1,
-                                     const double x2, const double y2, const double z2) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Geometry");
-    return This->distance(PointXYZ{x1, y1, z1}, PointXYZ{x2, y2, z2});
+double atlas__Geometry__distance_xyz(Geometry::Implementation* This,
+                                     const double x1, const double y1,
+                                     const double z1, const double x2,
+                                     const double y2, const double z2) {
+  ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Geometry");
+  return This->distance(PointXYZ{x1, y1, z1}, PointXYZ{x2, y2, z2});
 }
 double atlas__Geometry__radius(Geometry::Implementation* This) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Geometry");
-    return This->radius();
+  ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Geometry");
+  return This->radius();
 }
 double atlas__Geometry__area(Geometry::Implementation* This) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Geometry");
-    return This->area();
+  ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Geometry");
+  return This->area();
 }
 }
 // ------------------------------------------------------------------

--- a/src/tests/interpolation/test_interpolation_spherical_vector.cc
+++ b/src/tests/interpolation/test_interpolation_spherical_vector.cc
@@ -202,12 +202,6 @@ void testInterpolation(const Config& config) {
         }
       });
 
-  if (functionspace::StructuredColumns(sourceFunctionSpace)) {
-    sourceFieldSet[0].metadata().set("type", "scalar");
-    sourceFieldSet[0].haloExchange();
-    sourceFieldSet[0].metadata().set("type", "vector");
-  }
-
   const auto interp = Interpolation(
       InterpSchemeFixtures::get(config.getString("interp_fixture")),
       sourceFunctionSpace, targetFunctionSpace);

--- a/src/tests/util/test_unitsphere.cc
+++ b/src/tests/util/test_unitsphere.cc
@@ -5,9 +5,6 @@
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-#include <complex>
-
-#include "atlas/util/Constants.h"
 #include "atlas/util/Geometry.h"
 #include "atlas/util/Point.h"
 #include "tests/AtlasTestEnvironment.h"

--- a/src/tests/util/test_unitsphere.cc
+++ b/src/tests/util/test_unitsphere.cc
@@ -5,9 +5,11 @@
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-#include "atlas/util/Point.h"
-#include "atlas/util/Geometry.h"
+#include <complex>
 
+#include "atlas/util/Constants.h"
+#include "atlas/util/Geometry.h"
+#include "atlas/util/Point.h"
 #include "tests/AtlasTestEnvironment.h"
 
 namespace atlas {
@@ -16,28 +18,43 @@ namespace test {
 using namespace atlas::util;
 
 CASE("great-circle course") {
-
   geometry::UnitSphere g;
 
   const auto point1 = PointLonLat(-71.6, -33.0);  // Valparaiso
   const auto point2 = PointLonLat(121.8, 31.4);   // Shanghai
   const auto point3 = PointLonLat(0., 89.);
   const auto point4 = PointLonLat(180., 89.);
+  const auto point5 = PointLonLat(0., 90.);
+  const auto point6 = PointLonLat(180., 90.);
 
   const auto targetCourse1 = -94.41;
   const auto targetCourse2 = -78.42;
   const auto targetCourse3 = 0.;
   const auto targetCourse4 = 180.;
+  const auto targetCourse5 = 0.;
+  const auto targetCourse6 = 180.;
+  const auto targetCourse7 = 0.;
+  const auto targetCourse8 = 0.;
 
-  const auto[ course1, course2 ] = g.greatCircleCourse(point1, point2);
-  const auto[ course3, course4 ] = g.greatCircleCourse(point3, point4);
+
+  const auto [course1, course2] = g.greatCircleCourse(point1, point2);
+  const auto [course3, course4] = g.greatCircleCourse(point3, point4);
+
+  // Colocated points on pole.
+  const auto [course5, course6] = g.greatCircleCourse(point5, point6);
+  const auto [course7, course8] = g.greatCircleCourse(point5, point5);
+
 
   EXPECT_APPROX_EQ(course1, targetCourse1, 0.01);
   EXPECT_APPROX_EQ(course2, targetCourse2, 0.01);
   EXPECT_APPROX_EQ(course3, targetCourse3, 1.e-14);
   EXPECT_APPROX_EQ(std::abs(course4), targetCourse4, 1.e-14);
+  EXPECT_APPROX_EQ(std::abs(course5), targetCourse5, 1.e-14);
+  EXPECT_APPROX_EQ(std::abs(course6), targetCourse6, 1.e-14);
+  EXPECT_APPROX_EQ(std::abs(course7), targetCourse7, 1.e-14);
+  EXPECT_APPROX_EQ(std::abs(course8), targetCourse8, 1.e-14);
 }
-} // namespace test
-} // namespace atlas
+}  // namespace test
+}  // namespace atlas
 
 int main(int argc, char** argv) { return atlas::test::run(argc, argv); }


### PR DESCRIPTION
This draft PR updates the test from PR #168 to include halo exchanges. Due to issue #174, the following code has to be added before `Inderpolation::exectute` is called:

```
  if (functionspace::StructuredColumns(sourceFunctionSpace)) {
    sourceFieldSet[0].metadata().set("type", "scalar");
    sourceFieldSet[0].haloExchange();
    sourceFieldSet[0].metadata().set("type", "vector");
  }
```
For other functionspaces, the type is set to `vector` and  the halo exchange is called within `Inderpolation::exectute`.

If you comment out this block, you'll reproduce the output in #174 .


Once #174 is addressed, this block can be deleted and the PR will be ready for review.

Edit: further additions to this PR will close #174 