### PR TITLE
Fix missing header in FieldImpl.h

### DIFF
--- a/src/atlas/field/detail/FieldImpl.h
+++ b/src/atlas/field/detail/FieldImpl.h
@@ -16,6 +16,7 @@
 #include <functional>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 #include "atlas/util/Object.h"
 


### PR DESCRIPTION
`FieldImpl.h` used `std::find`, but did not include the `algorithm` header. This lead to some compilation errors in atlas4py with gcc 14.1.1.