### PR TITLE
Fix application of limiter for StructuredInterpolation2D

### DIFF
--- a/src/atlas/interpolation/method/structured/StructuredInterpolation2D.h
+++ b/src/atlas/interpolation/method/structured/StructuredInterpolation2D.h
@@ -75,8 +75,9 @@ protected:
     FunctionSpace source_;
     FunctionSpace target_;
 
-    bool matrix_free_;
     bool verbose_;
+    bool limiter_;
+    bool matrix_free_;
     double convert_units_;
     idx_t out_npts_;
 

--- a/src/atlas/interpolation/method/structured/StructuredInterpolation2D.tcc
+++ b/src/atlas/interpolation/method/structured/StructuredInterpolation2D.tcc
@@ -472,14 +472,23 @@ void StructuredInterpolation2D<Kernel>::do_execute( const FieldSet& src_fields, 
     if ( datatype.kind() == array::DataType::KIND_REAL64 && rank == 1 ) {
         execute_impl<double, 1>( *kernel_, src_fields, tgt_fields );
     }
-    if ( datatype.kind() == array::DataType::KIND_REAL32 && rank == 1 ) {
+    else if ( datatype.kind() == array::DataType::KIND_REAL32 && rank == 1 ) {
         execute_impl<float, 1>( *kernel_, src_fields, tgt_fields );
     }
-    if ( datatype.kind() == array::DataType::KIND_REAL64 && rank == 2 ) {
+    else if ( datatype.kind() == array::DataType::KIND_REAL64 && rank == 2 ) {
         execute_impl<double, 2>( *kernel_, src_fields, tgt_fields );
     }
-    if ( datatype.kind() == array::DataType::KIND_REAL32 && rank == 2 ) {
+    else if ( datatype.kind() == array::DataType::KIND_REAL32 && rank == 2 ) {
         execute_impl<float, 2>( *kernel_, src_fields, tgt_fields );
+    }
+    else if ( datatype.kind() == array::DataType::KIND_REAL64 && rank == 3 ) {
+        execute_impl<double, 3>( *kernel_, src_fields, tgt_fields );
+    }
+    else if ( datatype.kind() == array::DataType::KIND_REAL32 && rank == 3 ) {
+        execute_impl<float, 3>( *kernel_, src_fields, tgt_fields );
+    }
+    else {
+        ATLAS_NOTIMPLEMENTED;
     }
 
     tgt_fields.set_dirty();

--- a/src/atlas/interpolation/method/structured/kernels/CubicHorizontalKernel.h
+++ b/src/atlas/interpolation/method/structured/kernels/CubicHorizontalKernel.h
@@ -234,6 +234,39 @@ public:
         }
     }
 
+    template <typename stencil_t, typename weights_t, typename Value, int Rank>
+    typename std::enable_if<(Rank == 3), void>::type interpolate(const stencil_t& stencil, const weights_t& weights,
+                                                                 const array::ArrayView<const Value, Rank>& input,
+                                                                 array::ArrayView<Value, Rank>& output, idx_t r) const {
+        std::array<std::array<idx_t, stencil_width()>, stencil_width()> index;
+        const auto& weights_j = weights.weights_j;
+        const idx_t Nk        = output.shape(1);
+        const idx_t Nl        = output.shape(2);
+
+        for (idx_t k = 0; k < Nk; ++k) {
+            for (idx_t l = 0; l < Nl; ++l) {
+                output(r, k, l) = 0.;
+            }
+        }
+        for (idx_t j = 0; j < stencil_width(); ++j) {
+            const auto& weights_i = weights.weights_i[j];
+            for (idx_t i = 0; i < stencil_width(); ++i) {
+                idx_t n = src_.index(stencil.i(i, j), stencil.j(j));
+                Value w = static_cast<Value>(weights_i[i] * weights_j[j]);
+                for (idx_t k = 0; k < Nk; ++k) {
+                    for (idx_t l = 0; l < Nl; ++l) {
+                        output(r, k, l) += w * input(n, k, l);
+                    }
+                }
+                index[j][i] = n;
+            }
+        }
+
+        if (limiter_) {
+            Limiter::limit(index, input, output, r);
+        }
+    }
+
     template <typename array_t>
     typename array_t::value_type operator()(double x, double y, const array_t& input) const {
         Stencil stencil;

--- a/src/atlas/interpolation/method/structured/kernels/CubicHorizontalLimiter.h
+++ b/src/atlas/interpolation/method/structured/kernels/CubicHorizontalLimiter.h
@@ -108,6 +108,39 @@ public:
             }
         }
     }
