### PR TITLE
Wrap out-of-bounds source cells into the domain

### DIFF
--- a/src/atlas/interpolation/method/unstructured/UnstructuredBilinearLonLat.cc
+++ b/src/atlas/interpolation/method/unstructured/UnstructuredBilinearLonLat.cc
@@ -419,14 +419,21 @@ Method::Triplets UnstructuredBilinearLonLat::projectPointToElements(size_t ip, c
             }
             // shift cells on the east-west periodic boundary from the east to the west
             // so that the quad surrounds a point with output longitude in [0,360)
-            if (lons[0] > lons[1] || lons[3] > lons[2]) {
-                lons[0] -= 360;
-                lons[3] -= 360;
+            double minlon = std::numeric_limits<double>::max();
+            for ( int i = 0; i < 4; i++ ) {
+                minlon = std::min( minlon, lons[i] );
+            }
+            for ( int i = 0; i < 4; i++ ) {
+                if ( (lons[i] - minlon) > 180 ) {
+                    lons[i] -= 360;
+                }
             }
 
             element::Quad2D quad(
                 PointLonLat{lons[0], (*ilonlat_)(idx[0], LAT)}, PointLonLat{lons[1], (*ilonlat_)(idx[1], LAT)},
                 PointLonLat{lons[2], (*ilonlat_)(idx[2], LAT)}, PointLonLat{lons[3], (*ilonlat_)(idx[3], LAT)});
+
+            ATLAS_ASSERT( quad.validate() );
 
             if (itc == elems.begin()) {
                 inv_dist_weight_quad(quad, o_loc, inv_dist_w);


### PR DESCRIPTION
## Description
Recent work on adding a halo size > 0 to atlas-orca (https://github.com/ecmwf/atlas-orca/issues/19) revealed an issue in the North fold of the orca grid when comparing MPI to non-MPI interpolations.

This issue was traced to the interpolator not properly accounting fully for the wrapping of the source interpolation mesh cell when it crosses the periodic boundary.

This change fixes this issue by properly validating each cell.

The change was proposed by Simon Good, I am just performing the necessary admin to get the change into atlas.

## Testing
This is tricky to test, and requires a separate PR in atlas-orca to introduce a ctest to cover the issue.
 * A ctest will be added as part of https://github.com/ecmwf/atlas-orca/pull/20
 * Testing was performed using a combination build, as part of other changes associated with the move to halo size = 1. Regression tests against known-good-outputs was how the change was discovered, but this system is internal to the Met Office. The master pr for the coordinated change is https://github.com/MetOffice/orca-jedi/pull/96

An example of some of the affected interpolated points that were incorrect before this change and fixed afterwards on an eORCA025_T:

![hofx_differences](https://github.com/ecmwf/atlas/assets/14909402/dd07d22e-51c2-450f-974d-9cd547292ff5)



