### PR TITLE
Remove float in Triag2D intersection algorithm

### DIFF
--- a/src/atlas/interpolation/element/Triag2D.cc
+++ b/src/atlas/interpolation/element/Triag2D.cc
@@ -42,7 +42,7 @@ method::Intersect Triag2D::intersects(const PointXY& r, double edgeEpsilon, doub
     Vector2D pvec{rvec - v00};
 
     // solve u e1 + v e2 = pvec for u and v
-    float invDet = 1. / (e1.x() * e2.y() - e2.x() * e1.y());
+    double invDet = 1. / (e1.x() * e2.y() - e2.x() * e1.y());
     isect.u      = (pvec.x() * e2.y() - e2.x() * pvec.y()) * invDet;
     isect.v      = (e1.x() * pvec.y() - pvec.x() * e1.y()) * invDet;
 


### PR DESCRIPTION
Most floating-point numbers in this context are `double`, but there's a surprise `float` in the `Triag2D::intersects` algorithm. This lowers the precision of the `double` u,v coordinates.

I tried writing my own interpolation algorithm from the intersection outputs, and found I needed looser tolerances everywhere as a result of this `float` when using LonLat/2D triangles as compared to the Spherical/3D triangles.

Assuming this to be an oversight, I'm making this PR... let me know if the `float` is intentional.