### PR TITLE
Update ci.yml to fix notification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - private-downstream-ci
       - downstream-ci-hpc
       - private-downstream-ci-hpc
-    if: always() && ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
+    if: ${{ always() && !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     steps:
       - name: Trigger Teams notification
         uses: ecmwf-actions/notify-teams@v1


### PR DESCRIPTION
There's a weird problem with gh actions...
The `always()` should make the notification trigger even when some dependencies listed in `needs` fail. However we have to pull the evaluation in the ${{ }} to make it work.