### PR TITLE
Offload matrix based interpolation

### DIFF
--- a/hic/CMakeLists.txt
+++ b/hic/CMakeLists.txt
@@ -35,6 +35,7 @@ if( HAVE_CUDA )
   find_package(CUDAToolkit REQUIRED)
 elseif( HAVE_HIP )
   find_package(hip CONFIG REQUIRED)
+  find_package(hipsparse CONFIG REQUIRED)
 endif()
 
 add_subdirectory( src )

--- a/hic/src/CMakeLists.txt
+++ b/hic/src/CMakeLists.txt
@@ -30,6 +30,8 @@ ecbuild_add_library( TARGET hic
 install( FILES ${PROJECT_BINARY_DIR}/src/hic/hic_config.h DESTINATION include/hic )
 install( FILES hic/hic.h                                  DESTINATION include/hic )
 install( FILES hic/hic_runtime.h                          DESTINATION include/hic )
+install( FILES hic/hic_namespace_macro.h                  DESTINATION include/hic )
+install( FILES hic/hic_dummy/dummyShouldNotBeCalled.h     DESTINATION include/hic/hic_dummy )
 install( FILES hic/hic_dummy/hic_dummy_runtime.h          DESTINATION include/hic/hic_dummy )
 
 if( HAVE_CUDA )

--- a/hic/src/CMakeLists.txt
+++ b/hic/src/CMakeLists.txt
@@ -31,8 +31,11 @@ install( FILES ${PROJECT_BINARY_DIR}/src/hic/hic_config.h DESTINATION include/hi
 install( FILES hic/hic.h                                  DESTINATION include/hic )
 install( FILES hic/hic_runtime.h                          DESTINATION include/hic )
 install( FILES hic/hic_namespace_macro.h                  DESTINATION include/hic )
+install( FILES hic/hic_library_types.h                    DESTINATION include/hic )
+install( FILES hic/hicsparse.h                            DESTINATION include/hic )
 install( FILES hic/hic_dummy/dummyShouldNotBeCalled.h     DESTINATION include/hic/hic_dummy )
 install( FILES hic/hic_dummy/hic_dummy_runtime.h          DESTINATION include/hic/hic_dummy )
+install( FILES hic/hic_dummy/hicsparse_dummy.h            DESTINATION include/hic/hic_dummy )
 
 if( HAVE_CUDA )
   target_link_libraries( hic INTERFACE CUDA::cudart )

--- a/hic/src/CMakeLists.txt
+++ b/hic/src/CMakeLists.txt
@@ -36,6 +36,8 @@ install( FILES hic/hic_dummy/hic_dummy_runtime.h          DESTINATION include/hi
 
 if( HAVE_CUDA )
   target_link_libraries( hic INTERFACE CUDA::cudart )
+  target_link_libraries( hic INTERFACE CUDA::cusparse )
 elseif( HAVE_HIP )
   target_link_libraries( hic INTERFACE hip::host )
+  target_link_libraries( hic INTERFACE roc::hipsparse )
 endif()

--- a/hic/src/hic/hic_dummy/dummyShouldNotBeCalled.h
+++ b/hic/src/hic/hic_dummy/dummyShouldNotBeCalled.h
@@ -1,0 +1,21 @@
+/*
+ * (C) Copyright 2024- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+[[noreturn]] void dummyShouldNotBeCalled(const char* symbol) {
+    throw std::runtime_error(std::string(symbol)+" is using the dummy backend and should not be called");
+}
+
+}

--- a/hic/src/hic/hic_dummy/hic_dummy_runtime.h
+++ b/hic/src/hic/hic_dummy/hic_dummy_runtime.h
@@ -8,8 +8,7 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <stdexcept>
-#include <string>
+#include "hic/hic_dummy/dummyShouldNotBeCalled.h"
 
 #define DUMMY_SHOULD_NOT_BE_CALLED(SYMBOL) dummyShouldNotBeCalled( #SYMBOL )
 #define DUMMY_FUNCTION(SYMBOL) \
@@ -22,10 +21,6 @@
     constexpr int dummy##SYMBOL = 0;
 
 namespace {
-
-[[noreturn]] void dummyShouldNotBeCalled(const char* symbol) {
-    throw std::runtime_error(std::string(symbol)+" is using the dummy backend and should not be called");
-}
 
 using dummyError_t  = int;
 using dummyEvent_t  = void*;

--- a/hic/src/hic/hic_dummy/hicsparse_dummy.h
+++ b/hic/src/hic/hic_dummy/hicsparse_dummy.h
@@ -1,0 +1,78 @@
+/*
+ * (C) Copyright 2024- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "hic/hic_dummy/dummyShouldNotBeCalled.h"
+
+#define DUMMY_SHOULD_NOT_BE_CALLED(SYMBOL) dummyShouldNotBeCalled( #SYMBOL )
+#define DUMMY_FUNCTION(SYMBOL) \
+    template <typename... Args> inline \
+    dummysparseStatus_t dummy##SYMBOL(Args&&... args) { \
+        DUMMY_SHOULD_NOT_BE_CALLED( hic##SYMBOL ); \
+        return dummysparseStatus_t{0}; \
+    }
+#define DUMMY_VALUE(SYMBOL) \
+    constexpr int dummy##SYMBOL = 0;
+
+namespace {
+
+using dummysparseHandle_t = int;
+using dummysparseStatus_t = int;
+using dummysparseIndexType_t = int;
+using dummysparseOrder_t = int;
+using dummysparseConstDnVecDescr_t = void*;
+using dummysparseDnVecDescr_t = void*;
+using dummysparseConstDnMatDescr_t = void*;
+using dummysparseDnMatDescr_t = void*;
+using dummysparseConstSpVecDescr_t = void*;
+using dummysparseSpVecDescr_t = void*;
+using dummysparseConstSpMatDescr_t = void*;
+using dummysparseSpMatDescr_t = void*;
+using dummysparseSpMVAlg_t = int;
+using dummysparseSpMMAlg_t = int;
+
+DUMMY_FUNCTION(sparseGetErrorString)
+DUMMY_FUNCTION(sparseCreate)
+DUMMY_FUNCTION(sparseDestroy)
+DUMMY_FUNCTION(sparseCreateConstDnVec)
+DUMMY_FUNCTION(sparseCreateDnVec)
+DUMMY_FUNCTION(sparseDestroyDnVec)
+DUMMY_FUNCTION(sparseCreateConstDnMat)
+DUMMY_FUNCTION(sparseCreateDnMat)
+DUMMY_FUNCTION(sparseDestroyDnMat)
+DUMMY_FUNCTION(sparseCreateConstSpVec)
+DUMMY_FUNCTION(sparseCreateSpVec)
+DUMMY_FUNCTION(sparseDestroySpVec)
+DUMMY_FUNCTION(sparseCreateConstCsr)
+DUMMY_FUNCTION(sparseDestroySpMat)
+DUMMY_FUNCTION(sparseSpMV_bufferSize)
+DUMMY_FUNCTION(sparseSpMV_preprocess)
+DUMMY_FUNCTION(sparseSpMV)
+DUMMY_FUNCTION(sparseSpMM_bufferSize)
+DUMMY_FUNCTION(sparseSpMM_preprocess)
+DUMMY_FUNCTION(sparseSpMM)
+
+DUMMY_VALUE(SPARSE_STATUS_SUCCESS)
+DUMMY_VALUE(SPARSE_ORDER_COL)
+DUMMY_VALUE(SPARSE_ORDER_ROW)
+DUMMY_VALUE(SPARSE_INDEX_32I)
+DUMMY_VALUE(SPARSE_INDEX_64I)
+DUMMY_VALUE(SPARSE_INDEX_BASE_ZERO)
+DUMMY_VALUE(SPARSE_INDEX_BASE_ONE)
+DUMMY_VALUE(SPARSE_SPMV_ALG_DEFAULT)
+DUMMY_VALUE(SPARSE_SPMM_ALG_DEFAULT)
+DUMMY_VALUE(SPARSE_OPERATION_NON_TRANSPOSE)
+DUMMY_VALUE(SPARSE_OPERATION_TRANSPOSE)
+DUMMY_VALUE(SPARSE_OPERATION_CONJUGATE_TRANSPOSE)
+
+}
+
+#undef DUMMY_FUNCTION
+#undef DUMMY_VALUE
+#undef DUMMY_SHOULD_NOT_BE_CALLED

--- a/hic/src/hic/hic_library_types.h
+++ b/hic/src/hic/hic_library_types.h
@@ -1,0 +1,43 @@
+/*
+ * (C) Copyright 2024- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+#pragma once
+
+#include "hic/hic_namespace_macro.h"
+
+#if HIC_BACKEND_CUDA
+  #include <library_types.h>
+#elif HIC_BACKEND_HIP
+  #include <hip/library_types.h>
+#elif HIC_BACKEND_DUMMY
+  // intentionally blank
+#else
+  #error Unsupported hic backend. Please define HIC_BACKEND_CUDA or HIC_BACKEND_HIP or HIC_BACKEND_DUMMY
+#endif
+
+//------------------------------------------------
+HIC_NAMESPACE_BEGIN
+//------------------------------------------------
+
+#if HIC_BACKEND_CUDA
+  constexpr decltype(CUDA_R_32F) HIC_R_32F = CUDA_R_32F;
+  constexpr decltype(CUDA_R_64F) HIC_R_64F = CUDA_R_64F;
+#elif HIC_BACKEND_HIP
+  constexpr decltype(HIP_R_32F) HIC_R_32F = HIP_R_32F;
+  constexpr decltype(HIP_R_64F) HIC_R_64F = HIP_R_64F;
+#elif HIC_BACKEND_DUMMY
+  constexpr int HIC_R_32F = 0;
+  constexpr int HIC_R_64F = 0;
+#else
+  #error Unsupported hic backend. Please define HIC_BACKEND_CUDA or HIC_BACKEND_HIP or HIC_BACKEND_DUMMY
+#endif
+
+//------------------------------------------------
+HIC_NAMESPACE_END
+//------------------------------------------------

--- a/hic/src/hic/hic_namespace_macro.h
+++ b/hic/src/hic/hic_namespace_macro.h
@@ -1,0 +1,19 @@
+/*
+ * (C) Copyright 2024- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+#pragma once
+
+#if !defined(HIC_NAMESPACE)
+  #define HIC_NAMESPACE
+  #define HIC_NAMESPACE_BEGIN
+  #define HIC_NAMESPACE_END
+#else
+  #define HIC_NAMESPACE_BEGIN namespace HIC_NAMESPACE {
+  #define HIC_NAMESPACE_END }
+#endif

--- a/hic/src/hic/hic_runtime.h
+++ b/hic/src/hic/hic_runtime.h
@@ -9,14 +9,7 @@
  */
 #pragma once
 
-#if !defined(HIC_NAMESPACE)
-  #define HIC_NAMESPACE
-  #define HIC_NAMESPACE_BEGIN
-  #define HIC_NAMESPACE_END
-#else
-  #define HIC_NAMESPACE_BEGIN namespace HIC_NAMESPACE {
-  #define HIC_NAMESPACE_END }
-#endif
+#include "hic/hic_namespace_macro.h"
 
 #if HIC_BACKEND_CUDA
   #define HIC_BACKEND cuda

--- a/hic/src/hic/hicsparse.h
+++ b/hic/src/hic/hicsparse.h
@@ -1,0 +1,135 @@
+/*
+ * (C) Copyright 2024- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+#pragma once
+
+#include "hic/hic_namespace_macro.h"
+#include "hic/hic_library_types.h"
+
+#if HIC_BACKEND_CUDA
+  #define HICSPARSE_BACKEND_PREFIX cu
+  #define HICSPARSE_BACKEND_PREFIX_CAPS CU
+  #include <cusparse.h>
+#elif HIC_BACKEND_HIP
+  #define HICSPARSE_BACKEND_PREFIX hip
+  #define HICSPARSE_BACKEND_PREFIX_CAPS HIP
+  #include <hipsparse/hipsparse.h>
+#elif HIC_BACKEND_DUMMY
+  #define HICSPARSE_BACKEND_PREFIX dummy
+  #define HICSPARSE_BACKEND_PREFIX_CAPS dummy
+  #include "hic/hic_dummy/hicsparse_dummy.h"
+#else
+  #error Unsupported hic backend. Please define HIC_BACKEND_CUDA or HIC_BACKEND_HIP or HIC_BACKEND_DUMMY
+#endif
+
+#define HIC_PREFIX hic
+#define HIC_PREFIX_CAPS HIC
+#define HIC_CONCAT_(A, B) A ## B
+#define HIC_CONCAT(A, B) HIC_CONCAT_(A, B)
+#define HIC_SYMBOL(API) HIC_CONCAT(HIC_PREFIX, API)
+#define HIC_SYMBOL_CAPS(API) HIC_CONCAT(HIC_PREFIX_CAPS, API)
+
+#define HIC_TYPE(TYPE) \
+    using HIC_SYMBOL(TYPE) = HIC_CONCAT(HICSPARSE_BACKEND_PREFIX, TYPE);
+
+#define HIC_FUNCTION(FUNCTION) \
+    template <typename... Args> inline \
+    auto HIC_SYMBOL(FUNCTION)(Args&&... args) -> decltype(HIC_CONCAT(HICSPARSE_BACKEND_PREFIX, FUNCTION)(std::forward<Args>(args)...)) { \
+      return HIC_CONCAT(HICSPARSE_BACKEND_PREFIX, FUNCTION)(std::forward<Args>(args)...); \
+    }
+
+#define HIC_VALUE(VALUE) \
+    constexpr decltype(HIC_CONCAT(HICSPARSE_BACKEND_PREFIX_CAPS, VALUE)) HIC_SYMBOL_CAPS(VALUE) = HIC_CONCAT(HICSPARSE_BACKEND_PREFIX_CAPS, VALUE);
+
+//------------------------------------------------
+HIC_NAMESPACE_BEGIN
+//------------------------------------------------
+
+HIC_TYPE(sparseHandle_t)
+HIC_TYPE(sparseStatus_t)
+HIC_TYPE(sparseIndexType_t)
+HIC_TYPE(sparseOrder_t)
+HIC_TYPE(sparseConstDnVecDescr_t)
+HIC_TYPE(sparseDnVecDescr_t)
+HIC_TYPE(sparseConstDnMatDescr_t)
+HIC_TYPE(sparseDnMatDescr_t)
+HIC_TYPE(sparseConstSpVecDescr_t)
+HIC_TYPE(sparseSpVecDescr_t)
+HIC_TYPE(sparseConstSpMatDescr_t)
+HIC_TYPE(sparseSpMatDescr_t)
+HIC_TYPE(sparseSpMVAlg_t)
+HIC_TYPE(sparseSpMMAlg_t)
+
+HIC_FUNCTION(sparseGetErrorString)
+HIC_FUNCTION(sparseCreate)
+HIC_FUNCTION(sparseDestroy)
+HIC_FUNCTION(sparseCreateConstDnVec)
+HIC_FUNCTION(sparseCreateDnVec)
+HIC_FUNCTION(sparseDestroyDnVec)
+HIC_FUNCTION(sparseCreateConstDnMat)
+HIC_FUNCTION(sparseCreateDnMat)
+HIC_FUNCTION(sparseDestroyDnMat)
+HIC_FUNCTION(sparseCreateConstSpVec)
+HIC_FUNCTION(sparseCreateSpVec)
+HIC_FUNCTION(sparseDestroySpVec)
+HIC_FUNCTION(sparseCreateConstCsr)
+HIC_FUNCTION(sparseDestroySpMat)
+HIC_FUNCTION(sparseSpMV_bufferSize)
+HIC_FUNCTION(sparseSpMV_preprocess)
+HIC_FUNCTION(sparseSpMV)
+HIC_FUNCTION(sparseSpMM_bufferSize)
+HIC_FUNCTION(sparseSpMM_preprocess)
+HIC_FUNCTION(sparseSpMM)
+
+HIC_VALUE(SPARSE_STATUS_SUCCESS)
+HIC_VALUE(SPARSE_ORDER_COL)
+HIC_VALUE(SPARSE_ORDER_ROW)
+HIC_VALUE(SPARSE_INDEX_32I)
+HIC_VALUE(SPARSE_INDEX_64I)
+HIC_VALUE(SPARSE_INDEX_BASE_ZERO)
+HIC_VALUE(SPARSE_INDEX_BASE_ONE)
+HIC_VALUE(SPARSE_SPMV_ALG_DEFAULT)
+HIC_VALUE(SPARSE_SPMM_ALG_DEFAULT)
+HIC_VALUE(SPARSE_OPERATION_NON_TRANSPOSE)
+HIC_VALUE(SPARSE_OPERATION_TRANSPOSE)
+HIC_VALUE(SPARSE_OPERATION_CONJUGATE_TRANSPOSE)
+
+#if HIC_BACKEND_DUMMY
+#define HICSPARSE_CALL(val)
+#else
+#define HICSPARSE_CALL(val) hicsparse_assert((val), #val, __FILE__, __LINE__)
+#endif
+
+inline void hicsparse_assert(hicsparseStatus_t status, const char* const func, const char* const file, const int line) {
+    // Ignore errors when HIP/CUDA runtime is unloaded or deinitialized.
+    // This happens when calling HIP/CUDA after main has ended, e.g. in teardown of static variables calling `hicFree`
+    //   --> ignore hicErrorDeinitialized (a.k.a. cudaErrorCudartUnloading / hipErrorDeinitialized)
+    if (status != HICSPARSE_STATUS_SUCCESS) {
+        std::ostringstream msg;
+        msg << "HIC Runtime Error [code="<<status<<"] at: " << file << " + " << line << " : " << func << "\n";
+        msg << "  Reason: " << hicsparseGetErrorString(status);
+        throw std::runtime_error(msg.str());
+    }
+}
+  
+//------------------------------------------------
+HIC_NAMESPACE_END
+//------------------------------------------------
+
+#undef HIC_FUNCTION
+#undef HIC_TYPE
+#undef HIC_VALUE
+#undef HIC_PREFIX
+#undef HIC_PREFIX_CAPS
+#undef HIC_CONCAT
+#undef HIC_CONCAT_
+#undef HIC_SYMBOL
+#undef HIC_SYMBOL_CAPS
+#undef HICSPARSE_BACKEND_PREFIX
+#undef HICSPARSE_BACKEND_PREFIX_CAPS

--- a/hic/tests/CMakeLists.txt
+++ b/hic/tests/CMakeLists.txt
@@ -17,6 +17,11 @@ if( HAVE_HIP OR HAVE_CUDA )
     SOURCES   test_hic.cc
     LIBS      hic
   )
+
+  ecbuild_add_test( TARGET hic_test_hicsparse
+    SOURCES   test_hicsparse.cc
+    LIBS      hic
+  )
 endif()
 
 add_subdirectory(test_find_hic)

--- a/hic/tests/test_hicsparse.cc
+++ b/hic/tests/test_hicsparse.cc
@@ -1,0 +1,327 @@
+/*
+ * (C) Copyright 2024- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+#include <iostream>
+#include <functional>
+#include <vector>
+#include <utility>
+#include <cassert>
+
+#include "hic/hic.h"
+#include "hic/hicsparse.h"
+
+// -----------------------------------------------------------------------------
+
+int test_hicsparseCreate() {
+    std::cout << "--- " << __FUNCTION__ << std::endl;
+    hicsparseHandle_t handle;
+    HICSPARSE_CALL( hicsparseCreate(&handle) );
+    HICSPARSE_CALL( hicsparseDestroy(handle) );
+    std::cout << "--- " << __FUNCTION__ << " SUCCEEDED " << std::endl; 
+    return 0; // success 
+}
+
+// -----------------------------------------------------------------------------
+
+int test_hicsparseSpMV() {
+    std::cout << "--- " << __FUNCTION__ << std::endl;
+
+    // Create a sparse matrix
+    const int rows = 3;
+    const int cols = 3;
+    const int nnz = 3;
+    double values[nnz] = {1.0, 2.0, 3.0};
+    int row_offsets[rows+1] = {0, 1, 2, 3};
+    int column_indices[nnz] = {0, 1, 2};
+
+    // Put the sparse matrix onto the device
+    double* dvalues;
+    int* drow_offsets;
+    int* dcolumn_indices;
+    HIC_CALL( hicMalloc((void**)&dvalues, nnz * sizeof(double)) );
+    HIC_CALL( hicMalloc((void**)&drow_offsets, (rows+1) * sizeof(int)) );
+    HIC_CALL( hicMalloc((void**)&dcolumn_indices, nnz * sizeof(int)) );
+    HIC_CALL( hicMemcpy(dvalues, values, nnz * sizeof(double), hicMemcpyHostToDevice) );
+    HIC_CALL( hicMemcpy(drow_offsets, row_offsets, (rows+1) * sizeof(int), hicMemcpyHostToDevice) );
+    HIC_CALL( hicMemcpy(dcolumn_indices, column_indices, nnz * sizeof(int), hicMemcpyHostToDevice) );
+
+    // Create a dense vector
+    const int N = 3;
+    double x[N] = {1.0, 2.0, 3.0};
+    double y[N] = {0.0, 0.0, 0.0};
+
+    // Put the dense vector onto the device
+    double* dx;
+    double* dy;
+    HIC_CALL( hicMalloc((void**)&dx, N * sizeof(double)) );
+    HIC_CALL( hicMalloc((void**)&dy, N * sizeof(double)) );
+    HIC_CALL( hicMemcpy(dx, x, N * sizeof(double), hicMemcpyHostToDevice) );
+    HIC_CALL( hicMemcpy(dy, y, N * sizeof(double), hicMemcpyHostToDevice) );
+
+    // Create sparse library handle
+    hicsparseHandle_t handle;
+    HICSPARSE_CALL( hicsparseCreate(&handle) );
+
+    // Create a sparse matrix descriptor
+    hicsparseConstSpMatDescr_t matA;
+    HICSPARSE_CALL( hicsparseCreateConstCsr(
+        &matA,
+        rows, cols, nnz,
+        drow_offsets,
+        dcolumn_indices,
+        dvalues,
+        HICSPARSE_INDEX_32I,
+        HICSPARSE_INDEX_32I,
+        HICSPARSE_INDEX_BASE_ZERO,
+        HIC_R_64F) );
+    
+    // Create dense matrix descriptors
+    hicsparseConstDnVecDescr_t vecX;
+    HICSPARSE_CALL( hicsparseCreateConstDnVec(
+        &vecX,
+        N,
+        dx,
+        HIC_R_64F) );
+    
+    hicsparseDnVecDescr_t vecY;
+    HICSPARSE_CALL( hicsparseCreateDnVec(
+        &vecY,
+        N,
+        dy,
+        HIC_R_64F) );
+
+    // Set parameters
+    const double alpha = 1.0;
+    const double beta = 0.0;
+    
+    // Determine buffer size
+    size_t bufferSize = 0;
+    HICSPARSE_CALL( hicsparseSpMV_bufferSize(
+        handle,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        &alpha,
+        matA,
+        vecX,
+        &beta,
+        vecY,
+        HIC_R_64F,
+        HICSPARSE_SPMV_ALG_DEFAULT,
+        &bufferSize) );
+
+    // Allocate buffer
+    char* buffer;
+    HIC_CALL( hicMalloc(&buffer, bufferSize) );
+    
+    // Perform SpMV
+    HICSPARSE_CALL( hicsparseSpMV(
+        handle,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        &alpha,
+        matA,
+        vecX,
+        &beta,
+        vecY,
+        HIC_R_64F,
+        HICSPARSE_SPMV_ALG_DEFAULT,
+        buffer) );
+    
+    // Copy result back to host
+    HIC_CALL( hicMemcpy(y, dy, N * sizeof(double), hicMemcpyDeviceToHost) );
+
+    // Check result
+    const double expected_y[N] = {1.0, 4.0, 9.0};
+    for( int i = 0; i < N; ++i ) {
+        if( y[i] != expected_y[i] ) {
+            throw std::runtime_error("Error: y[" + std::to_string(i) + "] = " + std::to_string(y[i]) + " != " + std::to_string(expected_y[i]));
+        }
+    }
+
+    // Clean up
+    HIC_CALL( hicFree(dy) );
+    HIC_CALL( hicFree(dx) );
+    HIC_CALL( hicFree(dcolumn_indices) );
+    HIC_CALL( hicFree(drow_offsets) );
+    HIC_CALL( hicFree(dvalues) );
+    HICSPARSE_CALL( hicsparseDestroyDnVec(vecY) );
+    HICSPARSE_CALL( hicsparseDestroyDnVec(vecX) );
+    HICSPARSE_CALL( hicsparseDestroySpMat(matA) );
+    HICSPARSE_CALL( hicsparseDestroy(handle) );
+
+    std::cout << "--- " << __FUNCTION__ << " SUCCEEDED " << std::endl; 
+    return 0; // success 
+}
+
+// -----------------------------------------------------------------------------
+
+int test_hicsparseSpMM() {
+    std::cout << "--- " << __FUNCTION__ << std::endl;
+
+    // Create a sparse matrix
+    const int rows = 3;
+    const int cols = 3;
+    const int nnz = 3;
+    double values[nnz] = {1.0, 2.0, 3.0};
+    int row_offsets[rows + 1] = {0, 1, 2, 3};
+    int column_indices[nnz] = {0, 1, 2};
+
+    // Put the sparse matrix onto the device
+    double* dvalues;
+    int* drow_offsets;
+    int* dcolumn_indices;
+    HIC_CALL(hicMalloc((void**)&dvalues, nnz * sizeof(double)));
+    HIC_CALL(hicMalloc((void**)&drow_offsets, (rows + 1) * sizeof(int)));
+    HIC_CALL(hicMalloc((void**)&dcolumn_indices, nnz * sizeof(int)));
+    HIC_CALL(hicMemcpy(dvalues, values, nnz * sizeof(double), hicMemcpyHostToDevice));
+    HIC_CALL(hicMemcpy(drow_offsets, row_offsets, (rows + 1) * sizeof(int), hicMemcpyHostToDevice));
+    HIC_CALL(hicMemcpy(dcolumn_indices, column_indices, nnz * sizeof(int), hicMemcpyHostToDevice));
+
+    // Create dense matrices
+    const int B_rows = 3;
+    const int B_cols = 3;
+    double B[B_rows * B_cols] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
+    double C[rows * B_cols] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
+    // Put the dense matrices onto the device
+    double* dB;
+    double* dC;
+    HIC_CALL(hicMalloc((void**)&dB, B_rows * B_cols * sizeof(double)));
+    HIC_CALL(hicMalloc((void**)&dC, rows * B_cols * sizeof(double)));
+    HIC_CALL(hicMemcpy(dB, B, B_rows * B_cols * sizeof(double), hicMemcpyHostToDevice));
+    HIC_CALL(hicMemcpy(dC, C, rows * B_cols * sizeof(double), hicMemcpyHostToDevice));
+
+    // Create sparse library handle
+    hicsparseHandle_t handle;
+    HICSPARSE_CALL(hicsparseCreate(&handle));
+
+    // Create a sparse matrix descriptor
+    hicsparseConstSpMatDescr_t matA;
+    HICSPARSE_CALL(hicsparseCreateConstCsr(
+        &matA,
+        rows, cols, nnz,
+        drow_offsets,
+        dcolumn_indices,
+        dvalues,
+        HICSPARSE_INDEX_32I,
+        HICSPARSE_INDEX_32I,
+        HICSPARSE_INDEX_BASE_ZERO,
+        HIC_R_64F));
+
+    // Create dense matrix descriptors
+    hicsparseConstDnMatDescr_t matB;
+    HICSPARSE_CALL(hicsparseCreateConstDnMat(
+        &matB,
+        B_rows,
+        B_cols,
+        B_cols,
+        dB,
+        HIC_R_64F,
+        HICSPARSE_ORDER_ROW));
+
+    hicsparseDnMatDescr_t matC;
+    HICSPARSE_CALL(hicsparseCreateDnMat(
+        &matC,
+        rows,
+        B_cols,
+        B_cols,
+        dC,
+        HIC_R_64F,
+        HICSPARSE_ORDER_ROW));
+
+    // Set parameters
+    const double alpha = 1.0;
+    const double beta = 0.0;
+
+    // Determine buffer size
+    size_t bufferSize = 0;
+    HICSPARSE_CALL(hicsparseSpMM_bufferSize(
+        handle,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        &alpha,
+        matA,
+        matB,
+        &beta,
+        matC,
+        HIC_R_64F,
+        HICSPARSE_SPMM_ALG_DEFAULT,
+        &bufferSize));
+
+    // Allocate buffer
+    char* buffer;
+    HIC_CALL(hicMalloc(&buffer, bufferSize));
+
+    // Perform SpMM
+    HICSPARSE_CALL(hicsparseSpMM(
+        handle,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        &alpha,
+        matA,
+        matB,
+        &beta,
+        matC,
+        HIC_R_64F,
+        HICSPARSE_SPMM_ALG_DEFAULT,
+        buffer));
+
+    // Copy result back to host
+    HIC_CALL(hicMemcpy(C, dC, rows * B_cols * sizeof(double), hicMemcpyDeviceToHost));
+
+    // Check result
+    const double expected_C[rows * B_cols] = {1.0, 2.0, 3.0, 8.0, 10.0, 12.0, 21.0, 24.0, 27.0};
+    for (int i = 0; i < rows * B_cols; ++i) {
+        if (C[i] != expected_C[i]) {
+            throw std::runtime_error("Error: C[" + std::to_string(i) + "] = " + std::to_string(C[i]) + " != " + std::to_string(expected_C[i]));
+        }
+    }
+
+    // Clean up
+    HIC_CALL(hicFree(dC));
+    HIC_CALL(hicFree(dB));
+    HIC_CALL(hicFree(dcolumn_indices));
+    HIC_CALL(hicFree(drow_offsets));
+    HIC_CALL(hicFree(dvalues));
+    HICSPARSE_CALL(hicsparseDestroyDnMat(matC));
+    HICSPARSE_CALL(hicsparseDestroyDnMat(matB));
+    HICSPARSE_CALL(hicsparseDestroySpMat(matA));
+    HICSPARSE_CALL(hicsparseDestroy(handle));
+
+    std::cout << "--- " << __FUNCTION__ << " SUCCEEDED " << std::endl;
+    return 0; // success
+}
+
+// -----------------------------------------------------------------------------
+
+std::vector<std::function<int()>> tests = {
+    test_hicsparseCreate,
+    test_hicsparseSpMV,
+    test_hicsparseSpMM,
+};
+
+int main(int argc, char* argv[]) {
+    int num_devices = 0;
+    hicGetDeviceCount(&num_devices);
+    if( num_devices == 0 ) {
+        std::ignore = hicGetLastError();
+        std::cout << "TEST IGNORED, hicGetDeviceCount -> 0" << std::endl; 
+        return 0;
+    }
+    std::cout << "hicGetDeviceCount -> " << num_devices << std::endl; 
+    int error = 0;
+    for( auto& test: tests) {
+        try {
+            error += test();
+        }
+        catch( std::exception& e ) {
+            error += 1;
+            std::cout << e.what() << std::endl;
+        }
+    }
+    return error;
+}

--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -703,6 +703,8 @@ linalg/Indexing.h
 linalg/Introspection.h
 linalg/View.h
 linalg/sparse.h
+linalg/SparseMatrix.h
+linalg/SparseMatrix.cc
 linalg/sparse/Backend.h
 linalg/sparse/Backend.cc
 linalg/sparse/SparseMatrixMultiply.h

--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -713,6 +713,8 @@ linalg/sparse/SparseMatrixMultiply_EckitLinalg.h
 linalg/sparse/SparseMatrixMultiply_EckitLinalg.cc
 linalg/sparse/SparseMatrixMultiply_OpenMP.h
 linalg/sparse/SparseMatrixMultiply_OpenMP.cc
+linalg/sparse/SparseMatrixMultiply_HicSparse.h
+linalg/sparse/SparseMatrixMultiply_HicSparse.cc
 linalg/dense.h
 linalg/dense/Backend.h
 linalg/dense/Backend.cc

--- a/src/atlas/interpolation/Cache.h
+++ b/src/atlas/interpolation/Cache.h
@@ -17,8 +17,7 @@
 #include "eckit/filesystem/PathName.h"
 #include "eckit/io/Buffer.h"
 
-#include "eckit/linalg/SparseMatrix.h"
-
+#include "atlas/linalg/SparseMatrix.h"
 #include "atlas/runtime/Exception.h"
 #include "atlas/util/KDTree.h"
 
@@ -82,7 +81,7 @@ private:
 
 class MatrixCacheEntry : public InterpolationCacheEntry {
 public:
-    using Matrix = eckit::linalg::SparseMatrix;
+    using Matrix = atlas::linalg::SparseMatrix;
     ~MatrixCacheEntry() override;
     MatrixCacheEntry(const Matrix* matrix, const std::string& uid = ""): matrix_{matrix}, uid_(uid) {
         ATLAS_ASSERT(matrix_ != nullptr);

--- a/src/atlas/interpolation/method/Method.cc
+++ b/src/atlas/interpolation/method/Method.cc
@@ -95,14 +95,78 @@ void set_missing_values(Field& tgt, const std::vector<idx_t>& missing) {
     }
 }
 
+enum class MemorySpace { Host, Device };
+
+MemorySpace getSparseBackendMemorySpace(const sparse::Backend& backend) {
+    if (backend.type() == "eckit_linalg") {
+        return MemorySpace::Host;
+    } else if (backend.type() == "openmp") {
+        return MemorySpace::Host;
+    } else if (backend.type() == "hicsparse") {
+        return MemorySpace::Device;
+    } else {
+        ATLAS_NOTIMPLEMENTED;
+    }
+}
+
+void fetch(const atlas::Field& f, MemorySpace memorySpace) {
+    if(memorySpace == MemorySpace::Host) {
+        if (f.hostNeedsUpdate()) {
+            f.updateHost();
+        }
+    }
+    else {
+        ATLAS_ASSERT(memorySpace == MemorySpace::Device);
+        if (f.deviceNeedsUpdate()) {
+            f.updateDevice();
+        }
+    }
+}
+
+void setOtherMemorySpaceNeedsUpdate(const atlas::Field& f, MemorySpace memorySpace) {
+    if(memorySpace == MemorySpace::Host) {
+        f.setDeviceNeedsUpdate(true);
+    }
+    else {
+        ATLAS_ASSERT(memorySpace == MemorySpace::Device);
+        f.setHostNeedsUpdate(true);
+    }
+}
+
+template<typename Value, int Rank>
+atlas::array::ArrayView<Value, Rank> make_device_view_fetched(atlas::Field& f) {
+    fetch(f, MemorySpace::Device);
+    return atlas::array::make_device_view<Value, Rank>(f);
+}
+
+template<typename Value, int Rank>
+atlas::array::ArrayView<const Value, Rank> make_device_view_fetched(const atlas::Field& f) {
+    fetch(f, MemorySpace::Device);
+    return atlas::array::make_device_view<const Value, Rank>(f);
+}
+
+template<typename Value, int Rank>
+atlas::array::ArrayView<Value, Rank> make_host_view_fetched(atlas::Field& f) {
+    fetch(f, MemorySpace::Host);
+    return atlas::array::make_host_view<Value, Rank>(f);
+}
+
+template<typename Value, int Rank>
+atlas::array::ArrayView<const Value, Rank> make_host_view_fetched(const atlas::Field& f) {
+    fetch(f, MemorySpace::Host);
+    return atlas::array::make_host_view<const Value, Rank>(f);
+}
+
 }  // anonymous namespace
 
 
 template <typename Value>
 void Method::interpolate_field_rank1(const Field& src, Field& tgt, const Matrix& W) const {
     auto backend = std::is_same<Value, float>::value ? sparse::backend::openmp() : sparse::Backend{linalg_backend_};
-    auto src_v   = array::make_view<Value, 1>(src);
-    auto tgt_v   = array::make_view<Value, 1>(tgt);
+    const auto memorySpace = getSparseBackendMemorySpace(backend);
+
+    auto src_v = (memorySpace == MemorySpace::Host) ? make_host_view_fetched<Value, 1>(src) : make_device_view_fetched<Value, 1>(src);
+    auto tgt_v = (memorySpace == MemorySpace::Host) ? make_host_view_fetched<Value, 1>(tgt) : make_device_view_fetched<Value, 1>(tgt);
 
     if (nonLinear_(src)) {
         Matrix W_nl(W);  // copy (a big penalty -- copy-on-write would definitely be better)
@@ -112,17 +176,25 @@ void Method::interpolate_field_rank1(const Field& src, Field& tgt, const Matrix&
     else {
         sparse_matrix_multiply(W, src_v, tgt_v, backend);
     }
+
+    setOtherMemorySpaceNeedsUpdate(tgt, memorySpace);
 }
 
 
 template <typename Value>
 void Method::interpolate_field_rank2(const Field& src, Field& tgt, const Matrix& W) const {
-    sparse::Backend backend{linalg_backend_};
-    auto src_v = array::make_view<Value, 2>(src);
-    auto tgt_v = array::make_view<Value, 2>(tgt);
+    auto backend = std::is_same<Value, float>::value ? sparse::backend::openmp() : sparse::Backend{linalg_backend_};
+    
+    // To match previous logic of only using OpenMP (probably because eckit_linalg backend doesn't support "layout_left" indexing)
+    if (backend.type() == "eckit_linalg") {
+        backend = sparse::backend::openmp();
+    }
 
     if (nonLinear_(src)) {
         // We cannot apply the same matrix to full columns as e.g. missing values could be present in only certain parts.
+        
+        auto src_v = array::make_view<Value, 2>(src);
+        auto tgt_v = array::make_view<Value, 2>(tgt);
 
         // Allocate temporary rank-1 fields corresponding to one horizontal level
         auto src_slice = Field("s", array::make_datatype<Value>(), {src.shape(0)});
@@ -144,13 +216,19 @@ void Method::interpolate_field_rank2(const Field& src, Field& tgt, const Matrix&
             interpolate_field_rank1<Value>(src_slice, tgt_slice, W);
 
             // Copy rank-1 field to this level in the rank-2 field
+            fetch(tgt_slice, MemorySpace::Host);
             for (idx_t i = 0; i < tgt.shape(0); ++i) {
                 tgt_v(i, lev) = tgt_slice_v(i);
             }
+            setOtherMemorySpaceNeedsUpdate(tgt, MemorySpace::Host);
         }
     }
     else {
-        sparse_matrix_multiply(W, src_v, tgt_v, sparse::backend::openmp());
+        const auto memorySpace = getSparseBackendMemorySpace(backend);
+        auto src_dv = (memorySpace == MemorySpace::Host) ? make_host_view_fetched<Value, 2>(src) : make_device_view_fetched<Value, 2>(src);
+        auto tgt_dv = (memorySpace == MemorySpace::Host) ? make_host_view_fetched<Value, 2>(tgt) : make_device_view_fetched<Value, 2>(tgt);
+        sparse_matrix_multiply(W, src_dv, tgt_dv, backend);    
+        setOtherMemorySpaceNeedsUpdate(tgt, memorySpace);
     }
 }
 
@@ -158,75 +236,57 @@ void Method::interpolate_field_rank2(const Field& src, Field& tgt, const Matrix&
 template <typename Value>
 void Method::interpolate_field_rank3(const Field& src, Field& tgt, const Matrix& W) const {
     sparse::Backend backend{linalg_backend_};
-    auto src_v = array::make_view<Value, 3>(src);
-    auto tgt_v = array::make_view<Value, 3>(tgt);
+    auto src_v = make_host_view_fetched<Value, 3>(src);
+    auto tgt_v = make_host_view_fetched<Value, 3>(tgt);
     if (not W.empty() && nonLinear_(src)) {
         ATLAS_ASSERT(false, "nonLinear interpolation not supported for rank-3 fields.");
     }
     sparse_matrix_multiply(W, src_v, tgt_v, sparse::backend::openmp());
+    setOtherMemorySpaceNeedsUpdate(tgt, MemorySpace::Host);
 }
 
 template <typename Value>
 void Method::adjoint_interpolate_field_rank1(Field& src, const Field& tgt, const Matrix& W) const {
-    array::ArrayT<Value> tmp(src.shape());
+    auto backend = std::is_same<Value, float>::value ? sparse::backend::openmp() : sparse::Backend{linalg_backend_};
+    const auto memorySpace = getSparseBackendMemorySpace(backend);
 
-    auto tmp_v = array::make_view<Value, 1>(tmp);
-    auto src_v = array::make_view<Value, 1>(src);
-    auto tgt_v = array::make_view<Value, 1>(tgt);
+    auto src_v = (memorySpace == MemorySpace::Host) ? make_host_view_fetched<Value, 1>(src) : make_device_view_fetched<Value, 1>(src);
+    auto tgt_v = (memorySpace == MemorySpace::Host) ? make_host_view_fetched<Value, 1>(tgt) : make_device_view_fetched<Value, 1>(tgt);
 
-    tmp_v.assign(0.);
+    sparse_matrix_multiply_add(W, tgt_v, src_v, backend);
 
-    if (std::is_same<Value, float>::value) {
-        sparse_matrix_multiply(W, tgt_v, tmp_v, sparse::backend::openmp());
-    }
-    else {
-        sparse_matrix_multiply(W, tgt_v, tmp_v, sparse::Backend{linalg_backend_});
-    }
-
-
-    for (idx_t t = 0; t < tmp.shape(0); ++t) {
-        src_v(t) += tmp_v(t);
-    }
+    setOtherMemorySpaceNeedsUpdate(src, memorySpace);
 }
 
 template <typename Value>
 void Method::adjoint_interpolate_field_rank2(Field& src, const Field& tgt, const Matrix& W) const {
-    array::ArrayT<Value> tmp(src.shape());
-
-    auto tmp_v = array::make_view<Value, 2>(tmp);
-    auto src_v = array::make_view<Value, 2>(src);
-    auto tgt_v = array::make_view<Value, 2>(tgt);
-
-    tmp_v.assign(0.);
-
-    sparse_matrix_multiply(W, tgt_v, tmp_v, sparse::backend::openmp());
-
-    for (idx_t t = 0; t < tmp.shape(0); ++t) {
-        for (idx_t k = 0; k < tmp.shape(1); ++k) {
-            src_v(t, k) += tmp_v(t, k);
-        }
+    auto backend = std::is_same<Value, float>::value ? sparse::backend::openmp() : sparse::Backend{linalg_backend_};
+    
+    // To match previous logic of only using OpenMP (probably because eckit_linalg backend doesn't support "layout_left" indexing)
+    if (backend.type() == "eckit_linalg") {
+        backend = sparse::backend::openmp();
     }
+
+    const auto memorySpace = getSparseBackendMemorySpace(backend);
+
+    auto src_v = (memorySpace == MemorySpace::Host) ? make_host_view_fetched<Value, 2>(src) : make_device_view_fetched<Value, 2>(src);
+    auto tgt_v = (memorySpace == MemorySpace::Host) ? make_host_view_fetched<Value, 2>(tgt) : make_device_view_fetched<Value, 2>(tgt);
+
+    sparse_matrix_multiply_add(W, tgt_v, src_v, backend);
+
+    setOtherMemorySpaceNeedsUpdate(src, memorySpace);
 }
 
 template <typename Value>
 void Method::adjoint_interpolate_field_rank3(Field& src, const Field& tgt, const Matrix& W) const {
-    array::ArrayT<Value> tmp(src.shape());
+    sparse::Backend backend{linalg_backend_};
 
-    auto tmp_v = array::make_view<Value, 3>(tmp);
-    auto src_v = array::make_view<Value, 3>(src);
-    auto tgt_v = array::make_view<Value, 3>(tgt);
+    auto src_v = make_host_view_fetched<Value, 3>(src);
+    auto tgt_v = make_host_view_fetched<Value, 3>(tgt);
 
-    tmp_v.assign(0.);
+    sparse_matrix_multiply_add(W, tgt_v, src_v, sparse::backend::openmp());
 
-    sparse_matrix_multiply(W, tgt_v, tmp_v, sparse::backend::openmp());
-
-    for (idx_t t = 0; t < tmp.shape(0); ++t) {
-        for (idx_t j = 0; j < tmp.shape(1); ++j) {
-            for (idx_t k = 0; k < tmp.shape(2); ++k) {
-                src_v(t, j, k) += tmp_v(t, j, k);
-            }
-        }
-    }
+    setOtherMemorySpaceNeedsUpdate(src, MemorySpace::Host);
 }
 
 void Method::check_compatibility(const Field& src, const Field& tgt, const Matrix& W) const {
@@ -381,8 +441,13 @@ void Method::do_execute(const FieldSet& fieldsSource, FieldSet& fieldsTarget, Me
 void Method::do_execute(const Field& src, Field& tgt, Metadata&) const {
     ATLAS_TRACE("atlas::interpolation::method::Method::do_execute()");
 
+    // todo: dispatch to gpu-aware mpi if available
+    if (src.hostNeedsUpdate()) {
+        src.updateHost();
+    }
     haloExchange(src);
-
+    src.setDeviceNeedsUpdate(true);
+    
     if( matrix_ ) { // (matrix == nullptr) when a partition is empty
         if (src.datatype().kind() == array::DataType::KIND_REAL64) {
             interpolate_field<double>(src, tgt, *matrix_);
@@ -411,7 +476,13 @@ void Method::do_execute(const Field& src, Field& tgt, Metadata&) const {
     }
 
     // set missing values
-    set_missing_values(tgt, missing_);
+    if (not missing_.empty()) {
+        if (tgt.hostNeedsUpdate()) {
+            tgt.updateHost();
+        }
+        set_missing_values(tgt, missing_);
+        tgt.setDeviceNeedsUpdate(true);
+    }
 
     tgt.set_dirty();
 }
@@ -454,7 +525,12 @@ void Method::do_execute_adjoint(Field& src, const Field& tgt, Metadata&) const {
 
     src.set_dirty();
 
+    // todo: dispatch to gpu-aware mpi if available
+    if (src.hostNeedsUpdate()) {
+        src.updateHost();
+    }
     adjointHaloExchange(src);
+    src.setDeviceNeedsUpdate(true);
 }
 
 

--- a/src/atlas/interpolation/method/Method.h
+++ b/src/atlas/interpolation/method/Method.h
@@ -16,10 +16,10 @@
 
 #include "atlas/interpolation/Cache.h"
 #include "atlas/interpolation/NonLinear.h"
+#include "atlas/linalg/SparseMatrix.h"
 #include "atlas/util/Metadata.h"
 #include "atlas/util/Object.h"
 #include "eckit/config/Configuration.h"
-#include "eckit/linalg/SparseMatrix.h"
 
 namespace atlas {
 class Field;
@@ -87,7 +87,7 @@ protected:
 
     using Triplet  = eckit::linalg::Triplet;
     using Triplets = std::vector<Triplet>;
-    using Matrix   = eckit::linalg::SparseMatrix;
+    using Matrix   = atlas::linalg::SparseMatrix;
 
     static void normalise(Triplets& triplets);
 

--- a/src/atlas/interpolation/method/binning/Binning.cc
+++ b/src/atlas/interpolation/method/binning/Binning.cc
@@ -12,12 +12,12 @@
 #include "atlas/interpolation/Interpolation.h"
 #include "atlas/interpolation/method/binning/Binning.h"
 #include "atlas/interpolation/method/MethodFactory.h"
+#include "atlas/linalg/SparseMatrix.h"
 #include "atlas/mesh.h"
 #include "atlas/mesh/actions/GetCubedSphereNodalArea.h"
 #include "atlas/runtime/Trace.h"
 
 #include "eckit/config/LocalConfiguration.h"
-#include "eckit/linalg/SparseMatrix.h"
 #include "eckit/linalg/Triplet.h"
 #include "eckit/mpi/Comm.h"
 
@@ -58,7 +58,7 @@ void Binning::do_setup(const FunctionSpace& source,
 
   using Index = eckit::linalg::Index;
   using Triplet = eckit::linalg::Triplet;
-  using SMatrix = eckit::linalg::SparseMatrix;
+  using SMatrix = atlas::linalg::SparseMatrix;
 
   source_ = source;
   target_ = target;

--- a/src/atlas/interpolation/method/knn/GridBoxMaximum.cc
+++ b/src/atlas/interpolation/method/knn/GridBoxMaximum.cc
@@ -61,7 +61,7 @@ void GridBoxMaximum::do_execute(const Field& source, Field& target, Metadata&) c
 
     if (!matrixFree_) {
         const Matrix& m = matrix();
-        Matrix::const_iterator k(m);
+        Matrix::const_iterator k(m.host_matrix());
 
         for (decltype(m.rows()) i = 0, j = 0; i < m.rows(); ++i) {
             double max = std::numeric_limits<double>::lowest();

--- a/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
+++ b/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
@@ -1683,7 +1683,11 @@ void ConservativeSphericalPolygonInterpolation::do_execute(const Field& src_fiel
     stopwatch.stop();
     {
         ATLAS_TRACE("halo exchange target");
+        if (tgt_field.hostNeedsUpdate()) {
+            tgt_field.updateHost();
+        }
         tgt_field.haloExchange();
+        tgt_field.setDeviceNeedsUpdate(true);
     }
 
     auto remap_stat = remap_stat_;

--- a/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
+++ b/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
@@ -1248,7 +1248,7 @@ void ConservativeSphericalPolygonInterpolation::intersect_polygons(const CSPolyg
     }
 }
 
-eckit::linalg::SparseMatrix ConservativeSphericalPolygonInterpolation::compute_1st_order_matrix() {
+atlas::linalg::SparseMatrix ConservativeSphericalPolygonInterpolation::compute_1st_order_matrix() {
     ATLAS_TRACE("ConservativeMethod::setup: build cons-1 interpolant matrix");
     ATLAS_ASSERT(not matrix_free_);
     Triplets triplets;
@@ -1358,7 +1358,7 @@ eckit::linalg::SparseMatrix ConservativeSphericalPolygonInterpolation::compute_1
     return Matrix(n_tpoints_, n_spoints_, triplets);
 }
 
-eckit::linalg::SparseMatrix ConservativeSphericalPolygonInterpolation::compute_2nd_order_matrix() {
+atlas::linalg::SparseMatrix ConservativeSphericalPolygonInterpolation::compute_2nd_order_matrix() {
     ATLAS_TRACE("ConservativeMethod::setup: build cons-2 interpolant matrix");
     ATLAS_ASSERT(not matrix_free_);
     const auto& src_points_ = data_->src_points_;

--- a/src/atlas/interpolation/nonlinear/Missing.cc
+++ b/src/atlas/interpolation/nonlinear/Missing.cc
@@ -81,7 +81,7 @@ bool MissingIfAllMissing::executeT(NonLinear::Matrix& W, const Field& field) con
     bool zeros = false;
 
     Size i = 0;
-    Matrix::iterator it(W);
+    Matrix::iterator it = W.begin();
     for (Size r = 0; r < W.rows(); ++r) {
         const Matrix::iterator end = W.end(r);
 
@@ -161,7 +161,7 @@ bool MissingIfAnyMissing::executeT(NonLinear::Matrix& W, const Field& field) con
     bool zeros = false;
 
     Size i = 0;
-    Matrix::iterator it(W);
+    Matrix::iterator it = W.begin();
     for (Size r = 0; r < W.rows(); ++r) {
         const Matrix::iterator end = W.end(r);
 
@@ -228,7 +228,7 @@ bool MissingIfHeaviestMissing::executeT(NonLinear::Matrix& W, const Field& field
     bool zeros = false;
 
     Size i = 0;
-    Matrix::iterator it(W);
+    Matrix::iterator it = W.begin();
     for (Size r = 0; r < W.rows(); ++r) {
         const Matrix::iterator end = W.end(r);
 

--- a/src/atlas/interpolation/nonlinear/NonLinear.h
+++ b/src/atlas/interpolation/nonlinear/NonLinear.h
@@ -16,10 +16,10 @@
 #include <type_traits>
 
 #include "eckit/config/Parametrisation.h"
-#include "eckit/linalg/SparseMatrix.h"
 
 #include "atlas/array.h"
 #include "atlas/field/Field.h"
+#include "atlas/linalg/SparseMatrix.h"
 #include "atlas/runtime/Exception.h"
 #include "atlas/util/Factory.h"
 #include "atlas/util/ObjectHandle.h"
@@ -37,9 +37,9 @@ namespace nonlinear {
 class NonLinear : public util::Object {
 public:
     using Config = eckit::Parametrisation;
-    using Matrix = eckit::linalg::SparseMatrix;
-    using Scalar = eckit::linalg::Scalar;
-    using Size   = eckit::linalg::Size;
+    using Matrix = atlas::linalg::SparseMatrix;
+    using Scalar = atlas::linalg::SparseMatrix::Scalar;
+    using Size   = atlas::linalg::SparseMatrix::Size;
 
     /**
      * @brief ctor

--- a/src/atlas/linalg/SparseMatrix.cc
+++ b/src/atlas/linalg/SparseMatrix.cc
@@ -1,0 +1,86 @@
+
+#include "atlas/linalg/SparseMatrix.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+
+#include "atlas/array/helpers/ArrayCopier.h"
+
+#include "eckit/exception/Exceptions.h"
+
+namespace atlas {
+namespace linalg {
+
+//----------------------------------------------------------------------------------------------------------------------
+
+SparseMatrix::SparseMatrix() : host_matrix_() {}
+
+
+SparseMatrix::SparseMatrix(Size nrows, Size ncols, const std::vector<eckit::linalg::Triplet>& triplets) :
+    host_matrix_(nrows, ncols, triplets) {
+    resetDeviceStorage();
+}
+
+
+SparseMatrix::SparseMatrix(const SparseMatrix& other) : host_matrix_(other.host_matrix_) {
+    if (!other.empty()) {  // in case we copy an other that was constructed empty
+        resetDeviceStorage();
+    }
+}
+
+
+SparseMatrix& SparseMatrix::operator=(const SparseMatrix& other) {
+    SparseMatrix copy(other);
+    swap(copy);
+    return *this;
+}
+
+
+void SparseMatrix::swap(SparseMatrix& other) {
+    host_matrix_.swap(other.host_matrix_);
+    outer_.swap(other.outer_);
+    inner_.swap(other.inner_);
+    data_.swap(other.data_);
+}
+
+
+size_t SparseMatrix::footprint() const {
+    return host_matrix_.footprint() +
+           outer_->footprint() +
+           inner_->footprint() +
+           data_->footprint();
+}
+
+
+SparseMatrix& SparseMatrix::prune(Scalar val) {
+    host_matrix_.prune(val);
+    resetDeviceStorage();
+    setDeviceNeedsUpdate(true);
+    return *this;
+}
+
+
+SparseMatrix& SparseMatrix::transpose() {
+    host_matrix_.transpose();
+    resetDeviceStorage();
+    setDeviceNeedsUpdate(true);
+    return *this;
+}
+
+SparseMatrix& SparseMatrix::setIdentity(Size nrows, Size ncols) {
+    host_matrix_.setIdentity(nrows, ncols);
+    resetDeviceStorage();
+    setDeviceNeedsUpdate(true);
+    return *this;
+}
+
+void SparseMatrix::resetDeviceStorage() {
+    outer_.reset(atlas::array::Array::wrap<Index>(const_cast<Index*>(outer()), atlas::array::make_shape(rows() + 1)));
+    inner_.reset(atlas::array::Array::wrap<Index>(const_cast<Index*>(inner()), atlas::array::make_shape(nonZeros())));
+    data_.reset(atlas::array::Array::wrap<Scalar>(const_cast<Scalar*>(data()), atlas::array::make_shape(nonZeros())));
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+}  // namespace linalg
+}  // namespace atlas

--- a/src/atlas/linalg/SparseMatrix.h
+++ b/src/atlas/linalg/SparseMatrix.h
@@ -1,0 +1,174 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "atlas/array.h"
+
+#include "eckit/linalg/SparseMatrix.h"
+#include "eckit/linalg/Triplet.h"
+#include "eckit/linalg/types.h"
+
+namespace atlas {
+namespace linalg {
+
+//----------------------------------------------------------------------------------------------------------------------
+
+/// Sparse matrix in CRS (compressed row storage) format
+class SparseMatrix {
+public:
+    using Scalar = eckit::linalg::Scalar;
+    using Index = eckit::linalg::Index;
+    using Size = eckit::linalg::Size;
+    using iterator = eckit::linalg::SparseMatrix::iterator;
+    using const_iterator = eckit::linalg::SparseMatrix::const_iterator;
+
+public:
+    // -- Constructors
+
+    /// Default constructor, empty matrix
+    SparseMatrix();
+
+    /// Constructor from triplets
+    SparseMatrix(Size nrows, Size ncols, const std::vector<eckit::linalg::Triplet>&);
+
+    /// Copy constructor
+    SparseMatrix(const SparseMatrix&);
+
+    /// Assignment operator (allocates and copies data)
+    SparseMatrix& operator=(const SparseMatrix&);
+
+public:
+    void swap(SparseMatrix&);
+
+    /// @returns number of rows
+    Size rows() const { return host_matrix_.rows(); }
+
+    /// @returns number of columns
+    Size cols() const { return host_matrix_.cols(); }
+
+    /// @returns number of non-zeros
+    Size nonZeros() const { return host_matrix_.nonZeros(); }
+
+    /// @returns true if this matrix does not contain non-zero entries
+    bool empty() const { return host_matrix_.empty(); }
+
+    /// @returns footprint of the matrix in memory
+    size_t footprint() const;
+
+    /// Prune entries, in-place, with exactly the given value
+    SparseMatrix& prune(Scalar = 0);
+
+    /// Transpose matrix in-place
+    SparseMatrix& transpose();
+
+    SparseMatrix& setIdentity(Size nrows, Size ncols);
+
+public:
+    void updateDevice() const { 
+        outer_->updateDevice();
+        inner_->updateDevice();
+        data_->updateDevice();
+    }
+
+    void updateHost() const { 
+        outer_->updateHost();
+        inner_->updateHost();
+        data_->updateHost();
+    }
+
+    bool hostNeedsUpdate() const { 
+        return outer_->hostNeedsUpdate() ||
+               inner_->hostNeedsUpdate() ||
+               data_->hostNeedsUpdate();
+    }
+
+    bool deviceNeedsUpdate() const { 
+        return outer_->deviceNeedsUpdate() ||
+               inner_->deviceNeedsUpdate() ||
+               data_->deviceNeedsUpdate();
+    }
+
+    void setHostNeedsUpdate(bool v) const { 
+        outer_->setHostNeedsUpdate(v);
+        inner_->setHostNeedsUpdate(v);
+        data_->setHostNeedsUpdate(v);
+    }
+
+    void setDeviceNeedsUpdate(bool v) const {
+        outer_->setDeviceNeedsUpdate(v);
+        inner_->setDeviceNeedsUpdate(v);
+        data_->setDeviceNeedsUpdate(v);
+    }
+
+    bool deviceAllocated() const {
+        return outer_->deviceAllocated() &&
+               inner_->deviceAllocated() &&
+               data_->deviceAllocated();
+    }
+
+    void allocateDevice() {
+        outer_->allocateDevice();
+        inner_->allocateDevice();
+        data_->allocateDevice();
+    }
+
+    void deallocateDevice() { 
+        outer_->deallocateDevice();
+        inner_->deallocateDevice();
+        data_->deallocateDevice();
+    }
+
+    const eckit::linalg::SparseMatrix& host_matrix() const { return host_matrix_; }
+
+    // eckit::linalg::SparseMatrix& host_matrix() { return host_matrix_; }
+
+    const Scalar* data() const { return host_matrix_.data(); }
+    
+    const Index* outer() const { return host_matrix_.outer(); }
+
+    const Index* inner() const { return host_matrix_.inner(); }
+
+    const Scalar* host_data() const { return host_matrix_.data(); }
+    
+    const Index* host_outer() const { return host_matrix_.outer(); }
+
+    const Index* host_inner() const { return host_matrix_.inner(); }
+
+    const Scalar* device_data() const { return data_->device_data<Scalar>(); }
+    
+    const Index* device_outer() const { return outer_->device_data<Index>(); }
+
+    const Index* device_inner() const { return inner_->device_data<Index>(); }
+
+public:  // iterators
+    
+    /// const iterators to begin/end of row
+    const_iterator begin(Size row) const { return host_matrix_.begin(row); }
+    const_iterator end(Size row) const { return host_matrix_.end(row); }
+
+    /// const iterators to begin/end of matrix
+    const_iterator begin() const { return host_matrix_.begin(); }
+    const_iterator end() const { return host_matrix_.end(); }
+
+    /// iterators to begin/end of row
+    iterator begin(Size row) { return host_matrix_.begin(row); }
+    iterator end(Size row) { return host_matrix_.end(row); }
+
+    /// const iterators to begin/end of matrix
+    iterator begin() { return host_matrix_.begin(); }
+    iterator end() { return host_matrix_.end(); }
+
+private:
+    void resetDeviceStorage();
+
+private:
+    eckit::linalg::SparseMatrix host_matrix_;
+    std::unique_ptr<atlas::array::Array> outer_;
+    std::unique_ptr<atlas::array::Array> inner_;
+    std::unique_ptr<atlas::array::Array> data_;
+};
+
+//----------------------------------------------------------------------------------------------------------------------
+}  // namespace linalg
+}  // namespace atlas

--- a/src/atlas/linalg/sparse/Backend.h
+++ b/src/atlas/linalg/sparse/Backend.h
@@ -43,6 +43,11 @@ struct eckit_linalg : Backend {
     static std::string type() { return "eckit_linalg"; }
     eckit_linalg(): Backend(type()) {}
 };
+
+struct hicsparse : Backend {
+    static std::string type() { return "hicsparse"; }
+    hicsparse(): Backend(type()) {}
+};
 }  // namespace backend
 
 

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply.h
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply.h
@@ -38,6 +38,19 @@ template <typename Matrix, typename SourceView, typename TargetView>
 void sparse_matrix_multiply(const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing,
                             const Configuration& config);
 
+template <typename Matrix, typename SourceView, typename TargetView>
+void sparse_matrix_multiply_add(const Matrix& matrix, const SourceView& src, TargetView& tgt);
+
+template <typename Matrix, typename SourceView, typename TargetView>
+void sparse_matrix_multiply_add(const Matrix& matrix, const SourceView& src, TargetView& tgt, const Configuration& config);
+
+template <typename Matrix, typename SourceView, typename TargetView>
+void sparse_matrix_multiply_add(const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing);
+
+template <typename Matrix, typename SourceView, typename TargetView>
+void sparse_matrix_multiply_add(const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing,
+                            const Configuration& config);
+
 class SparseMatrixMultiply {
 public:
     SparseMatrixMultiply() = default;
@@ -46,12 +59,32 @@ public:
 
     template <typename Matrix, typename SourceView, typename TargetView>
     void operator()(const Matrix& matrix, const SourceView& src, TargetView& tgt) const {
-        sparse_matrix_multiply(matrix, src, tgt, backend());
+        multiply(matrix, src, tgt);
     }
 
     template <typename Matrix, typename SourceView, typename TargetView>
     void operator()(const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing indexing) const {
+        multiply(matrix, src, tgt, indexing);
+    }
+
+    template <typename Matrix, typename SourceView, typename TargetView>
+    void multiply(const Matrix& matrix, const SourceView& src, TargetView& tgt) const {
+        sparse_matrix_multiply(matrix, src, tgt, backend());
+    }
+
+    template <typename Matrix, typename SourceView, typename TargetView>
+    void multiply(const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing indexing) const {
         sparse_matrix_multiply(matrix, src, tgt, indexing, backend());
+    }
+
+    template <typename Matrix, typename SourceView, typename TargetView>
+    void multiply_add(const Matrix& matrix, const SourceView& src, TargetView& tgt) const {
+        sparse_matrix_multiply_add(matrix, src, tgt, backend());
+    }
+
+    template <typename Matrix, typename SourceView, typename TargetView>
+    void multiply_add(const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing indexing) const {
+        sparse_matrix_multiply_add(matrix, src, tgt, indexing, backend());
     }
 
     const sparse::Backend& backend() const { return backend_; }
@@ -65,8 +98,12 @@ namespace sparse {
 // Template class which needs (full or partial) specialization for concrete template parameters
 template <typename Backend, Indexing, int Rank, typename SourceValue, typename TargetValue>
 struct SparseMatrixMultiply {
-    static void apply(const SparseMatrix&, const View<SourceValue, Rank>&, View<TargetValue, Rank>&,
-                      const Configuration&) {
+    static void multiply(const SparseMatrix&, const View<SourceValue, Rank>&, View<TargetValue, Rank>&,
+                         const Configuration&) {
+        throw_NotImplemented("SparseMatrixMultiply needs a template specialization with the implementation", Here());
+    }
+    static void multiply_add(const SparseMatrix&, const View<SourceValue, Rank>&, View<TargetValue, Rank>&,
+                             const Configuration&) {
         throw_NotImplemented("SparseMatrixMultiply needs a template specialization with the implementation", Here());
     }
 };

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply.h
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply.h
@@ -78,3 +78,4 @@ struct SparseMatrixMultiply {
 #include "SparseMatrixMultiply.tcc"
 #include "SparseMatrixMultiply_EckitLinalg.h"
 #include "SparseMatrixMultiply_OpenMP.h"
+#include "SparseMatrixMultiply_HicSparse.h"

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply.h
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply.h
@@ -11,9 +11,9 @@
 #pragma once
 
 #include "eckit/config/Configuration.h"
-#include "eckit/linalg/SparseMatrix.h"
 
 #include "atlas/linalg/Indexing.h"
+#include "atlas/linalg/SparseMatrix.h"
 #include "atlas/linalg/View.h"
 #include "atlas/linalg/sparse/Backend.h"
 #include "atlas/runtime/Exception.h"
@@ -22,7 +22,7 @@
 namespace atlas {
 namespace linalg {
 
-using SparseMatrix  = eckit::linalg::SparseMatrix;
+using SparseMatrix  = atlas::linalg::SparseMatrix;
 using Configuration = eckit::Configuration;
 
 template <typename Matrix, typename SourceView, typename TargetView>

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply.tcc
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply.tcc
@@ -87,6 +87,9 @@ void sparse_matrix_multiply( const Matrix& matrix, const SourceView& src, Target
 #endif
         sparse::dispatch_sparse_matrix_multiply<sparse::backend::eckit_linalg>( matrix, src, tgt, indexing, util::Config("backend",type)  );
     }
+    else if ( type == sparse::backend::hicsparse::type() ) {
+        sparse::dispatch_sparse_matrix_multiply<sparse::backend::hicsparse>( matrix, src, tgt, indexing, config  );
+    }
     else {
         throw_NotImplemented( "sparse_matrix_multiply cannot be performed with unsupported backend [" + type + "]",
                               Here() );

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply.tcc
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply.tcc
@@ -33,14 +33,25 @@ namespace {
 template <typename Backend, Indexing indexing>
 struct SparseMatrixMultiplyHelper {
     template <typename SourceView, typename TargetView>
-    static void apply( const SparseMatrix& W, const SourceView& src, TargetView& tgt,
+    static void multiply( const SparseMatrix& W, const SourceView& src, TargetView& tgt,
                        const eckit::Configuration& config ) {
         using SourceValue = const typename std::remove_const<typename SourceView::value_type>::type;
         using TargetValue = typename std::remove_const<typename TargetView::value_type>::type;
         constexpr int src_rank = introspection::rank<SourceView>();
         constexpr int tgt_rank = introspection::rank<TargetView>();
         static_assert( src_rank == tgt_rank, "src and tgt need same rank" );
-        SparseMatrixMultiply<Backend, indexing, src_rank, SourceValue, TargetValue>::apply( W, src, tgt, config );
+        SparseMatrixMultiply<Backend, indexing, src_rank, SourceValue, TargetValue>::multiply( W, src, tgt, config );
+    }
+
+    template <typename SourceView, typename TargetView>
+    static void multiply_add( const SparseMatrix& W, const SourceView& src, TargetView& tgt,
+                       const eckit::Configuration& config ) {
+        using SourceValue = const typename std::remove_const<typename SourceView::value_type>::type;
+        using TargetValue = typename std::remove_const<typename TargetView::value_type>::type;
+        constexpr int src_rank = introspection::rank<SourceView>();
+        constexpr int tgt_rank = introspection::rank<TargetView>();
+        static_assert( src_rank == tgt_rank, "src and tgt need same rank" );
+        SparseMatrixMultiply<Backend, indexing, src_rank, SourceValue, TargetValue>::multiply_add( W, src, tgt, config );
     }
 };
 
@@ -53,14 +64,38 @@ void dispatch_sparse_matrix_multiply( const Matrix& matrix, const SourceView& sr
     if ( introspection::layout_right( src ) || introspection::layout_right( tgt ) ) {
         ATLAS_ASSERT( introspection::layout_right( src ) && introspection::layout_right( tgt ) );
         // Override layout with known layout given by introspection
-        SparseMatrixMultiplyHelper<Backend, linalg::Indexing::layout_right>::apply( matrix, src_v, tgt_v, config );
+        SparseMatrixMultiplyHelper<Backend, linalg::Indexing::layout_right>::multiply( matrix, src_v, tgt_v, config );
     }
     else {
         if( indexing == Indexing::layout_left ) {
-            SparseMatrixMultiplyHelper<Backend, Indexing::layout_left>::apply( matrix, src_v, tgt_v, config );
+            SparseMatrixMultiplyHelper<Backend, Indexing::layout_left>::multiply( matrix, src_v, tgt_v, config );
         }
         else if( indexing == Indexing::layout_right ) {
-            SparseMatrixMultiplyHelper<Backend, Indexing::layout_right>::apply( matrix, src_v, tgt_v, config );
+            SparseMatrixMultiplyHelper<Backend, Indexing::layout_right>::multiply( matrix, src_v, tgt_v, config );
+        }
+        else {
+            throw_NotImplemented( "indexing not implemented", Here() );
+        }
+    }
+}
+
+template <typename Backend, typename Matrix, typename SourceView, typename TargetView>
+void dispatch_sparse_matrix_multiply_add( const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing indexing,
+                                      const eckit::Configuration& config ) {
+    auto src_v = make_view( src );
+    auto tgt_v = make_view( tgt );
+
+    if ( introspection::layout_right( src ) || introspection::layout_right( tgt ) ) {
+        ATLAS_ASSERT( introspection::layout_right( src ) && introspection::layout_right( tgt ) );
+        // Override layout with known layout given by introspection
+        SparseMatrixMultiplyHelper<Backend, linalg::Indexing::layout_right>::multiply_add( matrix, src_v, tgt_v, config );
+    }
+    else {
+        if( indexing == Indexing::layout_left ) {
+            SparseMatrixMultiplyHelper<Backend, Indexing::layout_left>::multiply_add( matrix, src_v, tgt_v, config );
+        }
+        else if( indexing == Indexing::layout_right ) {
+            SparseMatrixMultiplyHelper<Backend, Indexing::layout_right>::multiply_add( matrix, src_v, tgt_v, config );
         }
         else {
             throw_NotImplemented( "indexing not implemented", Here() );
@@ -109,6 +144,47 @@ void sparse_matrix_multiply( const Matrix& matrix, const SourceView& src, Target
 template <typename Matrix, typename SourceView, typename TargetView>
 void sparse_matrix_multiply( const Matrix& matrix, const SourceView& src, TargetView& tgt ) {
     sparse_matrix_multiply( matrix, src, tgt, Indexing::layout_left );
+}
+
+template <typename Matrix, typename SourceView, typename TargetView>
+void sparse_matrix_multiply_add( const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing indexing,
+                             const eckit::Configuration& config ) {
+    std::string type = config.getString( "type", sparse::current_backend() );
+    if ( type == sparse::backend::openmp::type() ) {
+        sparse::dispatch_sparse_matrix_multiply_add<sparse::backend::openmp>( matrix, src, tgt, indexing, config );
+    }
+    else if ( type == sparse::backend::eckit_linalg::type() ) {
+        sparse::dispatch_sparse_matrix_multiply_add<sparse::backend::eckit_linalg>( matrix, src, tgt, indexing, config );
+    }
+#if ATLAS_ECKIT_HAVE_ECKIT_585
+    else if( eckit::linalg::LinearAlgebraSparse::hasBackend(type) ) {
+#else
+    else if( eckit::linalg::LinearAlgebra::hasBackend(type) ) {
+#endif
+        sparse::dispatch_sparse_matrix_multiply_add<sparse::backend::eckit_linalg>( matrix, src, tgt, indexing, util::Config("backend",type)  );
+    }
+    else if ( type == sparse::backend::hicsparse::type() ) {
+        sparse::dispatch_sparse_matrix_multiply_add<sparse::backend::hicsparse>( matrix, src, tgt, indexing, config  );
+    }
+    else {
+        throw_NotImplemented( "sparse_matrix_multiply_add cannot be performed with unsupported backend [" + type + "]",
+                              Here() );
+    }
+}
+
+template <typename Matrix, typename SourceView, typename TargetView>
+void sparse_matrix_multiply_add( const Matrix& matrix, const SourceView& src, TargetView& tgt, const eckit::Configuration& config ) {
+    sparse_matrix_multiply_add( matrix, src, tgt, Indexing::layout_left, config );
+}
+
+template <typename Matrix, typename SourceView, typename TargetView>
+void sparse_matrix_multiply_add( const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing indexing ) {
+    sparse_matrix_multiply_add( matrix, src, tgt, indexing, sparse::Backend() );
+}
+
+template <typename Matrix, typename SourceView, typename TargetView>
+void sparse_matrix_multiply_add( const Matrix& matrix, const SourceView& src, TargetView& tgt ) {
+    sparse_matrix_multiply_add( matrix, src, tgt, Indexing::layout_left );
 }
 
 }  // namespace linalg

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_EckitLinalg.cc
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_EckitLinalg.cc
@@ -70,7 +70,7 @@ void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 1, cons
     ATLAS_ASSERT(tgt.contiguous());
     eckit::linalg::Vector v_src(src.data(), src.size());
     eckit::linalg::Vector v_tgt(tgt.data(), tgt.size());
-    eckit_linalg_backend(config).spmv(W, v_src, v_tgt);
+    eckit_linalg_backend(config).spmv(W.host_matrix(), v_src, v_tgt);
 }
 
 void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 2, const double, double>::apply(
@@ -81,7 +81,7 @@ void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 2, cons
     ATLAS_ASSERT(tgt.shape(1) >= W.rows());
     eckit::linalg::Matrix m_src(src.data(), src.shape(1), src.shape(0));
     eckit::linalg::Matrix m_tgt(tgt.data(), tgt.shape(1), tgt.shape(0));
-    eckit_linalg_backend(config).spmm(W, m_src, m_tgt);
+    eckit_linalg_backend(config).spmm(W.host_matrix(), m_src, m_tgt);
 }
 
 void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_left, 1, const double, double>::apply(

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_EckitLinalg.h
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_EckitLinalg.h
@@ -28,20 +28,26 @@ namespace sparse {
 
 template <>
 struct SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 1, const double, double> {
-    static void apply(const SparseMatrix&, const View<const double, 1>& src, View<double, 1>& tgt,
+    static void multiply(const SparseMatrix&, const View<const double, 1>& src, View<double, 1>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix&, const View<const double, 1>& src, View<double, 1>& tgt,
                       const Configuration&);
 };
 
 template <>
 struct SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 2, const double, double> {
-    static void apply(const SparseMatrix&, const View<const double, 2>& src, View<double, 2>& tgt,
+    static void multiply(const SparseMatrix&, const View<const double, 2>& src, View<double, 2>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix&, const View<const double, 2>& src, View<double, 2>& tgt,
                       const Configuration&);
 };
 
 
 template <>
 struct SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_left, 1, const double, double> {
-    static void apply(const SparseMatrix&, const View<const double, 1>& src, View<double, 1>& tgt,
+    static void multiply(const SparseMatrix&, const View<const double, 1>& src, View<double, 1>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix&, const View<const double, 1>& src, View<double, 1>& tgt,
                       const Configuration&);
 };
 

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_HicSparse.cc
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_HicSparse.cc
@@ -265,27 +265,51 @@ void hsSpMM(const SparseMatrix& W, const View<SourceValue, 2>& src, TargetValue 
     HIC_CALL(hicDeviceSynchronize());
 }
 
-void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 1, double const, double>::apply(
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 1, double const, double>::multiply(
     const SparseMatrix& W, const View<double const, 1>& src, View<double, 1>& tgt, const Configuration&) {
     double beta = 0;
     hsSpMV(W, src, beta, tgt);
 }
 
-void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 2, double const, double>::apply(
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 1, double const, double>::multiply_add(
+    const SparseMatrix& W, const View<double const, 1>& src, View<double, 1>& tgt, const Configuration&) {
+    double beta = 1;
+    hsSpMV(W, src, beta, tgt);
+}
+
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 2, double const, double>::multiply(
     const SparseMatrix& W, const View<double const, 2>& src, View<double, 2>& tgt, const Configuration&) {
     double beta = 0;
     hsSpMM<Indexing::layout_left>(W, src, beta, tgt);
 }
 
-void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 1, double const, double>::apply(
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 2, double const, double>::multiply_add(
+    const SparseMatrix& W, const View<double const, 2>& src, View<double, 2>& tgt, const Configuration&) {
+    double beta = 1;
+    hsSpMM<Indexing::layout_left>(W, src, beta, tgt);
+}
+
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 1, double const, double>::multiply(
     const SparseMatrix& W, const View<double const, 1>& src, View<double, 1>& tgt, const Configuration&) {
     double beta = 0;
     hsSpMV(W, src, beta, tgt);
 }
 
-void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 2, double const, double>::apply(
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 1, double const, double>::multiply_add(
+    const SparseMatrix& W, const View<double const, 1>& src, View<double, 1>& tgt, const Configuration&) {
+    double beta = 1;
+    hsSpMV(W, src, beta, tgt);
+}
+
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 2, double const, double>::multiply(
     const SparseMatrix& W, const View<double const, 2>& src, View<double, 2>& tgt, const Configuration&) {
     double beta = 0;
+    hsSpMM<Indexing::layout_right>(W, src, beta, tgt);
+}
+
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 2, double const, double>::multiply_add(
+    const SparseMatrix& W, const View<double const, 2>& src, View<double, 2>& tgt, const Configuration&) {
+    double beta = 1;
     hsSpMM<Indexing::layout_right>(W, src, beta, tgt);
 }
 

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_HicSparse.cc
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_HicSparse.cc
@@ -1,0 +1,294 @@
+/*
+ * (C) Copyright 2024 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "atlas/linalg/sparse/SparseMatrixMultiply_HicSparse.h"
+
+#include "atlas/parallel/omp/omp.h"
+#include "atlas/runtime/Exception.h"
+
+#include "hic/hic.h"
+#include "hic/hic_library_types.h"
+#include "hic/hicsparse.h"
+
+namespace {
+
+template<typename T>
+constexpr hicsparseIndexType_t getHicsparseIndexType() {
+    using base_type = std::remove_const_t<T>;
+    if constexpr (std::is_same_v<base_type, int>) {
+        return HICSPARSE_INDEX_32I;
+    } else {
+        static_assert(std::is_same_v<base_type, long>, "Unsupported index type");
+        return HICSPARSE_INDEX_64I;
+    }
+}
+
+template<typename T>
+constexpr auto getHicsparseValueType() {
+    using base_type = std::remove_const_t<T>;
+    if constexpr (std::is_same_v<base_type, float>) {
+        return HIC_R_32F;
+    } else {
+        static_assert(std::is_same_v<base_type, double>, "Unsupported value type");\
+        return HIC_R_64F;
+    }
+}
+
+template<atlas::linalg::Indexing IndexLayout, typename T>
+hicsparseOrder_t getHicsparseOrder(const atlas::linalg::View<T, 2>& v) {
+    constexpr int row_idx = (IndexLayout == atlas::linalg::Indexing::layout_left) ? 0 : 1;
+    constexpr int col_idx = (IndexLayout == atlas::linalg::Indexing::layout_left) ? 1 : 0;
+
+    if (v.stride(row_idx) == 1) {
+        return HICSPARSE_ORDER_COL;
+    } else if (v.stride(col_idx) == 1) {
+        return HICSPARSE_ORDER_ROW;
+    } else {
+        atlas::throw_Exception("Unsupported dense matrix memory order", Here());
+        return HICSPARSE_ORDER_COL;
+    }
+}
+
+template<typename T>
+int64_t getLeadingDimension(const atlas::linalg::View<T, 2>& v) {
+    if (v.stride(0) == 1) {
+        return v.stride(1);
+    } else if (v.stride(1) == 1) {
+        return v.stride(0);
+    } else {
+        atlas::throw_Exception("Unsupported dense matrix memory order", Here());
+        return 0;
+    }
+}
+
+}
+
+namespace atlas {
+namespace linalg {
+namespace sparse {
+
+template <typename SourceValue, typename TargetValue>
+void hsSpMV(const SparseMatrix& W, const View<SourceValue, 1>& src, TargetValue beta, View<TargetValue, 1>& tgt) {
+    // Assume that src and tgt are device views
+
+    ATLAS_ASSERT(src.shape(0) >= W.cols());
+    ATLAS_ASSERT(tgt.shape(0) >= W.rows());
+
+    // Check if W is on the device and if not, copy it to the device
+    if (W.deviceNeedsUpdate()) {
+        W.updateDevice();
+    }
+
+    // Create sparse library handle
+    // todo: use singleton class for storing hicSparse library handle.
+    hicsparseHandle_t handle;
+    HICSPARSE_CALL(hicsparseCreate(&handle));
+
+    // Create a sparse matrix descriptor
+    hicsparseConstSpMatDescr_t matA;
+    HICSPARSE_CALL(hicsparseCreateConstCsr(
+        &matA,
+        W.rows(), W.cols(), W.nonZeros(),
+        W.device_outer(),    // row_offsets
+        W.device_inner(),    // column_indices
+        W.device_data(),     // values
+        getHicsparseIndexType<SparseMatrix::Index>(),
+        getHicsparseIndexType<SparseMatrix::Index>(),  
+        HICSPARSE_INDEX_BASE_ZERO,
+        getHicsparseValueType<SparseMatrix::Scalar>()));
+
+    // Create dense matrix descriptors
+    hicsparseConstDnVecDescr_t vecX;
+    HICSPARSE_CALL(hicsparseCreateConstDnVec(
+        &vecX,
+        static_cast<int64_t>(W.cols()), 
+        src.data(),
+        getHicsparseValueType<typename View<SourceValue, 1>::value_type>()));
+
+    hicsparseDnVecDescr_t vecY;
+    HICSPARSE_CALL(hicsparseCreateDnVec(
+        &vecY,
+        W.rows(),
+        tgt.data(),
+        getHicsparseValueType<typename View<TargetValue, 1>::value_type>()));
+
+    using ComputeType = typename View<TargetValue, 1>::value_type;
+    constexpr auto compute_type = getHicsparseValueType<ComputeType>();
+
+    ComputeType alpha = 1;
+
+    // Determine buffer size
+    size_t bufferSize = 0;
+    HICSPARSE_CALL(hicsparseSpMV_bufferSize(
+        handle,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        &alpha,
+        matA,
+        vecX,
+        &beta,
+        vecY,
+        compute_type,
+        HICSPARSE_SPMV_ALG_DEFAULT,
+        &bufferSize));
+
+    // Allocate buffer
+    char* buffer;
+    HIC_CALL(hicMalloc(&buffer, bufferSize));
+    
+    // Perform SpMV
+    HICSPARSE_CALL(hicsparseSpMV(
+        handle,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        &alpha,
+        matA,
+        vecX,
+        &beta,
+        vecY,
+        compute_type,
+        HICSPARSE_SPMV_ALG_DEFAULT,
+        buffer));
+
+    HIC_CALL(hicFree(buffer));
+    HICSPARSE_CALL(hicsparseDestroyDnVec(vecX));
+    HICSPARSE_CALL(hicsparseDestroyDnVec(vecY));
+    HICSPARSE_CALL(hicsparseDestroySpMat(matA));
+    HICSPARSE_CALL(hicsparseDestroy(handle));
+
+    HIC_CALL(hicDeviceSynchronize());
+}
+
+
+template <Indexing IndexLayout, typename SourceValue, typename TargetValue>
+void hsSpMM(const SparseMatrix& W, const View<SourceValue, 2>& src, TargetValue beta, View<TargetValue, 2>& tgt) {
+    // Assume that src and tgt are device views
+
+    constexpr int row_idx = (IndexLayout == Indexing::layout_left) ? 0 : 1;
+    constexpr int col_idx = (IndexLayout == Indexing::layout_left) ? 1 : 0;
+
+    ATLAS_ASSERT(src.shape(row_idx) >= W.cols());
+    ATLAS_ASSERT(tgt.shape(row_idx) >= W.rows());
+    ATLAS_ASSERT(src.shape(col_idx) == tgt.shape(col_idx));
+
+    // Check if W is on the device and if not, copy it to the device
+    if (W.deviceNeedsUpdate()) {
+        W.updateDevice();
+    }
+
+    // Create sparse library handle
+    // todo: use singleton class for storing hicSparse library handle.
+    hicsparseHandle_t handle;
+    HICSPARSE_CALL(hicsparseCreate(&handle));
+
+    // Create a sparse matrix descriptor
+    hicsparseConstSpMatDescr_t matA;
+    HICSPARSE_CALL(hicsparseCreateConstCsr(
+        &matA,
+        W.rows(), W.cols(), W.nonZeros(),
+        W.device_outer(),    // row_offsets
+        W.device_inner(),    // column_indices
+        W.device_data(),     // values
+        getHicsparseIndexType<SparseMatrix::Index>(),
+        getHicsparseIndexType<SparseMatrix::Index>(),
+        HICSPARSE_INDEX_BASE_ZERO,
+        getHicsparseValueType<SparseMatrix::Scalar>()));
+
+    // Create dense matrix descriptors
+    hicsparseConstDnMatDescr_t matB;
+    HICSPARSE_CALL(hicsparseCreateConstDnMat(
+        &matB,
+        W.cols(), src.shape(col_idx),
+        getLeadingDimension(src),
+        src.data(),
+        getHicsparseValueType<typename View<SourceValue, 2>::value_type>(),
+        getHicsparseOrder<IndexLayout>(src)));
+
+    hicsparseDnMatDescr_t matC;
+    HICSPARSE_CALL(hicsparseCreateDnMat(
+        &matC,
+        W.rows(), tgt.shape(col_idx),
+        getLeadingDimension(tgt),
+        tgt.data(),
+        getHicsparseValueType<typename View<TargetValue, 2>::value_type>(),
+        getHicsparseOrder<IndexLayout>(tgt)));
+
+    using ComputeType = typename View<TargetValue, 2>::value_type;
+    constexpr auto compute_type = getHicsparseValueType<ComputeType>();
+
+    ComputeType alpha = 1;
+
+    // Determine buffer size
+    size_t bufferSize = 0;
+    HICSPARSE_CALL(hicsparseSpMM_bufferSize(
+        handle,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        &alpha,
+        matA,
+        matB,
+        &beta,
+        matC,
+        compute_type,
+        HICSPARSE_SPMM_ALG_DEFAULT,
+        &bufferSize));
+
+    // Allocate buffer
+    char* buffer;
+    HIC_CALL(hicMalloc(&buffer, bufferSize));
+
+    // Perform SpMM
+    HICSPARSE_CALL(hicsparseSpMM(
+        handle,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        &alpha,
+        matA,
+        matB,
+        &beta,
+        matC,
+        compute_type,
+        HICSPARSE_SPMM_ALG_DEFAULT,
+        buffer));
+
+    HIC_CALL(hicFree(buffer));
+    HICSPARSE_CALL(hicsparseDestroyDnMat(matC));
+    HICSPARSE_CALL(hicsparseDestroyDnMat(matB));
+    HICSPARSE_CALL(hicsparseDestroySpMat(matA));
+    HICSPARSE_CALL(hicsparseDestroy(handle));
+
+    HIC_CALL(hicDeviceSynchronize());
+}
+
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 1, double const, double>::apply(
+    const SparseMatrix& W, const View<double const, 1>& src, View<double, 1>& tgt, const Configuration&) {
+    double beta = 0;
+    hsSpMV(W, src, beta, tgt);
+}
+
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 2, double const, double>::apply(
+    const SparseMatrix& W, const View<double const, 2>& src, View<double, 2>& tgt, const Configuration&) {
+    double beta = 0;
+    hsSpMM<Indexing::layout_left>(W, src, beta, tgt);
+}
+
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 1, double const, double>::apply(
+    const SparseMatrix& W, const View<double const, 1>& src, View<double, 1>& tgt, const Configuration&) {
+    double beta = 0;
+    hsSpMV(W, src, beta, tgt);
+}
+
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 2, double const, double>::apply(
+    const SparseMatrix& W, const View<double const, 2>& src, View<double, 2>& tgt, const Configuration&) {
+    double beta = 0;
+    hsSpMM<Indexing::layout_right>(W, src, beta, tgt);
+}
+
+}  // namespace sparse
+}  // namespace linalg
+}  // namespace atlas

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_HicSparse.h
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_HicSparse.h
@@ -18,25 +18,33 @@ namespace sparse {
 
 template <>
 struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 1, const double, double> {
-    static void apply(const SparseMatrix& W, const View<const double, 1>& src, View<double, 1>& tgt,
+    static void multiply(const SparseMatrix& W, const View<const double, 1>& src, View<double, 1>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<const double, 1>& src, View<double, 1>& tgt,
                       const Configuration&);
 };
 
 template <>
 struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 2, const double, double> {
-    static void apply(const SparseMatrix& W, const View<const double, 2>& src, View<double, 2>& tgt,
+    static void multiply(const SparseMatrix& W, const View<const double, 2>& src, View<double, 2>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<const double, 2>& src, View<double, 2>& tgt,
                       const Configuration&);
 };
 
 template <>
 struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 1, const double, double> {
-    static void apply(const SparseMatrix& W, const View<const double, 1>& src, View<double, 1>& tgt,
+    static void multiply(const SparseMatrix& W, const View<const double, 1>& src, View<double, 1>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<const double, 1>& src, View<double, 1>& tgt,
                       const Configuration&);
 };
 
 template <>
 struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 2, const double, double> {
-    static void apply(const SparseMatrix& W, const View<const double, 2>& src, View<double, 2>& tgt,
+    static void multiply(const SparseMatrix& W, const View<const double, 2>& src, View<double, 2>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<const double, 2>& src, View<double, 2>& tgt,
                       const Configuration&);
 };
 

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_HicSparse.h
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_HicSparse.h
@@ -1,0 +1,45 @@
+/*
+ * (C) Copyright 2024 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#pragma once
+
+#include "atlas/linalg/sparse/SparseMatrixMultiply.h"
+
+namespace atlas {
+namespace linalg {
+namespace sparse {
+
+template <>
+struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 1, const double, double> {
+    static void apply(const SparseMatrix& W, const View<const double, 1>& src, View<double, 1>& tgt,
+                      const Configuration&);
+};
+
+template <>
+struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 2, const double, double> {
+    static void apply(const SparseMatrix& W, const View<const double, 2>& src, View<double, 2>& tgt,
+                      const Configuration&);
+};
+
+template <>
+struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 1, const double, double> {
+    static void apply(const SparseMatrix& W, const View<const double, 1>& src, View<double, 1>& tgt,
+                      const Configuration&);
+};
+
+template <>
+struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 2, const double, double> {
+    static void apply(const SparseMatrix& W, const View<const double, 2>& src, View<double, 2>& tgt,
+                      const Configuration&);
+};
+
+}  // namespace sparse
+}  // namespace linalg
+}  // namespace atlas

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_OpenMP.cc
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_OpenMP.cc
@@ -17,9 +17,8 @@ namespace atlas {
 namespace linalg {
 namespace sparse {
 
-template <typename SourceValue, typename TargetValue>
-void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue, TargetValue>::apply(
-    const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt, const Configuration&) {
+template <bool SetZero, typename SourceValue, typename TargetValue>
+void spmv_layout_left(const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt) {
     using Value       = TargetValue;
     const auto outer  = W.outer();
     const auto index  = W.inner();
@@ -28,9 +27,11 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue
 
     ATLAS_ASSERT(src.shape(0) >= W.cols());
     ATLAS_ASSERT(tgt.shape(0) >= W.rows());
-
+    
     atlas_omp_parallel_for(idx_t r = 0; r < rows; ++r) {
-        tgt[r] = 0.;
+        if constexpr (SetZero) {
+            tgt[r] = 0.;
+        }
         for (idx_t c = outer[r]; c < outer[r + 1]; ++c) {
             idx_t n = index[c];
             Value w = static_cast<Value>(weight[c]);
@@ -39,10 +40,20 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue
     }
 }
 
+template <typename SourceValue, typename TargetValue>
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue, TargetValue>::multiply(
+    const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt, const Configuration&) {
+    spmv_layout_left<true>(W, src, tgt);
+}
 
 template <typename SourceValue, typename TargetValue>
-void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 2, SourceValue, TargetValue>::apply(
-    const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt, const Configuration&) {
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue, TargetValue>::multiply_add(
+    const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt, const Configuration&) {
+    spmv_layout_left<false>(W, src, tgt);
+}
+
+template <bool SetZero, typename SourceValue, typename TargetValue>
+void spmm_layout_left(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt) {
     using Value       = TargetValue;
     const auto outer  = W.outer();
     const auto index  = W.inner();
@@ -54,8 +65,10 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 2, SourceValue
     ATLAS_ASSERT(tgt.shape(0) >= W.rows());
 
     atlas_omp_parallel_for(idx_t r = 0; r < rows; ++r) {
-        for (idx_t k = 0; k < Nk; ++k) {
-            tgt(r, k) = 0.;
+        if constexpr (SetZero) {
+            for (idx_t k = 0; k < Nk; ++k) {
+                tgt(r, k) = 0.;
+            }
         }
         for (idx_t c = outer[r]; c < outer[r + 1]; ++c) {
             idx_t n = index[c];
@@ -68,14 +81,24 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 2, SourceValue
 }
 
 template <typename SourceValue, typename TargetValue>
-void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 3, SourceValue, TargetValue>::apply(
-    const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt, const Configuration& config) {
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 2, SourceValue, TargetValue>::multiply(
+    const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt, const Configuration&) {
+    spmm_layout_left<true>(W, src, tgt);
+}
+
+template <typename SourceValue, typename TargetValue>
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 2, SourceValue, TargetValue>::multiply_add(
+    const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt, const Configuration&) {
+    spmm_layout_left<false>(W, src, tgt);
+}
+
+template <bool SetZero, typename SourceValue, typename TargetValue>
+void spmt_layout_left(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt) {
     if (src.contiguous() && tgt.contiguous()) {
         // We can take a more optimized route by reducing rank
         auto src_v = View<SourceValue, 2>(src.data(), array::make_shape(src.shape(0), src.stride(0)));
         auto tgt_v = View<TargetValue, 2>(tgt.data(), array::make_shape(tgt.shape(0), tgt.stride(0)));
-        SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 2, SourceValue, TargetValue>::apply(W, src_v,
-                                                                                                         tgt_v, config);
+        spmm_layout_left<SetZero>(W, src_v, tgt_v);
         return;
     }
     using Value       = TargetValue;
@@ -87,9 +110,11 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 3, SourceValue
     const idx_t Nl    = src.shape(2);
 
     atlas_omp_parallel_for(idx_t r = 0; r < rows; ++r) {
-        for (idx_t k = 0; k < Nk; ++k) {
-            for (idx_t l = 0; l < Nl; ++l) {
-                tgt(r, k, l) = 0.;
+        if constexpr (SetZero) {
+            for (idx_t k = 0; k < Nk; ++k) {
+                for (idx_t l = 0; l < Nl; ++l) {
+                    tgt(r, k, l) = 0.;
+                }
             }
         }
         for (idx_t c = outer[r]; c < outer[r + 1]; ++c) {
@@ -105,15 +130,31 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 3, SourceValue
 }
 
 template <typename SourceValue, typename TargetValue>
-void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 1, SourceValue, TargetValue>::apply(
-    const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt, const Configuration& config) {
-    return SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue, TargetValue>::apply(W, src, tgt,
-                                                                                                            config);
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 3, SourceValue, TargetValue>::multiply(
+    const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt, const Configuration& config) {
+    spmt_layout_left<true>(W, src, tgt);
 }
 
 template <typename SourceValue, typename TargetValue>
-void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 2, SourceValue, TargetValue>::apply(
-    const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt, const Configuration&) {
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 3, SourceValue, TargetValue>::multiply_add(
+    const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt, const Configuration& config) {
+    spmt_layout_left<false>(W, src, tgt);
+}
+
+template <typename SourceValue, typename TargetValue>
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 1, SourceValue, TargetValue>::multiply(
+    const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt, const Configuration& config) {
+    return SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue, TargetValue>::multiply(W, src, tgt, config);
+}
+
+template <typename SourceValue, typename TargetValue>
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 1, SourceValue, TargetValue>::multiply_add(
+    const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt, const Configuration& config) {
+    return SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue, TargetValue>::multiply_add(W, src, tgt, config);
+}
+
+template <bool SetZero, typename SourceValue, typename TargetValue>
+void spmm_layout_right(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt) {
     using Value       = TargetValue;
     const auto outer  = W.outer();
     const auto index  = W.inner();
@@ -125,8 +166,10 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 2, SourceValu
     ATLAS_ASSERT(tgt.shape(1) >= W.rows());
 
     atlas_omp_parallel_for(idx_t r = 0; r < rows; ++r) {
-        for (idx_t k = 0; k < Nk; ++k) {
-            tgt(k, r) = 0.;
+        if constexpr (SetZero) {
+            for (idx_t k = 0; k < Nk; ++k) {
+                tgt(k, r) = 0.;
+            }
         }
         for (idx_t c = outer[r]; c < outer[r + 1]; ++c) {
             idx_t n = index[c];
@@ -139,14 +182,24 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 2, SourceValu
 }
 
 template <typename SourceValue, typename TargetValue>
-void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 3, SourceValue, TargetValue>::apply(
-    const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt, const Configuration& config) {
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 2, SourceValue, TargetValue>::multiply(
+    const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt, const Configuration&) {
+    spmm_layout_right<true>(W, src, tgt);
+}
+
+template <typename SourceValue, typename TargetValue>
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 2, SourceValue, TargetValue>::multiply_add(
+    const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt, const Configuration&) {
+    spmm_layout_right<false>(W, src, tgt);
+}
+
+template <bool SetZero, typename SourceValue, typename TargetValue>
+void spmt_layout_right(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt) {
     if (src.contiguous() && tgt.contiguous()) {
         // We can take a more optimized route by reducing rank
         auto src_v = View<SourceValue, 2>(src.data(), array::make_shape(src.shape(0), src.stride(0)));
         auto tgt_v = View<TargetValue, 2>(tgt.data(), array::make_shape(tgt.shape(0), tgt.stride(0)));
-        SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 2, SourceValue, TargetValue>::apply(
-            W, src_v, tgt_v, config);
+        spmm_layout_right<SetZero>(W, src_v, tgt_v);
         return;
     }
     using Value       = TargetValue;
@@ -158,9 +211,11 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 3, SourceValu
     const idx_t Nl    = src.shape(0);
 
     atlas_omp_parallel_for(idx_t r = 0; r < rows; ++r) {
-        for (idx_t k = 0; k < Nk; ++k) {
-            for (idx_t l = 0; l < Nl; ++l) {
-                tgt(l, k, r) = 0.;
+        if constexpr (SetZero){
+            for (idx_t k = 0; k < Nk; ++k) {
+                for (idx_t l = 0; l < Nl; ++l) {
+                    tgt(l, k, r) = 0.;
+                }
             }
         }
         for (idx_t c = outer[r]; c < outer[r + 1]; ++c) {
@@ -173,6 +228,18 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 3, SourceValu
             }
         }
     }
+}
+
+template <typename SourceValue, typename TargetValue>
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 3, SourceValue, TargetValue>::multiply(
+    const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt, const Configuration& config) {
+    spmt_layout_right<true>(W, src, tgt);
+}
+
+template <typename SourceValue, typename TargetValue>
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 3, SourceValue, TargetValue>::multiply_add(
+    const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt, const Configuration& config) {
+    spmt_layout_right<false>(W, src, tgt);
 }
 
 #define EXPLICIT_TEMPLATE_INSTANTIATION(TYPE)                                                           \

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_OpenMP.h
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_OpenMP.h
@@ -19,37 +19,49 @@ namespace sparse {
 
 template <typename SourceValue, typename TargetValue>
 struct SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue, TargetValue> {
-    static void apply(const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt,
+    static void multiply(const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt,
                       const Configuration&);
 };
 
 template <typename SourceValue, typename TargetValue>
 struct SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 2, SourceValue, TargetValue> {
-    static void apply(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt,
+    static void multiply(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt,
                       const Configuration&);
 };
 
 template <typename SourceValue, typename TargetValue>
 struct SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 3, SourceValue, TargetValue> {
-    static void apply(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt,
+    static void multiply(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt,
                       const Configuration&);
 };
 
 template <typename SourceValue, typename TargetValue>
 struct SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 1, SourceValue, TargetValue> {
-    static void apply(const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt,
+    static void multiply(const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt,
                       const Configuration&);
 };
 
 template <typename SourceValue, typename TargetValue>
 struct SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 2, SourceValue, TargetValue> {
-    static void apply(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt,
+    static void multiply(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt,
                       const Configuration&);
 };
 
 template <typename SourceValue, typename TargetValue>
 struct SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 3, SourceValue, TargetValue> {
-    static void apply(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt,
+    static void multiply(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt,
                       const Configuration&);
 };
 

--- a/src/tests/interpolation/CMakeLists.txt
+++ b/src/tests/interpolation/CMakeLists.txt
@@ -104,6 +104,13 @@ ecbuild_add_test( TARGET atlas_test_interpolation_biquasicubic
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )
 
+ecbuild_add_test( TARGET atlas_test_interpolation_bicubic_gpu
+  SOURCES test_interpolation_structured2D_gpu.cc
+  LIBS     atlas
+  CONDITION atlas_HAVE_CUDA OR atlas_HAVE_HIP
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
+
 ecbuild_add_test( TARGET atlas_test_interpolation_structured2D_to_unstructured
   SOURCES  test_interpolation_structured2D_to_unstructured.cc
   LIBS     atlas

--- a/src/tests/interpolation/test_interpolation_finite_element_cached.cc
+++ b/src/tests/interpolation/test_interpolation_finite_element_cached.cc
@@ -106,7 +106,7 @@ CASE("extract cache, copy it, and move it for use") {
 
     set_field(field_source, grid_source, func);
 
-    eckit::linalg::SparseMatrix matrix = get_or_create_cache(grid_source, grid_target).matrix();
+    atlas::linalg::SparseMatrix matrix = get_or_create_cache(grid_source, grid_target).matrix();
 
     EXPECT(not matrix.empty());
 
@@ -133,7 +133,7 @@ CASE("extract cache, copy it, and pass non-owning pointer") {
 
     set_field(field_source, grid_source, func);
 
-    eckit::linalg::SparseMatrix matrix = get_or_create_cache(grid_source, grid_target).matrix();
+    atlas::linalg::SparseMatrix matrix = get_or_create_cache(grid_source, grid_target).matrix();
 
     EXPECT(not matrix.empty());
 

--- a/src/tests/interpolation/test_interpolation_structured2D_gpu.cc
+++ b/src/tests/interpolation/test_interpolation_structured2D_gpu.cc
@@ -1,0 +1,196 @@
+/*
+ * (C) Copyright 2024 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "atlas/array.h"
+#include "atlas/field/Field.h"
+#include "atlas/field/FieldSet.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/functionspace/StructuredColumns.h"
+#include "atlas/grid/Grid.h"
+#include "atlas/grid/Iterator.h"
+#include "atlas/interpolation.h"
+#include "atlas/mesh/Mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/output/Gmsh.h"
+#include "atlas/util/CoordinateEnums.h"
+#include "atlas/util/function/VortexRollup.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using atlas::functionspace::NodeColumns;
+using atlas::functionspace::StructuredColumns;
+using atlas::util::Config;
+
+namespace atlas {
+namespace test {
+
+//-----------------------------------------------------------------------------
+
+static Config scheme() {
+    Config scheme;
+    scheme.set("type", "structured-cubic2D");
+    scheme.set("halo", 2);
+    scheme.set("name", "cubic");
+    scheme.set("verbose",eckit::Resource<bool>("--verbose",false));
+    scheme.set("sparse_matrix_multiply", "hicsparse");
+    return scheme;
+}
+
+std::string input_gridname(const std::string& default_grid) {
+    return eckit::Resource<std::string>("--input-grid", default_grid);
+}
+
+std::string output_gridname(const std::string& default_grid) {
+    return eckit::Resource<std::string>("--output-grid", default_grid);
+}
+
+CASE("which scheme?") {
+    Log::info() << scheme().getString("type") << std::endl;
+}
+
+template <typename Value>
+struct AdjointTolerance {
+    static const Value value;
+};
+template <>
+const double AdjointTolerance<double>::value = 2.e-14;
+template <>
+const float AdjointTolerance<float>::value = 2.e-5;
+
+
+void test_interpolation_structured_using_fs_API_for_fieldset_w_hicsparse_backend() {
+    Grid input_grid(input_gridname("O32"));
+    Grid output_grid(output_gridname("O64"));
+
+    // Cubic interpolation requires a StructuredColumns functionspace with 2 halos
+    StructuredColumns input_fs(input_grid, scheme() | option::levels(3));
+
+    MeshGenerator meshgen("structured");
+    Mesh output_mesh        = meshgen.generate(output_grid);
+    FunctionSpace output_fs = NodeColumns{output_mesh, option::levels(3)};
+
+    auto lonlat = array::make_view<double, 2>(input_fs.xy());
+
+    FieldSet fields_source;
+    FieldSet fields_target;
+    for (idx_t f = 0; f < 3; ++f) {
+        auto field_source = fields_source.add(input_fs.createField<double>(option::name("field " + std::to_string(f))));
+        fields_target.add(output_fs.createField<double>(option::name("field " + std::to_string(f))));
+
+        auto source = array::make_view<double, 2>(field_source);
+        for (idx_t n = 0; n < input_fs.size(); ++n) {
+            for (idx_t k = 0; k < 3; ++k) {
+                source(n, k) = util::function::vortex_rollup(lonlat(n, LON), lonlat(n, LAT), 0.5 + double(k) / 2);
+            }
+        }
+    }
+
+    ATLAS_TRACE_SCOPE("with matrix") {
+        Interpolation interpolation(scheme(), input_fs, output_fs);
+        interpolation.execute(fields_source, fields_target);
+        for (auto& field : fields_target) {
+            field.updateHost();
+        }
+        
+        ATLAS_TRACE_SCOPE("output") {
+            output::Gmsh gmsh(scheme().getString("name") + "-multilevel-fieldset-output-with-matrix-" +
+                                  array::make_datatype<double>().str() + ".msh",
+                              Config("coordinates", "xy"));
+            gmsh.write(output_mesh);
+            output_fs.haloExchange(fields_target);
+            gmsh.write(fields_target);
+        }
+    }
+
+    ATLAS_TRACE_SCOPE("with matrix adjoint") {
+        Interpolation interpolation(scheme() | Config("adjoint", true), input_fs, output_fs);
+
+        std::vector<double> AxAx(fields_source.field_names().size(), 0.);
+        std::vector<double> xAtAx(fields_source.field_names().size(), 0.);
+
+        FieldSet fields_source_reference;
+        for (atlas::Field& field : fields_source) {
+            Field temp_field(field.name(), field.datatype().kind(), field.shape());
+            temp_field.set_levels(field.levels());
+
+            auto fieldInView  = array::make_view<double, 2>(field);
+            auto fieldOutView = array::make_view<double, 2>(temp_field);
+
+            for (atlas::idx_t jn = 0; jn < temp_field.shape(0); ++jn) {
+                for (atlas::idx_t jl = 0; jl < temp_field.levels(); ++jl) {
+                    fieldOutView(jn, jl) = fieldInView(jn, jl);
+                }
+            }
+            fields_source_reference.add(temp_field);
+        }
+
+        interpolation.execute(fields_source, fields_target);
+        for (auto& field : fields_target) {
+            field.updateHost();
+        }
+
+        std::size_t fIndx(0);
+        auto source_names = fields_source.field_names();
+        for (const std::string& s : fields_target.field_names()) {
+            auto target = array::make_view<double, 2>(fields_target[s]);
+            auto source = array::make_view<double, 2>(fields_source[source_names[fIndx]]);
+
+            for (idx_t n = 0; n < input_fs.size(); ++n) {
+                for (idx_t k = 0; k < 3; ++k) {
+                    AxAx[fIndx] += source(n, k) * source(n, k);
+                }
+            }
+
+            for (idx_t n = 0; n < output_fs.size(); ++n) {
+                for (idx_t k = 0; k < 3; ++k) {
+                    AxAx[fIndx] += target(n, k) * target(n, k);
+                }
+            }
+            fIndx += 1;
+        }
+
+        interpolation.execute_adjoint(fields_source, fields_target);
+        for (auto& field : fields_source) {
+            field.updateHost();
+        }
+
+        fIndx = 0;
+        for (const std::string& s : fields_source.field_names()) {
+            auto source_reference = array::make_view<double, 2>(fields_source_reference[s]);
+            auto source           = array::make_view<double, 2>(fields_source[s]);
+
+            for (idx_t n = 0; n < input_fs.size(); ++n) {
+                for (idx_t k = 0; k < 3; ++k) {
+                    xAtAx[fIndx] += source(n, k) * source_reference(n, k);
+                }
+            }
+            fIndx += 1;
+        }
+
+        for (std::size_t t = 0; t < AxAx.size(); ++t) {
+            Log::debug() << " Adjoint test t  = " << t << " (Ax).(Ax) = " << AxAx[t] << " x.(AtAx) = " << xAtAx[t]
+                         << " std::abs( 1.0 - xAtAx[t]/AxAx[t] ) " << std::abs(1.0 - xAtAx[t] / AxAx[t])
+                         << " AdjointTolerance<double>::value " << AdjointTolerance<double>::value << std::endl;
+
+            EXPECT(std::abs(1.0 - xAtAx[t] / AxAx[t]) < AdjointTolerance<double>::value);
+        }
+    }
+}
+
+CASE("test_interpolation_structured using fs API for fieldset with hicsparse backend") {
+    test_interpolation_structured_using_fs_API_for_fieldset_w_hicsparse_backend();
+}
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}

--- a/src/tests/linalg/CMakeLists.txt
+++ b/src/tests/linalg/CMakeLists.txt
@@ -14,6 +14,14 @@ ecbuild_add_test( TARGET atlas_test_linalg_sparse
     ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
   )
 
+ecbuild_add_test( TARGET atlas_test_linalg_sparse_gpu
+  SOURCES test_linalg_sparse_gpu.cc
+  LIBS    atlas
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+  CONDITION atlas_HAVE_CUDA OR atlas_HAVE_HIP
+)
+
+
 ecbuild_add_test( TARGET atlas_test_linalg_dense
     SOURCES test_linalg_dense.cc
     LIBS    atlas

--- a/src/tests/linalg/test_linalg_sparse.cc
+++ b/src/tests/linalg/test_linalg_sparse.cc
@@ -30,6 +30,7 @@ namespace test {
 // strings to be used in the tests
 static std::string eckit_linalg = sparse::backend::eckit_linalg::type();
 static std::string openmp       = sparse::backend::openmp::type();
+static std::string hicsparse    = sparse::backend::hicsparse::type();
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -193,6 +194,7 @@ CASE("test backend functionalities") {
     sparse::current_backend(eckit_linalg);
     EXPECT_EQ(sparse::current_backend().type(), "eckit_linalg");
     EXPECT_EQ(sparse::current_backend().getString("backend", "undefined"), "undefined");
+
     sparse::current_backend().set("backend", "default");
     EXPECT_EQ(sparse::current_backend().getString("backend"), "default");
 
@@ -200,15 +202,21 @@ CASE("test backend functionalities") {
     EXPECT_EQ(sparse::current_backend().getString("backend", "undefined"), "undefined");
     EXPECT_EQ(sparse::default_backend(eckit_linalg).getString("backend"), "default");
 
+    sparse::current_backend(hicsparse);
+    EXPECT_EQ(sparse::current_backend().type(), "hicsparse");
+    EXPECT_EQ(sparse::current_backend().getString("backend", "undefined"), "undefined");
+
     sparse::default_backend(eckit_linalg).set("backend", "generic");
     EXPECT_EQ(sparse::default_backend(eckit_linalg).getString("backend"), "generic");
 
     const sparse::Backend backend_default      = sparse::Backend();
     const sparse::Backend backend_openmp       = sparse::backend::openmp();
     const sparse::Backend backend_eckit_linalg = sparse::backend::eckit_linalg();
-    EXPECT_EQ(backend_default.type(), openmp);
+    const sparse::Backend backend_hicsparse    = sparse::backend::hicsparse();
+    EXPECT_EQ(backend_default.type(), hicsparse);
     EXPECT_EQ(backend_openmp.type(), openmp);
     EXPECT_EQ(backend_eckit_linalg.type(), eckit_linalg);
+    EXPECT_EQ(backend_hicsparse.type(), hicsparse);
 
     EXPECT_EQ(std::string(backend_openmp), openmp);
     EXPECT_EQ(std::string(backend_eckit_linalg), eckit_linalg);

--- a/src/tests/linalg/test_linalg_sparse.cc
+++ b/src/tests/linalg/test_linalg_sparse.cc
@@ -104,6 +104,23 @@ private:
     array::ArrayView<Value, 1> view_;
 };
 
+bool operator==(const SparseMatrix& A, const SparseMatrix& B) {
+    if (A.rows() != B.rows() || A.cols() != B.cols() || A.nonZeros() != B.nonZeros()) {
+        return false;
+    }
+    const auto A_data_view = eckit::testing::make_view(A.data(), A.nonZeros());
+    const auto A_outer_view = eckit::testing::make_view(A.outer(), A.rows()+1);
+    const auto A_inner_view = eckit::testing::make_view(A.inner(), A.nonZeros());
+    const auto B_data_view = eckit::testing::make_view(B.data(), B.nonZeros());
+    const auto B_outer_view = eckit::testing::make_view(B.outer(), B.rows()+1);
+    const auto B_inner_view = eckit::testing::make_view(B.inner(), B.nonZeros());
+    if (A_data_view != B_data_view ||
+        A_outer_view != B_outer_view ||
+        A_inner_view != B_inner_view) {
+        return false;
+    }
+    return true;
+}
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -195,6 +212,102 @@ CASE("test backend functionalities") {
 
     EXPECT_EQ(std::string(backend_openmp), openmp);
     EXPECT_EQ(std::string(backend_eckit_linalg), eckit_linalg);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+CASE("SparseMatrix default constructor") {
+    SparseMatrix A;
+    EXPECT_EQ(A.rows(), 0);
+    EXPECT_EQ(A.cols(), 0);
+    EXPECT_EQ(A.nonZeros(), 0);
+}
+
+CASE("SparseMatrix copy constructor") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}};
+    SparseMatrix B{A};
+    EXPECT(A == B);
+}
+
+CASE("SparseMatrix assignment constructor") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}};
+    auto B = A;
+    EXPECT(A == B);
+}
+
+CASE("SparseMatrix assignment") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}};
+    SparseMatrix B;
+    B = A;
+    EXPECT(A == B);
+}
+
+CASE("SparseMatrix triplet constructor") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}};
+    const auto A_data_view = eckit::testing::make_view(A.data(), A.nonZeros());
+    const auto A_outer_view = eckit::testing::make_view(A.outer(), A.rows()+1);
+    const auto A_inner_view = eckit::testing::make_view(A.inner(), A.nonZeros());
+    
+    EXPECT_EQ(A.rows(), 3);
+    EXPECT_EQ(A.cols(), 3);
+    EXPECT_EQ(A.nonZeros(), 4);
+    
+    const std::vector<SparseMatrix::Scalar> test_data{2., -3., 2., 2.};
+    const std::vector<SparseMatrix::Index> test_outer{0, 2, 3, 4};
+    const std::vector<SparseMatrix::Index> test_inner{0, 2, 1, 2};
+    const auto test_data_view = eckit::testing::make_view(test_data.data(), test_data.size());
+    const auto test_outer_view = eckit::testing::make_view(test_outer.data(), test_outer.size());
+    const auto test_inner_view = eckit::testing::make_view(test_inner.data(), test_inner.size());
+    
+    EXPECT(A_data_view == test_data_view);
+    EXPECT(A_outer_view == test_outer_view);
+    EXPECT(A_inner_view == test_inner_view);
+}
+
+CASE("SparseMatrix triplet constructor 2") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, 0.}, {1, 1, 2.}, {2, 2, 2.}}};
+    const auto A_data_view = eckit::testing::make_view(A.data(), A.nonZeros());
+    const auto A_outer_view = eckit::testing::make_view(A.outer(), A.rows()+1);
+    const auto A_inner_view = eckit::testing::make_view(A.inner(), A.nonZeros());
+    
+    EXPECT_EQ(A.rows(), 3);
+    EXPECT_EQ(A.cols(), 3);
+    EXPECT_EQ(A.nonZeros(), 3);
+    
+    const std::vector<SparseMatrix::Scalar> test_data{2., 2., 2.};
+    const std::vector<SparseMatrix::Index> test_outer{0, 1, 2, 3};
+    const std::vector<SparseMatrix::Index> test_inner{0, 1, 2};
+    const auto test_data_view = eckit::testing::make_view(test_data.data(), test_data.size());
+    const auto test_outer_view = eckit::testing::make_view(test_outer.data(), test_outer.size());
+    const auto test_inner_view = eckit::testing::make_view(test_inner.data(), test_inner.size());
+    
+    EXPECT(A_data_view == test_data_view);
+    EXPECT(A_outer_view == test_outer_view);
+    EXPECT(A_inner_view == test_inner_view);
+}
+
+CASE("SparseMatrix swap") {
+    SparseMatrix A_test{3, 3, {{0, 0, 2.}, {0, 2, 0.}, {1, 1, 2.}, {2, 2, 2.}}};
+    SparseMatrix A{A_test};
+    SparseMatrix B_test{1, 1, {{0, 0, 7.}}};
+    SparseMatrix B{B_test};
+    A.swap(B);
+    EXPECT(A == B_test);
+    EXPECT(B == A_test);
+}
+
+CASE("SparseMatrix transpose") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}};
+    SparseMatrix AT{3, 3, {{0, 0, 2.}, {1, 1, 2.}, {2, 0, -3.}, {2, 2, 2.}}};
+    A.transpose();
+    EXPECT(A == AT);
+}
+
+CASE("SparseMatrix prune") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, 0}, {1, 1, 2.}, {2, 2, 2.}}};
+    SparseMatrix A_pruned{3, 3, {{0, 0, 2.}, {1, 1, 2.}, {2, 2, 2.}}};
+    A.prune();
+    EXPECT(A == A_pruned);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/tests/linalg/test_linalg_sparse.cc
+++ b/src/tests/linalg/test_linalg_sparse.cc
@@ -379,6 +379,25 @@ CASE("sparse_matrix vector multiply (spmv)") {
                 EXPECT_THROWS_AS(sparse_matrix_multiply(A, x2.view(), y.view()), eckit::AssertionFailed);
             }
         }
+
+        SECTION("View of atlas::Array [backend=" + backend + "]") {
+            ArrayVector<double> x(Vector{1., 2., 3.});
+            ArrayVector<double> y(Vector{4., 5., 6.});
+            sparse_matrix_multiply_add(A, x.view(), y.view());
+            expect_equal(y.view(), Vector{-3., 9., 12.});
+            // sparse_matrix_multiply of sparse matrix and vector of non-matching sizes should fail
+            {
+                ArrayVector<double> x2(2);
+                EXPECT_THROWS_AS(sparse_matrix_multiply_add(A, x2.view(), y.view()), eckit::AssertionFailed);
+            }
+        }
+
+        SECTION("sparse_matrix_multiply_add [backend=" + backend + "]") {
+            ArrayVector<double> x(Vector{1., 2., 3.});
+            ArrayVector<double> y(Vector{1., 2., 3.});
+            sparse_matrix_multiply_add(A, x.view(), y.view());
+            expect_equal(y.view(), Vector{-6., 6., 9.});
+        }
     }
 }
 
@@ -418,6 +437,14 @@ CASE("sparse_matrix matrix multiply (spmm)") {
             ArrayMatrix<double, Indexing::layout_right> c(3, 2);
             sparse_matrix_multiply(A, ma.view(), c.view(), Indexing::layout_right);
             expect_equal(c.view(), c_exp);
+        }
+
+        SECTION("sparse_matrix_multiply_add [backend=" + sparse::current_backend().type() + "]") {
+            ArrayMatrix<double, Indexing::layout_right> x(m);
+            ArrayMatrix<double, Indexing::layout_right> y(m);
+            Matrix y_exp{{-12., -12.}, {9., 12.}, {15., 18.}};
+            sparse_matrix_multiply_add(A, x.view(), y.view(), Indexing::layout_right);
+            expect_equal(y.view(), y_exp);
         }
     }
 

--- a/src/tests/linalg/test_linalg_sparse_gpu.cc
+++ b/src/tests/linalg/test_linalg_sparse_gpu.cc
@@ -169,6 +169,23 @@ CASE("sparse-matrix vector multiply (spmv) [backend=hicsparse]") {
             EXPECT_THROWS_AS(sparse_matrix_multiply(A, x2_device_view, y_device_view), eckit::AssertionFailed);
         }
     }
+
+    SECTION("sparse_matrix_multiply_add [backend=hicsparse]") {
+        ArrayVector<double> x(Vector{1., 2., 3.});
+        ArrayVector<double> y(Vector{4., 5., 6.});
+        auto x_device_view = x.device_view();
+        auto y_device_view = y.device_view();
+        sparse_matrix_multiply_add(A, x_device_view, y_device_view);
+        y.setHostNeedsUpdate(true);
+        auto y_view = y.view();
+        expect_equal(y.view(), Vector{-3., 9., 12.});
+        // sparse_matrix_multiply of sparse matrix and vector of non-matching sizes should fail
+        {
+            ArrayVector<double> x2(2);
+            auto x2_device_view = x2.device_view();
+            EXPECT_THROWS_AS(sparse_matrix_multiply_add(A, x2_device_view, y_device_view), eckit::AssertionFailed);
+        }
+    }
 }
 
 CASE("sparse-matrix matrix multiply (spmm) [backend=hicsparse]") {
@@ -229,6 +246,18 @@ CASE("sparse-matrix matrix multiply (spmm) [backend=hicsparse]") {
         c.setHostNeedsUpdate(true);
         auto c_view = c.view();
         expect_equal(c_view, ArrayMatrix<double>(c_exp).view());
+    }
+
+    SECTION("sparse_matrix_multiply_add [backend=hicsparse]") {
+        ArrayMatrix<double> x(m);
+        ArrayMatrix<double> y(m);
+        Matrix y_exp{{-12., -12.}, {9., 12.}, {15., 18.}};
+        auto x_device_view = x.device_view();
+        auto y_device_view = y.device_view();
+        sparse_matrix_multiply_add(A, x_device_view, y_device_view, sparse::backend::hicsparse());
+        y.setHostNeedsUpdate(true);
+        auto y_view = y.view();
+        expect_equal(y_view, ArrayMatrix<double>(y_exp).view());
     }
 }
 

--- a/src/tests/linalg/test_linalg_sparse_gpu.cc
+++ b/src/tests/linalg/test_linalg_sparse_gpu.cc
@@ -1,0 +1,242 @@
+/*
+ * (C) Copyright 2024- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <tuple>
+#include <vector>
+
+#include "eckit/linalg/Matrix.h"
+#include "eckit/linalg/Vector.h"
+
+#include "atlas/array.h"
+#include "atlas/linalg/sparse.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+
+using namespace atlas::linalg;
+
+namespace atlas {
+namespace test {
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// strings to be used in the tests
+static std::string hicsparse    = sparse::backend::hicsparse::type();
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// Only reason to define these derived classes is for nicer constructors and convenience in the tests
+
+class Vector : public eckit::linalg::Vector {
+public:
+    using Scalar = eckit::linalg::Scalar;
+    using eckit::linalg::Vector::Vector;
+    Vector(const std::initializer_list<Scalar>& v): eckit::linalg::Vector::Vector(v.size()) {
+        size_t i = 0;
+        for (auto& s : v) {
+            operator[](i++) = s;
+        }
+    }
+};
+
+class Matrix : public eckit::linalg::Matrix {
+public:
+    using Scalar = eckit::linalg::Scalar;
+    using eckit::linalg::Matrix::Matrix;
+
+    Matrix(const std::initializer_list<std::vector<Scalar>>& m):
+        eckit::linalg::Matrix::Matrix(m.size(), m.size() ? m.begin()->size() : 0) {
+        size_t r = 0;
+        for (auto& row : m) {
+            for (size_t c = 0; c < cols(); ++c) {
+                operator()(r, c) = row[c];
+            }
+            ++r;
+        }
+    }
+};
+
+// 2D array constructable from eckit::linalg::Matrix
+// Indexing/memorylayout and data type can be customized for testing
+template <typename Value, Indexing indexing = Indexing::layout_left>
+struct ArrayMatrix {
+    array::ArrayView<Value, 2> view() {
+        array.syncHostDevice();
+        return array::make_view<Value, 2>(array);
+    }
+    array::ArrayView<Value, 2> device_view() {
+        array.syncHostDevice();
+        return array::make_device_view<Value, 2>(array);
+    }
+    void setHostNeedsUpdate(bool b) {
+        array.setHostNeedsUpdate(b);
+    }
+    ArrayMatrix(const eckit::linalg::Matrix& m): ArrayMatrix(m.rows(), m.cols()) {
+        auto view_ = array::make_view<Value, 2>(array);
+        for (int r = 0; r < m.rows(); ++r) {
+            for (int c = 0; c < m.cols(); ++c) {
+                auto& v = layout_left ? view_(r, c) : view_(c, r);
+                v       = m(r, c);
+            }
+        }
+    }
+    ArrayMatrix(int r, int c): array(make_shape(r, c)) {}
+
+private:
+    static constexpr bool layout_left = (indexing == Indexing::layout_left);
+    static array::ArrayShape make_shape(int rows, int cols) {
+        return layout_left ? array::make_shape(rows, cols) : array::make_shape(cols, rows);
+    }
+    array::ArrayT<Value> array;
+};
+
+// 1D array constructable from eckit::linalg::Vector
+template <typename Value>
+struct ArrayVector {
+    array::ArrayView<Value, 1> view() {
+        array.syncHostDevice();
+        return array::make_view<Value, 1>(array);
+    }
+    array::ArrayView<const Value, 1> const_view() {
+        array.syncHostDevice();
+        return array::make_view<const Value, 1>(array);
+    }
+    array::ArrayView<Value, 1> device_view() {
+        array.syncHostDevice();
+        return array::make_device_view<Value, 1>(array);
+    }
+    void setHostNeedsUpdate(bool b) {
+        array.setHostNeedsUpdate(b);
+    }
+    ArrayVector(const eckit::linalg::Vector& v): ArrayVector(v.size()) {
+        auto view_ = array::make_view<Value, 1>(array);
+        for (int n = 0; n < v.size(); ++n) {
+            view_[n] = v[n];
+        }
+    }
+    ArrayVector(int size): array(size) {}
+
+private:
+    array::ArrayT<Value> array;
+};
+
+//----------------------------------------------------------------------------------------------------------------------
+
+template <typename T>
+void expect_equal(T* v, T* r, size_t s) {
+    EXPECT(is_approximately_equal(eckit::testing::make_view(v, s), eckit::testing::make_view(r, s), T(1.e-5)));
+}
+
+template <class T1, class T2>
+void expect_equal(const T1& v, const T2& r) {
+    expect_equal(v.data(), r.data(), std::min(v.size(), r.size()));
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+CASE("sparse-matrix vector multiply (spmv) [backend=hicsparse]") {
+    // "square" matrix
+    // A =  2  . -3
+    //      .  2  .
+    //      .  .  2
+    // x = 1 2 3
+    // y = 1 2 3
+    
+    sparse::current_backend(hicsparse);
+    
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}};
+    
+    SECTION("View of atlas::Array [backend=hicsparse]") {
+        ArrayVector<double> x(Vector{1., 2., 3.});
+        ArrayVector<double> y(3);
+        const auto x_device_view = x.device_view();
+        auto y_device_view = y.device_view();
+        sparse_matrix_multiply(A, x_device_view, y_device_view);
+        y.setHostNeedsUpdate(true);
+        auto y_view = y.view();
+        expect_equal(y.view(), Vector{-7., 4., 6.});
+        // sparse_matrix_multiply of sparse matrix and vector of non-matching sizes should fail
+        {
+            ArrayVector<double> x2(2);
+            auto x2_device_view = x2.device_view();
+            EXPECT_THROWS_AS(sparse_matrix_multiply(A, x2_device_view, y_device_view), eckit::AssertionFailed);
+        }
+    }
+}
+
+CASE("sparse-matrix matrix multiply (spmm) [backend=hicsparse]") {
+    // "square"
+    // A =  2  . -3
+    //      .  2  .
+    //      .  .  2
+    // x = 1 2 3
+    // y = 1 2 3
+    sparse::current_backend(hicsparse);
+
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}};
+    Matrix m{{1., 2.}, {3., 4.}, {5., 6.}};
+    Matrix c_exp{{-13., -14.}, {6., 8.}, {10., 12.}};
+
+    SECTION("View of atlas::Array PointsRight [backend=hicsparse]") {
+        ArrayMatrix<double, Indexing::layout_right> ma(m);
+        ArrayMatrix<double, Indexing::layout_right> c(3, 2);
+        auto ma_device_view = ma.device_view();
+        auto c_device_view = c.device_view();
+        sparse_matrix_multiply(A, ma_device_view, c_device_view, Indexing::layout_right);
+        c.setHostNeedsUpdate(true);
+        auto c_view = c.view();
+        expect_equal(c_view, ArrayMatrix<double, Indexing::layout_right>(c_exp).view());
+    }
+
+    SECTION("sparse_matrix_multiply [backend=hicsparse]") {
+        auto backend = sparse::backend::hicsparse();
+        ArrayMatrix<double> ma(m);
+        ArrayMatrix<double> c(3, 2);
+        auto ma_device_view = ma.device_view();
+        auto c_device_view = c.device_view();
+        sparse_matrix_multiply(A, ma_device_view, c_device_view, backend);
+        c.setHostNeedsUpdate(true);
+        auto c_view = c.view();
+        expect_equal(c_view, ArrayMatrix<double>(c_exp).view());
+    }
+
+    SECTION("SparseMatrixMultiply [backend=hicsparse] 1") {
+        auto spmm = SparseMatrixMultiply{sparse::backend::hicsparse()};
+        ArrayMatrix<double> ma(m);
+        ArrayMatrix<double> c(3, 2);
+        auto ma_device_view = ma.device_view();
+        auto c_device_view = c.device_view();
+        spmm(A, ma_device_view, c_device_view);
+        c.setHostNeedsUpdate(true);
+        auto c_view = c.view();
+        expect_equal(c_view, ArrayMatrix<double>(c_exp).view());
+    }
+
+    SECTION("SparseMatrixMultiply [backend=hicsparse] 2") {
+        auto spmm = SparseMatrixMultiply{hicsparse};
+        ArrayMatrix<double> ma(m);
+        ArrayMatrix<double> c(3, 2);
+        auto ma_device_view = ma.device_view();
+        auto c_device_view = c.device_view();
+        spmm(A, ma_device_view, c_device_view);
+        c.setHostNeedsUpdate(true);
+        auto c_view = c.view();
+        expect_equal(c_view, ArrayMatrix<double>(c_exp).view());
+    }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}


### PR DESCRIPTION
I've opened this as a draft PR to get early feedback and to recognise that we might want to iterate on the design.

This PR:
- adds a SparseMatrix class into Atlas that wraps eckit's SparseMatrix class to combine it with GPU memory management
- adds a hicsparse backend to Atlas's sparse linear algebra interface
- adds "multiply-add" support into Atlas's sparse linear algebra interface
- updates interpolation to support use of the hicparse backend of Atlas's sparse linear algebra interface