### PR TITLE
Move example-fortran inside atlas_HAVE_DOCS

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -6,11 +6,11 @@
 # granted to it by virtue of its status as an intergovernmental organisation nor
 # does it submit to any jurisdiction.
 
+if(atlas_HAVE_DOCS)
+
 if(atlas_HAVE_FORTRAN)
   add_subdirectory(example-fortran)
 endif()
-
-if(atlas_HAVE_DOCS)
 
 add_subdirectory(user-guide)
 


### PR DESCRIPTION
Hi @wdeconinck, would it be possible to move the `example-fortran` code compilation within the `atlas_HAVE_DOCS` key? This would be helpful for me because I need to compile the Fortran library, but I don't want to link the `example-fortran` binaries. Thanks!