### PR TITLE
Fix build for configuration setting ATLAS_BITS_LOCAL=64

### DIFF
--- a/src/atlas/functionspace/PointCloud.cc
+++ b/src/atlas/functionspace/PointCloud.cc
@@ -1001,7 +1001,7 @@ void PointCloud::setupGatherScatter() {
                             array::make_view<idx_t, 1>(remote_index_).data(),
                             REMOTE_IDX_BASE,
                             array::make_view<gidx_t, 1>(global_index_).data(),
-                            array::make_view<idx_t, 1>(ghost_).data(),
+                            array::make_view<int, 1>(ghost_).data(),
                             ghost_.size());
         size_global_ = gather_scatter_->glb_dof();
     }


### PR DESCRIPTION
I've tried matching the arguments to the signatures types (maybe there should only be one GatherScatter::setup). This seems to have been a requirement put forward for production ("for O8000" is the comment), so as far as I can tell is is urgent.
