### PR TITLE
Extend sparse linear algebra interface with multiply-add

### DIFF
--- a/src/atlas/linalg/sparse/SparseMatrixMultiply.h
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply.h
@@ -38,6 +38,19 @@ template <typename Matrix, typename SourceView, typename TargetView>
 void sparse_matrix_multiply(const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing,
                             const Configuration& config);
 
+template <typename Matrix, typename SourceView, typename TargetView>
+void sparse_matrix_multiply_add(const Matrix& matrix, const SourceView& src, TargetView& tgt);
+
+template <typename Matrix, typename SourceView, typename TargetView>
+void sparse_matrix_multiply_add(const Matrix& matrix, const SourceView& src, TargetView& tgt, const Configuration& config);
+
+template <typename Matrix, typename SourceView, typename TargetView>
+void sparse_matrix_multiply_add(const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing);
+
+template <typename Matrix, typename SourceView, typename TargetView>
+void sparse_matrix_multiply_add(const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing,
+                                const Configuration& config);
+
 class SparseMatrixMultiply {
 public:
     SparseMatrixMultiply() = default;
@@ -46,12 +59,32 @@ public:
 
     template <typename Matrix, typename SourceView, typename TargetView>
     void operator()(const Matrix& matrix, const SourceView& src, TargetView& tgt) const {
-        sparse_matrix_multiply(matrix, src, tgt, backend());
+        multiply(matrix, src, tgt);
     }
 
     template <typename Matrix, typename SourceView, typename TargetView>
     void operator()(const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing indexing) const {
+        multiply(matrix, src, tgt, indexing);
+    }
+
+    template <typename Matrix, typename SourceView, typename TargetView>
+    void multiply(const Matrix& matrix, const SourceView& src, TargetView& tgt) const {
+        sparse_matrix_multiply(matrix, src, tgt, backend());
+    }
+
+    template <typename Matrix, typename SourceView, typename TargetView>
+    void multiply(const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing indexing) const {
         sparse_matrix_multiply(matrix, src, tgt, indexing, backend());
+    }
+
+    template <typename Matrix, typename SourceView, typename TargetView>
+    void multiply_add(const Matrix& matrix, const SourceView& src, TargetView& tgt) const {
+        sparse_matrix_multiply_add(matrix, src, tgt, backend());
+    }
+
+    template <typename Matrix, typename SourceView, typename TargetView>
+    void multiply_add(const Matrix& matrix, const SourceView& src, TargetView& tgt, Indexing indexing) const {
+        sparse_matrix_multiply_add(matrix, src, tgt, indexing, backend());
     }
 
     const sparse::Backend& backend() const { return backend_; }
@@ -65,8 +98,12 @@ namespace sparse {
 // Template class which needs (full or partial) specialization for concrete template parameters
 template <typename Backend, Indexing, int Rank, typename SourceValue, typename TargetValue>
 struct SparseMatrixMultiply {
-    static void apply(const SparseMatrix&, const View<SourceValue, Rank>&, View<TargetValue, Rank>&,
-                      const Configuration&) {
+    static void multiply(const SparseMatrix&, const View<SourceValue, Rank>&, View<TargetValue, Rank>&,
+                         const Configuration&) {
+        throw_NotImplemented("SparseMatrixMultiply needs a template specialization with the implementation", Here());
+    }
+    static void multiply_add(const SparseMatrix&, const View<SourceValue, Rank>&, View<TargetValue, Rank>&,
+                             const Configuration&) {
         throw_NotImplemented("SparseMatrixMultiply needs a template specialization with the implementation", Here());
     }
 };

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_EckitLinalg.cc
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_EckitLinalg.cc
@@ -20,6 +20,7 @@
 
 #include "SparseMatrixMultiply_EckitLinalg.h"
 
+#include "atlas/array.h"
 #include "atlas/library/config.h"
 
 #if ATLAS_ECKIT_HAVE_ECKIT_585
@@ -62,9 +63,15 @@ const eckit::linalg::LinearAlgebra& eckit_linalg_backend(const Configuration& co
 }
 #endif
 
+template <typename Value, int Rank>
+auto linalg_make_view(atlas::array::ArrayT<double>& array) {
+    auto v_array = array::make_view<Value, Rank>(array);
+    return atlas::linalg::make_view(v_array);
+}
+
 }  // namespace
 
-void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 1, const double, double>::apply(
+void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 1, const double, double>::multiply(
     const SparseMatrix& W, const View<const double, 1>& src, View<double, 1>& tgt, const Configuration& config) {
     ATLAS_ASSERT(src.contiguous());
     ATLAS_ASSERT(tgt.contiguous());
@@ -73,7 +80,7 @@ void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 1, cons
     eckit_linalg_backend(config).spmv(W, v_src, v_tgt);
 }
 
-void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 2, const double, double>::apply(
+void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 2, const double, double>::multiply(
     const SparseMatrix& W, const View<const double, 2>& src, View<double, 2>& tgt, const Configuration& config) {
     ATLAS_ASSERT(src.contiguous());
     ATLAS_ASSERT(tgt.contiguous());
@@ -84,9 +91,45 @@ void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 2, cons
     eckit_linalg_backend(config).spmm(W, m_src, m_tgt);
 }
 
-void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_left, 1, const double, double>::apply(
+void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_left, 1, const double, double>::multiply(
     const SparseMatrix& W, const View<const double, 1>& src, View<double, 1>& tgt, const Configuration& config) {
-    SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 1, const double, double>::apply(W, src, tgt,
+    SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 1, const double, double>::multiply(W, src, tgt,
+                                                                                                        config);
+}
+
+void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 1, const double, double>::multiply_add(
+    const SparseMatrix& W, const View<const double, 1>& src, View<double, 1>& tgt, const Configuration& config) {
+
+    array::ArrayT<double> tmp(src.shape(0));
+    auto v_tmp = linalg_make_view<double, 1>(tmp);
+    v_tmp.assign(0.);
+
+    SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 1, const double, double>::multiply(W, src, v_tmp, config);
+
+    for (idx_t t = 0; t < tmp.shape(0); ++t) {
+        tgt(t) += v_tmp(t);
+    }
+}
+
+void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 2, const double, double>::multiply_add(
+    const SparseMatrix& W, const View<const double, 2>& src, View<double, 2>& tgt, const Configuration& config) {
+
+    array::ArrayT<double> tmp(src.shape(0), src.shape(1));
+    auto v_tmp = linalg_make_view<double, 2>(tmp);
+    v_tmp.assign(0.);
+
+    SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 2, const double, double>::multiply(W, src, v_tmp, config);
+
+    for (idx_t t = 0; t < tmp.shape(0); ++t) {
+        for (idx_t k = 0; k < tmp.shape(1); ++k) {
+            tgt(t, k) += v_tmp(t, k);
+        }
+    }
+}
+
+void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_left, 1, const double, double>::multiply_add(
+    const SparseMatrix& W, const View<const double, 1>& src, View<double, 1>& tgt, const Configuration& config) {
+    SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 1, const double, double>::multiply_add(W, src, tgt,
                                                                                                         config);
 }
 

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_EckitLinalg.h
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_EckitLinalg.h
@@ -28,20 +28,26 @@ namespace sparse {
 
 template <>
 struct SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 1, const double, double> {
-    static void apply(const SparseMatrix&, const View<const double, 1>& src, View<double, 1>& tgt,
+    static void multiply(const SparseMatrix&, const View<const double, 1>& src, View<double, 1>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix&, const View<const double, 1>& src, View<double, 1>& tgt,
                       const Configuration&);
 };
 
 template <>
 struct SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 2, const double, double> {
-    static void apply(const SparseMatrix&, const View<const double, 2>& src, View<double, 2>& tgt,
+    static void multiply(const SparseMatrix&, const View<const double, 2>& src, View<double, 2>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix&, const View<const double, 2>& src, View<double, 2>& tgt,
                       const Configuration&);
 };
 
 
 template <>
 struct SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_left, 1, const double, double> {
-    static void apply(const SparseMatrix&, const View<const double, 1>& src, View<double, 1>& tgt,
+    static void multiply(const SparseMatrix&, const View<const double, 1>& src, View<double, 1>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix&, const View<const double, 1>& src, View<double, 1>& tgt,
                       const Configuration&);
 };
 

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_OpenMP.cc
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_OpenMP.cc
@@ -17,9 +17,8 @@ namespace atlas {
 namespace linalg {
 namespace sparse {
 
-template <typename SourceValue, typename TargetValue>
-void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue, TargetValue>::apply(
-    const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt, const Configuration&) {
+template <bool SetZero, typename SourceValue, typename TargetValue>
+void spmv_layout_left(const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt) {
     using Value       = TargetValue;
     const auto outer  = W.outer();
     const auto index  = W.inner();
@@ -30,7 +29,9 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue
     ATLAS_ASSERT(tgt.shape(0) >= W.rows());
 
     atlas_omp_parallel_for(idx_t r = 0; r < rows; ++r) {
-        tgt[r] = 0.;
+        if constexpr (SetZero) {
+            tgt[r] = 0.;
+        }
         for (idx_t c = outer[r]; c < outer[r + 1]; ++c) {
             idx_t n = index[c];
             Value w = static_cast<Value>(weight[c]);
@@ -39,10 +40,20 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue
     }
 }
 
+template <typename SourceValue, typename TargetValue>
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue, TargetValue>::multiply(
+    const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt, const Configuration&) {
+    spmv_layout_left<true>(W, src, tgt);
+}
 
 template <typename SourceValue, typename TargetValue>
-void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 2, SourceValue, TargetValue>::apply(
-    const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt, const Configuration&) {
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue, TargetValue>::multiply_add(
+    const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt, const Configuration&) {
+    spmv_layout_left<false>(W, src, tgt);
+}
+
+template <bool SetZero, typename SourceValue, typename TargetValue>
+void spmm_layout_left(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt) {
     using Value       = TargetValue;
     const auto outer  = W.outer();
     const auto index  = W.inner();
@@ -54,8 +65,10 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 2, SourceValue
     ATLAS_ASSERT(tgt.shape(0) >= W.rows());
 
     atlas_omp_parallel_for(idx_t r = 0; r < rows; ++r) {
-        for (idx_t k = 0; k < Nk; ++k) {
-            tgt(r, k) = 0.;
+        if constexpr (SetZero) {
+            for (idx_t k = 0; k < Nk; ++k) {
+                tgt(r, k) = 0.;
+            }
         }
         for (idx_t c = outer[r]; c < outer[r + 1]; ++c) {
             idx_t n = index[c];
@@ -68,14 +81,24 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 2, SourceValue
 }
 
 template <typename SourceValue, typename TargetValue>
-void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 3, SourceValue, TargetValue>::apply(
-    const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt, const Configuration& config) {
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 2, SourceValue, TargetValue>::multiply(
+    const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt, const Configuration&) {
+    spmm_layout_left<true>(W, src, tgt);
+}
+
+template <typename SourceValue, typename TargetValue>
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 2, SourceValue, TargetValue>::multiply_add(
+    const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt, const Configuration&) {
+    spmm_layout_left<false>(W, src, tgt);
+}
+
+template <bool SetZero, typename SourceValue, typename TargetValue>
+void spmt_layout_left(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt) {
     if (src.contiguous() && tgt.contiguous()) {
         // We can take a more optimized route by reducing rank
         auto src_v = View<SourceValue, 2>(src.data(), array::make_shape(src.shape(0), src.stride(0)));
         auto tgt_v = View<TargetValue, 2>(tgt.data(), array::make_shape(tgt.shape(0), tgt.stride(0)));
-        SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 2, SourceValue, TargetValue>::apply(W, src_v,
-                                                                                                         tgt_v, config);
+        spmm_layout_left<SetZero>(W, src_v, tgt_v);
         return;
     }
     using Value       = TargetValue;
@@ -87,9 +110,11 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 3, SourceValue
     const idx_t Nl    = src.shape(2);
 
     atlas_omp_parallel_for(idx_t r = 0; r < rows; ++r) {
-        for (idx_t k = 0; k < Nk; ++k) {
-            for (idx_t l = 0; l < Nl; ++l) {
-                tgt(r, k, l) = 0.;
+        if constexpr (SetZero) {
+            for (idx_t k = 0; k < Nk; ++k) {
+                for (idx_t l = 0; l < Nl; ++l) {
+                    tgt(r, k, l) = 0.;
+                }
             }
         }
         for (idx_t c = outer[r]; c < outer[r + 1]; ++c) {
@@ -105,15 +130,31 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 3, SourceValue
 }
 
 template <typename SourceValue, typename TargetValue>
-void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 1, SourceValue, TargetValue>::apply(
-    const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt, const Configuration& config) {
-    return SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue, TargetValue>::apply(W, src, tgt,
-                                                                                                            config);
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 3, SourceValue, TargetValue>::multiply(
+    const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt, const Configuration& config) {
+    spmt_layout_left<true>(W, src, tgt);
 }
 
 template <typename SourceValue, typename TargetValue>
-void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 2, SourceValue, TargetValue>::apply(
-    const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt, const Configuration&) {
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 3, SourceValue, TargetValue>::multiply_add(
+    const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt, const Configuration& config) {
+    spmt_layout_left<false>(W, src, tgt);
+}
+
+template <typename SourceValue, typename TargetValue>
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 1, SourceValue, TargetValue>::multiply(
+    const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt, const Configuration& config) {
+    return SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue, TargetValue>::multiply(W, src, tgt, config);
+}
+
+template <typename SourceValue, typename TargetValue>
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 1, SourceValue, TargetValue>::multiply_add(
+    const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt, const Configuration& config) {
+    return SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue, TargetValue>::multiply_add(W, src, tgt, config);
+}
+
+template <bool SetZero, typename SourceValue, typename TargetValue>
+void spmm_layout_right(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt) {
     using Value       = TargetValue;
     const auto outer  = W.outer();
     const auto index  = W.inner();
@@ -125,8 +166,10 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 2, SourceValu
     ATLAS_ASSERT(tgt.shape(1) >= W.rows());
 
     atlas_omp_parallel_for(idx_t r = 0; r < rows; ++r) {
-        for (idx_t k = 0; k < Nk; ++k) {
-            tgt(k, r) = 0.;
+        if constexpr (SetZero) {
+            for (idx_t k = 0; k < Nk; ++k) {
+                tgt(k, r) = 0.;
+            }
         }
         for (idx_t c = outer[r]; c < outer[r + 1]; ++c) {
             idx_t n = index[c];
@@ -139,14 +182,24 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 2, SourceValu
 }
 
 template <typename SourceValue, typename TargetValue>
-void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 3, SourceValue, TargetValue>::apply(
-    const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt, const Configuration& config) {
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 2, SourceValue, TargetValue>::multiply(
+    const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt, const Configuration&) {
+    spmm_layout_right<true>(W, src, tgt);
+}
+
+template <typename SourceValue, typename TargetValue>
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 2, SourceValue, TargetValue>::multiply_add(
+    const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt, const Configuration&) {
+    spmm_layout_right<false>(W, src, tgt);
+}
+
+template <bool SetZero, typename SourceValue, typename TargetValue>
+void spmt_layout_right(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt) {
     if (src.contiguous() && tgt.contiguous()) {
         // We can take a more optimized route by reducing rank
         auto src_v = View<SourceValue, 2>(src.data(), array::make_shape(src.shape(0), src.stride(0)));
         auto tgt_v = View<TargetValue, 2>(tgt.data(), array::make_shape(tgt.shape(0), tgt.stride(0)));
-        SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 2, SourceValue, TargetValue>::apply(
-            W, src_v, tgt_v, config);
+        spmm_layout_right<SetZero>(W, src_v, tgt_v);
         return;
     }
     using Value       = TargetValue;
@@ -158,9 +211,11 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 3, SourceValu
     const idx_t Nl    = src.shape(0);
 
     atlas_omp_parallel_for(idx_t r = 0; r < rows; ++r) {
-        for (idx_t k = 0; k < Nk; ++k) {
-            for (idx_t l = 0; l < Nl; ++l) {
-                tgt(l, k, r) = 0.;
+        if constexpr (SetZero){
+            for (idx_t k = 0; k < Nk; ++k) {
+                for (idx_t l = 0; l < Nl; ++l) {
+                    tgt(l, k, r) = 0.;
+                }
             }
         }
         for (idx_t c = outer[r]; c < outer[r + 1]; ++c) {
@@ -173,6 +228,18 @@ void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 3, SourceValu
             }
         }
     }
+}
+
+template <typename SourceValue, typename TargetValue>
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 3, SourceValue, TargetValue>::multiply(
+    const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt, const Configuration& config) {
+    spmt_layout_right<true>(W, src, tgt);
+}
+
+template <typename SourceValue, typename TargetValue>
+void SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 3, SourceValue, TargetValue>::multiply_add(
+    const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt, const Configuration& config) {
+    spmt_layout_right<false>(W, src, tgt);
 }
 
 #define EXPLICIT_TEMPLATE_INSTANTIATION(TYPE)                                                           \

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_OpenMP.h
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_OpenMP.h
@@ -19,37 +19,49 @@ namespace sparse {
 
 template <typename SourceValue, typename TargetValue>
 struct SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 1, SourceValue, TargetValue> {
-    static void apply(const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt,
+    static void multiply(const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt,
                       const Configuration&);
 };
 
 template <typename SourceValue, typename TargetValue>
 struct SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 2, SourceValue, TargetValue> {
-    static void apply(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt,
+    static void multiply(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt,
                       const Configuration&);
 };
 
 template <typename SourceValue, typename TargetValue>
 struct SparseMatrixMultiply<backend::openmp, Indexing::layout_left, 3, SourceValue, TargetValue> {
-    static void apply(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt,
+    static void multiply(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt,
                       const Configuration&);
 };
 
 template <typename SourceValue, typename TargetValue>
 struct SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 1, SourceValue, TargetValue> {
-    static void apply(const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt,
+    static void multiply(const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<SourceValue, 1>& src, View<TargetValue, 1>& tgt,
                       const Configuration&);
 };
 
 template <typename SourceValue, typename TargetValue>
 struct SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 2, SourceValue, TargetValue> {
-    static void apply(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt,
+    static void multiply(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<SourceValue, 2>& src, View<TargetValue, 2>& tgt,
                       const Configuration&);
 };
 
 template <typename SourceValue, typename TargetValue>
 struct SparseMatrixMultiply<backend::openmp, Indexing::layout_right, 3, SourceValue, TargetValue> {
-    static void apply(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt,
+    static void multiply(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrix& W, const View<SourceValue, 3>& src, View<TargetValue, 3>& tgt,
                       const Configuration&);
 };
 


### PR DESCRIPTION
This PR extends Atlas's sparse linear algebra interface with multiply-add functionality.