### PR TITLE
Tidied up headers in `ArrayViewVariant.h` and `ArrayViewVariant.cc`

### DIFF
--- a/src/atlas/array/ArrayViewVariant.cc
+++ b/src/atlas/array/ArrayViewVariant.cc
@@ -10,6 +10,8 @@
 #include <string>
 #include <type_traits>
 
+#include "atlas/array/Array.h"
+#include "atlas/array/MakeView.h"
 #include "atlas/runtime/Exception.h"
 
 namespace atlas {
@@ -49,10 +51,9 @@ VariantType<ArrayType> executeMakeView(ArrayType& array,
   if constexpr (TypeIndex < std::variant_size_v<VariantType<ArrayType>> - 1) {
     return executeMakeView<TypeIndex + 1>(array, makeView);
   } else {
-    throw_Exception("ArrayView<" + array.datatype().str() + ", " +
-                        std::to_string(array.rank()) +
-                        "> is not an alternative in ArrayViewVariant.",
-                    Here());
+    ATLAS_THROW_EXCEPTION("Array with rank = " + std::to_string(array.rank()) +
+                          " and datatype = " + array.datatype().str() +
+                          " is not supported.");
   }
 }
 

--- a/src/atlas/array/ArrayViewVariant.h
+++ b/src/atlas/array/ArrayViewVariant.h
@@ -7,16 +7,15 @@
 
 #pragma once
 
+#include <type_traits>
 #include <variant>
 
-#include "atlas/array.h"
+#include "atlas/array/ArrayView.h"
 
 namespace atlas {
 namespace array {
 
 namespace detail {
-
-using namespace array;
 
 // Container struct for a list of types.
 template <typename... Ts>
@@ -53,6 +52,8 @@ using VariantValueTypes =
 using VariantRanks = detail::Ints<1, 2, 3, 4, 5, 6, 7, 8, 9>;
 
 }  // namespace detail
+
+class Array;
 
 /// @brief Variant containing all supported non-const ArrayView alternatives.
 using ArrayViewVariant =

--- a/src/atlas/runtime/Exception.h
+++ b/src/atlas/runtime/Exception.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <string>
+#include <sstream>
 
 #include "eckit/log/CodeLocation.h"
 


### PR DESCRIPTION
This PR does some tidying that I missed in PR #220. Namely headers and the error message. I also found a missing `<sstream>` header in `runtime/Exception.h`.