+
+    template <typename Value, int Rank>
+    static typename std::enable_if<(Rank == 3), void>::type limit(const std::array<std::array<idx_t, 4>, 4>& index,
+                                                                  const array::ArrayView<const Value, Rank>& input,
+                                                                  array::ArrayView<Value, Rank>& output, idx_t r) {
+        // Limit output to max/min of values in stencil marked by '*'
+        //         x        x        x         x
+        //              x     *-----*     x
+        //                   /   P  |
+        //          x       *------ *        x
+        //        x        x        x         x
+        for (idx_t k = 0; k < output.shape(1); ++k) {
+            for (idx_t l = 0; l < output.shape(2); ++l) {
+                Value maxval = std::numeric_limits<Value>::lowest();
+                Value minval = std::numeric_limits<Value>::max();
+                for (idx_t j = 1; j < 3; ++j) {
+                    for (idx_t i = 1; i < 3; ++i) {
+                        idx_t n   = index[j][i];
+                        Value val = input(n, k, l);
+                        maxval    = std::max(maxval, val);
+                        minval    = std::min(minval, val);
+                    }
+                }
+                if (output(r, k, l) < minval) {
+                    output(r, k, l) = minval;
+                }
+                else if (output(r, k, l) > maxval) {
+                    output(r, k, l) = maxval;
+                }
+            }
+        }
+    }
+
 };
 
 }  // namespace method

--- a/src/atlas/interpolation/method/structured/kernels/LinearHorizontalKernel.h
+++ b/src/atlas/interpolation/method/structured/kernels/LinearHorizontalKernel.h
@@ -186,6 +186,32 @@ public:
         }
     }
 
