### PR TITLE
Fixed ordering of `fixup_halos` and `halo_exhange.execute_adjoint` in `StructuredColumns.cc`

### DIFF
--- a/src/atlas/functionspace/detail/StructuredColumns.cc
+++ b/src/atlas/functionspace/detail/StructuredColumns.cc
@@ -830,20 +830,20 @@ void dispatch_adjointHaloExchange(Field& field, const parallel::HaloExchange& ha
                                   const StructuredColumns& fs) {
     FixupHaloForVectors<RANK> fixup_halos(fs);
     if (field.datatype() == array::DataType::kind<int>()) {
-        halo_exchange.template execute_adjoint<int, RANK>(field.array(), false);
         fixup_halos.template apply<int>(field);
+        halo_exchange.template execute_adjoint<int, RANK>(field.array(), false);
     }
     else if (field.datatype() == array::DataType::kind<long>()) {
-        halo_exchange.template execute_adjoint<long, RANK>(field.array(), false);
         fixup_halos.template apply<long>(field);
+        halo_exchange.template execute_adjoint<long, RANK>(field.array(), false);
     }
     else if (field.datatype() == array::DataType::kind<float>()) {
-        halo_exchange.template execute_adjoint<float, RANK>(field.array(), false);
         fixup_halos.template apply<float>(field);
+        halo_exchange.template execute_adjoint<float, RANK>(field.array(), false);
     }
     else if (field.datatype() == array::DataType::kind<double>()) {
-        halo_exchange.template execute_adjoint<double, RANK>(field.array(), false);
         fixup_halos.template apply<double>(field);
+        halo_exchange.template execute_adjoint<double, RANK>(field.array(), false);
     }
     else {
         throw_Exception("datatype not supported", Here());

--- a/src/tests/interpolation/test_interpolation_spherical_vector.cc
+++ b/src/tests/interpolation/test_interpolation_spherical_vector.cc
@@ -290,7 +290,6 @@ void testInterpolation(const Config& config) {
   auto sourceAdjointView = array::make_view<double, Rank>(sourceAdjoint);
   sourceAdjointView.assign(0.);
 
-  sourceAdjoint.set_dirty(false);
   interp.execute_adjoint(sourceAdjoint, targetAdjoint);
 
   // Check fields for nans or +/-inf


### PR DESCRIPTION
Whilst integrating `util::pack_vector_fields` into the `SphericalVector` interpolation method, I uncovered a bug in `StructuredColumns`. The methods `fixup_halos` and `halo_exchange.execute_adjoint` were called in the wrong order during a halo exchange adjoint. This PR fixes the bug.

I'd initially missed this by adding (and then forgetting) a workaround in the `SphericalVector` test.

@MarekWlasak this will likely be of interest to you.