### PR TITLE
Add Fortran interface for node-to-edge connectivity building

### DIFF
--- a/src/atlas_f/CMakeLists.txt
+++ b/src/atlas_f/CMakeLists.txt
@@ -96,6 +96,7 @@ generate_fortran_bindings(FORTRAN_BINDINGS ../atlas/mesh/actions/BuildPeriodicBo
 generate_fortran_bindings(FORTRAN_BINDINGS ../atlas/mesh/actions/BuildHalo.h)
 generate_fortran_bindings(FORTRAN_BINDINGS ../atlas/mesh/actions/BuildEdges.h)
 generate_fortran_bindings(FORTRAN_BINDINGS ../atlas/mesh/actions/BuildDualMesh.h)
+generate_fortran_bindings(FORTRAN_BINDINGS ../atlas/mesh/actions/BuildNode2CellConnectivity.h)
 generate_fortran_bindings(FORTRAN_BINDINGS ../atlas/mesh/actions/WriteLoadBalanceReport.h)
 generate_fortran_bindings(FORTRAN_BINDINGS ../atlas/meshgenerator/detail/MeshGeneratorInterface.h
     MODULE atlas_meshgenerator_c_binding

--- a/src/atlas_f/atlas_module.F90
+++ b/src/atlas_f/atlas_module.F90
@@ -141,6 +141,7 @@ use atlas_mesh_actions_module, only: &
     & atlas_build_halo, &
     & atlas_build_edges, &
     & atlas_build_pole_edges, &
+    & atlas_build_node_to_cell_connectivity, &
     & atlas_build_node_to_edge_connectivity, &
     & atlas_build_median_dual_mesh, &
     & atlas_write_load_balance_report, &

--- a/src/atlas_f/mesh/atlas_mesh_actions_module.F90
+++ b/src/atlas_f/mesh/atlas_mesh_actions_module.F90
@@ -19,6 +19,7 @@ public :: atlas_build_periodic_boundaries
 public :: atlas_build_halo
 public :: atlas_build_edges
 public :: atlas_build_pole_edges
+public :: atlas_build_node_to_cell_connectivity
 public :: atlas_build_node_to_edge_connectivity
 public :: atlas_build_median_dual_mesh
 public :: atlas_write_load_balance_report
@@ -83,6 +84,13 @@ subroutine atlas_build_pole_edges(mesh)
   type(atlas_Mesh), intent(inout) :: mesh
   call atlas__build_pole_edges(mesh%CPTR_PGIBUG_A)
 end subroutine atlas_build_pole_edges
+
+subroutine atlas_build_node_to_cell_connectivity(mesh)
+  use atlas_BuildNode2CellConnectivity_c_binding
+  use atlas_Mesh_module, only: atlas_Mesh
+  type(atlas_Mesh), intent(inout) :: mesh
+  call atlas__build_node_to_cell_connectivity(mesh%CPTR_PGIBUG_A)
+end subroutine atlas_build_node_to_cell_connectivity
 
 subroutine atlas_build_node_to_edge_connectivity(mesh)
   use atlas_BuildEdges_c_binding


### PR DESCRIPTION
The Fortran interface for node-to-edge connectivity building was half-implemented, this PR makes it fully available.