+    template <typename stencil_t, typename weights_t, typename Value, int Rank>
+    typename std::enable_if<(Rank == 3), void>::type interpolate(const stencil_t& stencil, const weights_t& weights,
+                                                                 const array::ArrayView<const Value, Rank>& input,
+                                                                 array::ArrayView<Value, Rank>& output, idx_t r) const {
+        const auto& weights_j = weights.weights_j;
+        const idx_t Nk        = output.shape(1);
+        const idx_t Nl        = output.shape(2);
+        for (idx_t k = 0; k < Nk; ++k) {
+            for (idx_t l = 0; l < Nl; ++l) {
+                output(r, k, l) = 0.;
+            }
+        }
+        for (idx_t j = 0; j < stencil_width(); ++j) {
+            const auto& weights_i = weights.weights_i[j];
+            for (idx_t i = 0; i < stencil_width(); ++i) {
+                idx_t n = src_.index(stencil.i(i, j), stencil.j(j));
+                Value w = static_cast<Value>(weights_i[i] * weights_j[j]);
+                for (idx_t k = 0; k < Nk; ++k) {
+                    for (idx_t l = 0; l < Nl; ++l) {
+                        output(r, k, l) += w * input(n, k, l);
+                    }
+                }
+            }
+        }
+    }
+
     template <typename array_t>
     typename array_t::value_type operator()(double x, double y, const array_t& input) const {
         Stencil stencil;

--- a/src/tests/interpolation/CMakeLists.txt
+++ b/src/tests/interpolation/CMakeLists.txt
@@ -75,6 +75,12 @@ ecbuild_add_executable( TARGET atlas_test_interpolation_structured2D
   NOINSTALL
 )
 
+ecbuild_add_executable( TARGET atlas_test_interpolation_structured_limiter
+  SOURCES  test_interpolation_structured2D_limiter.cc
+  LIBS     atlas
+  NOINSTALL
+)
+
 ecbuild_add_test( TARGET atlas_test_interpolation_structured2D_regional
   SOURCES  test_interpolation_structured2D_regional.cc
   LIBS     atlas

--- a/src/tests/interpolation/test_interpolation_structured2D_limiter.cc
+++ b/src/tests/interpolation/test_interpolation_structured2D_limiter.cc
@@ -1,0 +1,354 @@
+/*
+ * (C) Copyright 2013 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <fstream>
+#include <string>
+#include <cassert>
+#include <vector>
+#include <iomanip>
+
+#include "atlas/library.h"
+#include "atlas/runtime/Log.h"
+#include "atlas/functionspace.h"
+#include "atlas/interpolation.h"
+#include "atlas/output/Gmsh.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using atlas::functionspace::NodeColumns;
+using atlas::functionspace::StructuredColumns;
+using atlas::functionspace::PointCloud;
+using atlas::util::Config;
+
+namespace atlas {
+namespace test {
+
+//-----------------------------------------------------------------------------
+
+
+std::vector<double> read_array(const std::string& filename) {
+    std::string files_dir="/Users/willem/work/debug-ifs-mgrids-remap/files/H15p3_cubicatlasinterp/";
+    std::ifstream file (files_dir+filename);
+    assert(file.is_open());
+    std::size_t size;
+    file >> size;
+    std::vector<double> array(size);
+    for(std::size_t j=0; j<size; ++j) {
+        file >> array[j];
+    }
+    return array;
+}
+std::vector<atlas::PointXY> to_points(const std::vector<double>& lon, const std::vector<double>& lat) {
+    std::vector<atlas::PointXY> points(lon.size());
+    for( std::size_t j=0; j<points.size(); ++j) {
+        points[j][0] = lon[j];
+        points[j][1] = lat[j];
+    }
+    return points;
+}
+
+
+std::set<atlas::idx_t> ignore_overshoot{6271, 6272, 7196, 7212};
+std::set<atlas::idx_t> ignore_undershoot{43138,43319};
+
+template <typename View>
+std::pair<double,atlas::idx_t> view_max_loc(View v) {
+    double m = -std::numeric_limits<double>::max();
+    atlas::idx_t loc = 0;
+    for(atlas::idx_t j=0; j<v.size(); ++j) {
+        if(v[j] > m) {
+            if (ignore_overshoot.find(j) == ignore_overshoot.end()) {
+               m = v[j];
+               loc = j;
+            }
+        }
+    }
+    return {m,loc};
+}
+
+std::pair<double,atlas::idx_t> view_max_loc(atlas::array::ArrayView<const double,2> v) {
+    auto all = atlas::array::Range::all();
+    return view_max_loc( v.slice(all,0) );
+}
+
+std::pair<double,atlas::idx_t> view_max_loc(atlas::array::ArrayView<const double,3> v) {
+    auto all = atlas::array::Range::all();
+    return view_max_loc( v.slice(all,0,0) );
+}
+
+std::pair<double,atlas::idx_t> max_loc(const Field& field) {
+    if( field.rank() == 1 ) {
+        return view_max_loc(atlas::array::make_view<double,1>(field));
+    }
+    else if( field.rank() == 2 ) {
+        return view_max_loc(atlas::array::make_view<double,2>(field));
+    }
+    else if( field.rank() == 3 ) {
+        return view_max_loc(atlas::array::make_view<double,3>(field));
+    }
+    else {
+        ATLAS_NOTIMPLEMENTED;
+    }
+}
+
+template <typename View>
+std::pair<double,atlas::idx_t> view_min_loc(View v) {
+    double m = std::numeric_limits<double>::max();
+    atlas::idx_t loc = 0;
+    for(atlas::idx_t j=0; j<v.size(); ++j) {
+        if(v[j] < m) {
+            if (ignore_undershoot.find(j) == ignore_undershoot.end()) {
+                m = v[j];
+                loc = j;
+            }
+        }
+    }
+    return {m,loc};
+}
+
+std::pair<double,atlas::idx_t> view_min_loc(atlas::array::ArrayView<const double,2> v) {
+    auto all = atlas::array::Range::all();
+    return view_min_loc( v.slice(all,0) );
+}
+
+std::pair<double,atlas::idx_t> view_min_loc(atlas::array::ArrayView<const double,3> v) {
+    auto all = atlas::array::Range::all();
+    return view_min_loc( v.slice(all,0,0) );
+}
+
+
+std::pair<double,atlas::idx_t> min_loc(const Field& field) {
+    if( field.rank() == 1 ) {
+        return view_min_loc(atlas::array::make_view<double,1>(field));
+    }
+    else if( field.rank() == 2 ) {
+        return view_min_loc(atlas::array::make_view<double,2>(field));
+    }
+    else if( field.rank() == 3 ) {
+        return view_min_loc(atlas::array::make_view<double,3>(field));
+    }
+    else {
+        ATLAS_NOTIMPLEMENTED;
+    }
+}
+
+
+std::ostream& operator<<(std::ostream& out, const std::pair<double,atlas::idx_t>& mloc) {
+    out << std::setw(13) << std::fixed << std::setprecision(10) << mloc.first << "  at index " << mloc.second;
+    return out;
+}
+
+std::vector<atlas::PointXY> overshooting_dg_points() {
+    return std::vector<atlas::PointXY>{
+        {180., 45.2048},
+        {0.,-88.9603}, // undershoot
+        {360.,-88.9603} // undershoot
+    };
+}
+
+std::vector<atlas::PointXY> read_dg_points() {
+    static auto dg_lon = read_array("lambda_dg_nod.txt");
+    static auto dg_lat = read_array("theta_dg_nod.txt");
+    return to_points(dg_lon,dg_lat);
+};
+
+void read_tracer(atlas::Field& field_ifs) {
+    // the tracer read from file should match closely the analytical function below 'init_tracer'
+    static auto ifs_trc = read_array("trc_ifs_gp.txt");
+    if( field_ifs.rank() == 1 ) {
+        auto view_ifs = array::make_view<double,1>(field_ifs);
+        for( std::size_t j=0; j<std::min<std::size_t>(ifs_trc.size(), field_ifs.shape(0)); ++j) {
+            view_ifs(j) = ifs_trc[j];
+        }
+    }
+    else if( field_ifs.rank() == 2 ) {
+        auto view_ifs = array::make_view<double,2>(field_ifs);
+        for( std::size_t j=0; j<std::min<std::size_t>(ifs_trc.size(), field_ifs.shape(0)); ++j) {
+            view_ifs(j,0) = ifs_trc[j];
+        }
+    }
+    else if( field_ifs.rank() == 3 ) {
+        auto view_ifs = array::make_view<double,3>(field_ifs);
+        for( std::size_t j=0; j<std::min<std::size_t>(ifs_trc.size(), field_ifs.shape(0)); ++j) {
+            view_ifs(j,0,0) = ifs_trc[j];
+        }
+    }
+    else {
+        ATLAS_NOTIMPLEMENTED;
+    }
+    field_ifs.set_dirty();
+}
+
+void init_tracer(atlas::Field& field_ifs) {
+    auto func = [](double lon, double lat) -> double {
+        constexpr double lon_ctr = M_PI;
+        constexpr double lat_ctr = M_PI/4.;
+        constexpr double sigma_lon = 2.*M_PI/5.;
+        constexpr double sigma_lat = 2.*M_PI/5.;
+        constexpr double to_rad = M_PI/180.;
+        lon *= to_rad;
+        lat *= to_rad;
+        auto sqr = [](double x){ return x*x;};
+        return std::exp( - sqr( (lon-lon_ctr) / (std::sqrt(2.)*sigma_lon)) )
+            * std::exp( - sqr( (lat-lat_ctr) / (std::sqrt(2.)*sigma_lat)) );
+    };
+
+
+    auto ifs_lonlat = atlas::array::make_view<double,2>(field_ifs.functionspace().lonlat());
+    if( field_ifs.rank() == 1 ) {
+        auto view_ifs = array::make_view<double,1>(field_ifs);
+        for( std::size_t j=0; j<view_ifs.shape(0); ++j) {
+            view_ifs(j) = func(ifs_lonlat(j,0), ifs_lonlat(j,1));
+        }
+    }
+    else if( field_ifs.rank() == 2 ) {
+        auto view_ifs = array::make_view<double,2>(field_ifs);
+        for( std::size_t j=0; j<view_ifs.shape(0); ++j) {
+            view_ifs(j,0) = func(ifs_lonlat(j,0), ifs_lonlat(j,1));
+        }
+    }
+    else if( field_ifs.rank() == 3 ) {
+        auto view_ifs = array::make_view<double,3>(field_ifs);
+        for( std::size_t j=0; j<view_ifs.shape(0); ++j) {
+            view_ifs(j,0,0) = func(ifs_lonlat(j,0), ifs_lonlat(j,1));
+        }
+    }
+    else {
+        ATLAS_NOTIMPLEMENTED;
+    }
+    field_ifs.set_dirty();
+}
+
+void init_crazy(atlas::Field& field) {
+    if( field.rank() == 1 ) {
+        array::make_view<double,1>(field).assign(99999999999.);
+    }
+    else if( field.rank() == 2 ) {
+        array::make_view<double,2>(field).assign(99999999999.);
+    }
+    else if( field.rank() == 3 ) {
+        array::make_view<double,3>(field).assign(99999999999.);
+    }
+    else {
+        ATLAS_NOTIMPLEMENTED;
+    }
+}
+
+
+
+// ----------------------------------------------------------------------
+
+void do_test(bool limiter, int rank) {
+
+    // std::vector<atlas::PointXY> dg_points = read_dg_points();
+    //     This reads coordinates from files in ascii with format "nb_points value[0] value[1] ... value[nb_points-1]"
+    std::vector<atlas::PointXY> dg_points = overshooting_dg_points();
+
+    atlas::functionspace::PointCloud        dg_fs(dg_points);
+    atlas::functionspace::StructuredColumns ifs_fs(atlas::Grid("O80"), atlas::option::halo(3));
+    atlas::Field field_ifs;
+    atlas::Field field_dg;
+
+    if( rank == 1 ) {
+        field_ifs = ifs_fs.createField<double>();
+        field_dg  = dg_fs.createField<double>();
+    }
+    else if( rank == 2 ) {
+        int nlev = 60;
+        field_ifs = ifs_fs.createField<double>(atlas::option::levels(nlev));
+        field_dg  = dg_fs.createField<double>(atlas::option::levels(nlev));
+    }
+    else if( rank == 3 ) {
+        int nlev = 60;
+        int ntrc = 1;
+        field_ifs = ifs_fs.createField<double>(atlas::option::levels(nlev)|atlas::option::variables(ntrc));
+        field_dg  = dg_fs.createField<double>(atlas::option::levels(nlev)|atlas::option::variables(ntrc));
+    }
+    else {
+        ATLAS_NOTIMPLEMENTED;
+    }
+    init_crazy(field_dg);
+    init_tracer(field_ifs);
+    // read_tracer(field_ifs);
+
+    atlas::util::Config config;
+    config.set("type", "structured-quasicubic2D");
+    config.set("limiter", limiter);
+    config.set("matrix_free", true);
+    atlas::Interpolation interpolator(config, ifs_fs, dg_fs);
+    interpolator.execute(field_ifs, field_dg);
+
+    auto max_ifs = max_loc(field_ifs);
+    auto min_ifs = min_loc(field_ifs);
+    auto max_dg  = max_loc(field_dg);
+    auto min_dg  = min_loc(field_dg);
+
+    int precision = 10;
+    std::cout << "max_ifs:  " << max_ifs << std::endl;
+    std::cout << "max_dg:   " << max_dg  << std::endl;
+    std::cout << "max_diff: " << std::setw(13) << std::fixed << std::setprecision(precision) << max_ifs.first - max_dg.first << std::endl;
+    std::cout << std::endl;
+    std::cout << "min_ifs:  " << min_ifs << std::endl;
+    std::cout << "min_dg:   " << min_dg  << std::endl;
+    std::cout << "min_diff: " << std::setw(13) << std::fixed << std::setprecision(precision) << min_dg.first - min_ifs.first << std::endl;
+
+    if( limiter && max_dg.first > max_ifs.first ) {
+        std::cout << std::endl;
+        std::cout << "FAILURE: overshoot in interpolation detected " << std::endl;
+        auto lonlat = atlas::array::make_view<double,2>(dg_fs.lonlat());
+        std::cout << " coordinate ["<<max_dg.second<<"]: " << atlas::PointLonLat{lonlat(max_dg.second,0),lonlat(max_dg.second,1)} << std::endl;
+        EXPECT(max_dg.first <= max_ifs.first);
+    }
+    if( limiter && min_dg.first < min_ifs.first ) {
+        std::cout << std::endl;
+        std::cout << "FAILURE: undershoot in interpolation detected " << std::endl;
+        auto lonlat = atlas::array::make_view<double,2>(dg_fs.lonlat());
+        std::cout << " coordinate ["<<min_dg.second<<"]: " << atlas::PointLonLat{lonlat(min_dg.second,0),lonlat(min_dg.second,1)} << std::endl;
+        EXPECT(min_dg.first >= min_ifs.first);
+    }
+}
+
+CASE("structured-quasicubic2D without limiter, rank 1") {
+    bool limiter = false;
+    int rank = 1;
+    do_test(limiter, rank);
+}
+CASE("structured-quasicubic2D with limiter, rank 1") {
+    bool limiter = true;
+    int rank = 1;
+    do_test(limiter, rank);
+}
+CASE("structured-quasicubic2D without limiter, rank 2") {
+    bool limiter = false;
+    int rank = 2;
+    do_test(limiter, rank);
+}
+CASE("structured-quasicubic2D with limiter, rank 2") {
+    bool limiter = true;
+    int rank = 2;
+    do_test(limiter, rank);
+}
+CASE("structured-quasicubic2D without limiter, rank 3") {
+    bool limiter = false;
+    int rank = 3;
+    do_test(limiter, rank);
+}
+CASE("structured-quasicubic2D with limiter, rank 3") {
+    bool limiter = true;
+    int rank = 3;
+    do_test(limiter, rank);
+}
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}


### PR DESCRIPTION
This fixes an issue where the "limiter" configuration for StructuredInterpolation2D was not having any effect.
The fix is to propagate the option to the underlying Kernel.

Also an error is thrown when the "limiter" option is used in conjunction with the use of a matrix, as that is not supported.
So to enable the limiter one should both set "matrix_free=true" and "limiter=true".