### PR TITLE
Fix typo in commented description of the spectral functionspace

### DIFF
--- a/src/atlas/functionspace/Spectral.h
+++ b/src/atlas/functionspace/Spectral.h
@@ -47,9 +47,10 @@ class Spectral : public functionspace::FunctionSpaceImpl {
      n = total wavenumber
   
   const auto zonal_wavenumbers = Spectral::zonal_wavenumbers();
+  const int truncation = Spectral::truncation();
   idx_t jc=0;
   for( int jm=0; jm<zonal_wavenumbers.size(); ++jm ) {
-    int m = zonal_wavenumbers(m);
+    int m = zonal_wavenumbers(jm);
     for( int n=m; m<=truncation; ++n ) {
       data( jc++, jfld ) = func_real_part(m,n);
       data( jc++, jfld ) = func_imag_part(m,n);


### PR DESCRIPTION
## Description

This PR fixes a small typo in a comment that describes the structure of the Spectral FunctionSpace. 

## Impact

None