### PR TITLE
Made sure cubed-sphere interpolation method always sets metadata.

### DIFF
--- a/src/atlas/interpolation/method/cubedsphere/CubedSphereBilinear.cc
+++ b/src/atlas/interpolation/method/cubedsphere/CubedSphereBilinear.cc
@@ -33,6 +33,13 @@ void CubedSphereBilinear::do_setup(const FunctionSpace& source, const FunctionSp
     ATLAS_ASSERT(ncSource);
     ATLAS_ASSERT(target_);
 
+    // Add tile index metadata to target.
+    target_->metadata().set("tile index", std::vector<idx_t>{});
+
+    // Enable or disable halo exchange.
+    this->allow_halo_exchange_ = halo_exchange_;
+
+
     // return early if no output points on this partition reserve is called on
     // the triplets but also during the sparseMatrix constructor. This won't
     // work for empty matrices
@@ -45,9 +52,6 @@ void CubedSphereBilinear::do_setup(const FunctionSpace& source, const FunctionSp
     // Numeric tolerance should scale with N.
     const auto N         = CubedSphereGrid(ncSource.mesh().grid()).N();
     const auto tolerance = 2. * std::numeric_limits<double>::epsilon() * N;
-
-    // Enable or disable halo exchange.
-    this->allow_halo_exchange_ = halo_exchange_;
 
     // Loop over target at calculate interpolation weights.
     auto weights          = std::vector<Triplet>{};


### PR DESCRIPTION
Follow-on from #206.

Added a slight oversight in the last PR which, when combined with jcsda/oops [#2670](https://github.com/JCSDA-internal/oops/pull/2670), breaks the lfric-jedi model interface.

The metadata itself is a bit hacky and both will be redundant soon. But for now, it's needed to keep things running.