### PR TITLE
Add GPU offload capable sparse matrix

### DIFF
--- a/hic/tests/test_hicsparse.cc
+++ b/hic/tests/test_hicsparse.cc
@@ -283,6 +283,7 @@ int test_hicsparseSpMM() {
     }
 
     // Clean up
+    HIC_CALL(hicFree(buffer));
     HIC_CALL(hicFree(dC));
     HIC_CALL(hicFree(dB));
     HIC_CALL(hicFree(dcolumn_indices));

--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -703,6 +703,8 @@ linalg/Indexing.h
 linalg/Introspection.h
 linalg/View.h
 linalg/sparse.h
+linalg/SparseMatrix.h
+linalg/SparseMatrix.cc
 linalg/sparse/Backend.h
 linalg/sparse/Backend.cc
 linalg/sparse/SparseMatrixMultiply.h

--- a/src/atlas/interpolation/Cache.h
+++ b/src/atlas/interpolation/Cache.h
@@ -17,8 +17,8 @@
 #include "eckit/filesystem/PathName.h"
 #include "eckit/io/Buffer.h"
 
-#include "eckit/linalg/SparseMatrix.h"
 
+#include "atlas/linalg/SparseMatrix.h"
 #include "atlas/runtime/Exception.h"
 #include "atlas/util/KDTree.h"
 
@@ -82,7 +82,7 @@ private:
 
 class MatrixCacheEntry : public InterpolationCacheEntry {
 public:
-    using Matrix = eckit::linalg::SparseMatrix;
+    using Matrix = atlas::linalg::SparseMatrix;
     ~MatrixCacheEntry() override;
     MatrixCacheEntry(const Matrix* matrix, const std::string& uid = ""): matrix_{matrix}, uid_(uid) {
         ATLAS_ASSERT(matrix_ != nullptr);

--- a/src/atlas/interpolation/method/Method.h
+++ b/src/atlas/interpolation/method/Method.h
@@ -16,10 +16,10 @@
 
 #include "atlas/interpolation/Cache.h"
 #include "atlas/interpolation/NonLinear.h"
+#include "atlas/linalg/SparseMatrix.h"
 #include "atlas/util/Metadata.h"
 #include "atlas/util/Object.h"
 #include "eckit/config/Configuration.h"
-#include "eckit/linalg/SparseMatrix.h"
 
 namespace atlas {
 class Field;
@@ -87,7 +87,7 @@ protected:
 
     using Triplet  = eckit::linalg::Triplet;
     using Triplets = std::vector<Triplet>;
-    using Matrix   = eckit::linalg::SparseMatrix;
+    using Matrix   = atlas::linalg::SparseMatrix;
 
     static void normalise(Triplets& triplets);
 

--- a/src/atlas/interpolation/method/binning/Binning.cc
+++ b/src/atlas/interpolation/method/binning/Binning.cc
@@ -12,12 +12,12 @@
 #include "atlas/interpolation/Interpolation.h"
 #include "atlas/interpolation/method/binning/Binning.h"
 #include "atlas/interpolation/method/MethodFactory.h"
+#include "atlas/linalg/SparseMatrix.h"
 #include "atlas/mesh.h"
 #include "atlas/mesh/actions/GetCubedSphereNodalArea.h"
 #include "atlas/runtime/Trace.h"
 
 #include "eckit/config/LocalConfiguration.h"
-#include "eckit/linalg/SparseMatrix.h"
 #include "eckit/linalg/Triplet.h"
 #include "eckit/mpi/Comm.h"
 
@@ -58,7 +58,7 @@ void Binning::do_setup(const FunctionSpace& source,
 
   using Index = eckit::linalg::Index;
   using Triplet = eckit::linalg::Triplet;
-  using SMatrix = eckit::linalg::SparseMatrix;
+  using SMatrix = atlas::linalg::SparseMatrix;
 
   source_ = source;
   target_ = target;

--- a/src/atlas/interpolation/method/knn/GridBoxMaximum.cc
+++ b/src/atlas/interpolation/method/knn/GridBoxMaximum.cc
@@ -61,7 +61,7 @@ void GridBoxMaximum::do_execute(const Field& source, Field& target, Metadata&) c
 
     if (!matrixFree_) {
         const Matrix& m = matrix();
-        Matrix::const_iterator k(m);
+        Matrix::const_iterator k = m.begin();
 
         for (decltype(m.rows()) i = 0, j = 0; i < m.rows(); ++i) {
             double max = std::numeric_limits<double>::lowest();

--- a/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
+++ b/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
@@ -1248,7 +1248,7 @@ void ConservativeSphericalPolygonInterpolation::intersect_polygons(const CSPolyg
     }
 }
 
-eckit::linalg::SparseMatrix ConservativeSphericalPolygonInterpolation::compute_1st_order_matrix() {
+atlas::linalg::SparseMatrix ConservativeSphericalPolygonInterpolation::compute_1st_order_matrix() {
     ATLAS_TRACE("ConservativeMethod::setup: build cons-1 interpolant matrix");
     ATLAS_ASSERT(not matrix_free_);
     Triplets triplets;
@@ -1358,7 +1358,7 @@ eckit::linalg::SparseMatrix ConservativeSphericalPolygonInterpolation::compute_1
     return Matrix(n_tpoints_, n_spoints_, triplets);
 }
 
-eckit::linalg::SparseMatrix ConservativeSphericalPolygonInterpolation::compute_2nd_order_matrix() {
+atlas::linalg::SparseMatrix ConservativeSphericalPolygonInterpolation::compute_2nd_order_matrix() {
     ATLAS_TRACE("ConservativeMethod::setup: build cons-2 interpolant matrix");
     ATLAS_ASSERT(not matrix_free_);
     const auto& src_points_ = data_->src_points_;

--- a/src/atlas/interpolation/nonlinear/Missing.cc
+++ b/src/atlas/interpolation/nonlinear/Missing.cc
@@ -81,7 +81,7 @@ bool MissingIfAllMissing::executeT(NonLinear::Matrix& W, const Field& field) con
     bool zeros = false;
 
     Size i = 0;
-    Matrix::iterator it(W);
+    Matrix::iterator it = W.begin();
     for (Size r = 0; r < W.rows(); ++r) {
         const Matrix::iterator end = W.end(r);
 
@@ -128,6 +128,9 @@ bool MissingIfAllMissing::executeT(NonLinear::Matrix& W, const Field& field) con
             modif = true;
         }
     }
+    if (modif) {
+        W.setDeviceNeedsUpdate(true);
+    }
 
     if (zeros && missingValue.isnan()) {
         W.prune(0.);
@@ -161,7 +164,7 @@ bool MissingIfAnyMissing::executeT(NonLinear::Matrix& W, const Field& field) con
     bool zeros = false;
 
     Size i = 0;
-    Matrix::iterator it(W);
+    Matrix::iterator it = W.begin();
     for (Size r = 0; r < W.rows(); ++r) {
         const Matrix::iterator end = W.end(r);
 
@@ -194,6 +197,9 @@ bool MissingIfAnyMissing::executeT(NonLinear::Matrix& W, const Field& field) con
             }
             modif = true;
         }
+    }
+    if (modif) {
+        W.setDeviceNeedsUpdate(true);
     }
 
     if (zeros && missingValue.isnan()) {
@@ -228,7 +234,7 @@ bool MissingIfHeaviestMissing::executeT(NonLinear::Matrix& W, const Field& field
     bool zeros = false;
 
     Size i = 0;
-    Matrix::iterator it(W);
+    Matrix::iterator it = W.begin();
     for (Size r = 0; r < W.rows(); ++r) {
         const Matrix::iterator end = W.end(r);
 
@@ -281,6 +287,9 @@ bool MissingIfHeaviestMissing::executeT(NonLinear::Matrix& W, const Field& field
             }
             modif = true;
         }
+    }
+    if (modif) {
+        W.setDeviceNeedsUpdate(true);
     }
 
     if (zeros && missingValue.isnan()) {

--- a/src/atlas/interpolation/nonlinear/NonLinear.h
+++ b/src/atlas/interpolation/nonlinear/NonLinear.h
@@ -16,10 +16,10 @@
 #include <type_traits>
 
 #include "eckit/config/Parametrisation.h"
-#include "eckit/linalg/SparseMatrix.h"
 
 #include "atlas/array.h"
 #include "atlas/field/Field.h"
+#include "atlas/linalg/SparseMatrix.h"
 #include "atlas/runtime/Exception.h"
 #include "atlas/util/Factory.h"
 #include "atlas/util/ObjectHandle.h"
@@ -37,9 +37,9 @@ namespace nonlinear {
 class NonLinear : public util::Object {
 public:
     using Config = eckit::Parametrisation;
-    using Matrix = eckit::linalg::SparseMatrix;
-    using Scalar = eckit::linalg::Scalar;
-    using Size   = eckit::linalg::Size;
+    using Matrix = atlas::linalg::SparseMatrix;
+    using Scalar = atlas::linalg::SparseMatrix::Scalar;
+    using Size   = atlas::linalg::SparseMatrix::Size;
 
     /**
      * @brief ctor

--- a/src/atlas/linalg/SparseMatrix.cc
+++ b/src/atlas/linalg/SparseMatrix.cc
@@ -1,0 +1,84 @@
+
+#include "atlas/linalg/SparseMatrix.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+
+#include "atlas/array/helpers/ArrayCopier.h"
+
+#include "eckit/exception/Exceptions.h"
+
+namespace atlas {
+namespace linalg {
+
+//----------------------------------------------------------------------------------------------------------------------
+
+SparseMatrix::SparseMatrix() : host_matrix_() {}
+
+
+SparseMatrix::SparseMatrix(Size nrows, Size ncols, const std::vector<eckit::linalg::Triplet>& triplets) :
+    host_matrix_(nrows, ncols, triplets) {
+    resetDeviceStorage();
+}
+
+
+SparseMatrix::SparseMatrix(const SparseMatrix& other) : host_matrix_(other.host_matrix_) {
+    if (!other.empty()) {  // in case we copy an other that was constructed empty
+        resetDeviceStorage();
+    }
+}
+
+
+SparseMatrix& SparseMatrix::operator=(const SparseMatrix& other) {
+    SparseMatrix copy(other);
+    swap(copy);
+    return *this;
+}
+
+
+void SparseMatrix::swap(SparseMatrix& other) {
+    host_matrix_.swap(other.host_matrix_);
+    outer_.swap(other.outer_);
+    inner_.swap(other.inner_);
+    data_.swap(other.data_);
+}
+
+
+size_t SparseMatrix::footprint() const {
+    return host_matrix_.footprint() +
+           outer_->footprint() +
+           inner_->footprint() +
+           data_->footprint();
+}
+
+
+SparseMatrix& SparseMatrix::prune(Scalar val) {
+    host_matrix_.prune(val);
+    resetDeviceStorage();
+    return *this;
+}
+
+
+SparseMatrix& SparseMatrix::transpose() {
+    host_matrix_.transpose();
+    resetDeviceStorage();
+    return *this;
+}
+
+SparseMatrix& SparseMatrix::setIdentity(Size nrows, Size ncols) {
+    host_matrix_.setIdentity(nrows, ncols);
+    resetDeviceStorage();
+    return *this;
+}
+
+void SparseMatrix::resetDeviceStorage() {
+    outer_.reset(atlas::array::Array::wrap<Index>(const_cast<Index*>(outer()), atlas::array::make_shape(rows() + 1)));
+    inner_.reset(atlas::array::Array::wrap<Index>(const_cast<Index*>(inner()), atlas::array::make_shape(nonZeros())));
+    data_.reset(atlas::array::Array::wrap<Scalar>(const_cast<Scalar*>(data()), atlas::array::make_shape(nonZeros())));
+    setDeviceNeedsUpdate(true);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+}  // namespace linalg
+}  // namespace atlas

--- a/src/atlas/linalg/SparseMatrix.h
+++ b/src/atlas/linalg/SparseMatrix.h
@@ -1,0 +1,178 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "atlas/array.h"
+
+#include "eckit/linalg/SparseMatrix.h"
+#include "eckit/linalg/Triplet.h"
+#include "eckit/linalg/types.h"
+
+namespace atlas {
+namespace linalg {
+
+//----------------------------------------------------------------------------------------------------------------------
+
+/// Sparse matrix in CRS (compressed row storage) format
+class SparseMatrix {
+public:
+    using Scalar = eckit::linalg::Scalar;
+    using Index = eckit::linalg::Index;
+    using Size = eckit::linalg::Size;
+    using iterator = eckit::linalg::SparseMatrix::iterator;
+    using const_iterator = eckit::linalg::SparseMatrix::const_iterator;
+
+public:
+    // -- Constructors
+
+    /// Default constructor, empty matrix
+    SparseMatrix();
+
+    /// Constructor from triplets
+    SparseMatrix(Size nrows, Size ncols, const std::vector<eckit::linalg::Triplet>&);
+
+    /// Copy constructor
+    SparseMatrix(const SparseMatrix&);
+
+    /// Assignment operator (allocates and copies data)
+    SparseMatrix& operator=(const SparseMatrix&);
+
+public:
+    void swap(SparseMatrix&);
+
+    /// @returns number of rows
+    Size rows() const { return host_matrix_.rows(); }
+
+    /// @returns number of columns
+    Size cols() const { return host_matrix_.cols(); }
+
+    /// @returns number of non-zeros
+    Size nonZeros() const { return host_matrix_.nonZeros(); }
+
+    /// @returns true if this matrix does not contain non-zero entries
+    bool empty() const { return host_matrix_.empty(); }
+
+    /// @returns footprint of the matrix in memory
+    size_t footprint() const;
+
+    /// Prune entries, in-place, with exactly the given value
+    SparseMatrix& prune(Scalar = 0);
+
+    /// Transpose matrix in-place
+    SparseMatrix& transpose();
+
+    SparseMatrix& setIdentity(Size nrows, Size ncols);
+
+public:
+    void updateDevice() const { 
+        outer_->updateDevice();
+        inner_->updateDevice();
+        data_->updateDevice();
+    }
+
+    void updateHost() const { 
+        outer_->updateHost();
+        inner_->updateHost();
+        data_->updateHost();
+    }
+
+    bool hostNeedsUpdate() const { 
+        return outer_->hostNeedsUpdate() ||
+               inner_->hostNeedsUpdate() ||
+               data_->hostNeedsUpdate();
+    }
+
+    bool deviceNeedsUpdate() const { 
+        return outer_->deviceNeedsUpdate() ||
+               inner_->deviceNeedsUpdate() ||
+               data_->deviceNeedsUpdate();
+    }
+
+    void setHostNeedsUpdate(bool v) const { 
+        outer_->setHostNeedsUpdate(v);
+        inner_->setHostNeedsUpdate(v);
+        data_->setHostNeedsUpdate(v);
+    }
+
+    void setDeviceNeedsUpdate(bool v) const {
+        outer_->setDeviceNeedsUpdate(v);
+        inner_->setDeviceNeedsUpdate(v);
+        data_->setDeviceNeedsUpdate(v);
+    }
+
+    bool deviceAllocated() const {
+        return outer_->deviceAllocated() &&
+               inner_->deviceAllocated() &&
+               data_->deviceAllocated();
+    }
+
+    void allocateDevice() {
+        outer_->allocateDevice();
+        inner_->allocateDevice();
+        data_->allocateDevice();
+    }
+
+    void deallocateDevice() { 
+        outer_->deallocateDevice();
+        inner_->deallocateDevice();
+        data_->deallocateDevice();
+    }
+
+    const eckit::linalg::SparseMatrix& host_matrix() const { return host_matrix_; }
+
+    size_t data_size() const { return nonZeros(); }
+
+    size_t outer_size() const { return rows() + 1; }
+    
+    size_t inner_size() const { return nonZeros(); }
+
+    const Scalar* data() const { return host_matrix_.data(); }
+    
+    const Index* outer() const { return host_matrix_.outer(); }
+
+    const Index* inner() const { return host_matrix_.inner(); }
+
+    const Scalar* host_data() const { return host_matrix_.data(); }
+    
+    const Index* host_outer() const { return host_matrix_.outer(); }
+
+    const Index* host_inner() const { return host_matrix_.inner(); }
+
+    const Scalar* device_data() const { return data_->device_data<Scalar>(); }
+    
+    const Index* device_outer() const { return outer_->device_data<Index>(); }
+
+    const Index* device_inner() const { return inner_->device_data<Index>(); }
+
+public:  // iterators
+    
+    /// const iterators to begin/end of row
+    const_iterator begin(Size row) const { return host_matrix_.begin(row); }
+    const_iterator end(Size row) const { return host_matrix_.end(row); }
+
+    /// const iterators to begin/end of matrix
+    const_iterator begin() const { return host_matrix_.begin(); }
+    const_iterator end() const { return host_matrix_.end(); }
+
+    /// iterators to begin/end of row
+    iterator begin(Size row) { return host_matrix_.begin(row); }
+    iterator end(Size row) { return host_matrix_.end(row); }
+
+    /// const iterators to begin/end of matrix
+    iterator begin() { return host_matrix_.begin(); }
+    iterator end() { return host_matrix_.end(); }
+
+private:
+    void resetDeviceStorage();
+
+private:
+    eckit::linalg::SparseMatrix host_matrix_;
+    std::unique_ptr<atlas::array::Array> outer_;
+    std::unique_ptr<atlas::array::Array> inner_;
+    std::unique_ptr<atlas::array::Array> data_;
+};
+
+//----------------------------------------------------------------------------------------------------------------------
+}  // namespace linalg
+}  // namespace atlas

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply.h
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply.h
@@ -11,9 +11,9 @@
 #pragma once
 
 #include "eckit/config/Configuration.h"
-#include "eckit/linalg/SparseMatrix.h"
 
 #include "atlas/linalg/Indexing.h"
+#include "atlas/linalg/SparseMatrix.h"
 #include "atlas/linalg/View.h"
 #include "atlas/linalg/sparse/Backend.h"
 #include "atlas/runtime/Exception.h"
@@ -22,7 +22,6 @@
 namespace atlas {
 namespace linalg {
 
-using SparseMatrix  = eckit::linalg::SparseMatrix;
 using Configuration = eckit::Configuration;
 
 template <typename Matrix, typename SourceView, typename TargetView>

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_EckitLinalg.cc
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_EckitLinalg.cc
@@ -77,7 +77,7 @@ void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 1, cons
     ATLAS_ASSERT(tgt.contiguous());
     eckit::linalg::Vector v_src(src.data(), src.size());
     eckit::linalg::Vector v_tgt(tgt.data(), tgt.size());
-    eckit_linalg_backend(config).spmv(W, v_src, v_tgt);
+    eckit_linalg_backend(config).spmv(W.host_matrix(), v_src, v_tgt);
 }
 
 void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 2, const double, double>::multiply(
@@ -88,7 +88,7 @@ void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_right, 2, cons
     ATLAS_ASSERT(tgt.shape(1) >= W.rows());
     eckit::linalg::Matrix m_src(src.data(), src.shape(1), src.shape(0));
     eckit::linalg::Matrix m_tgt(tgt.data(), tgt.shape(1), tgt.shape(0));
-    eckit_linalg_backend(config).spmm(W, m_src, m_tgt);
+    eckit_linalg_backend(config).spmm(W.host_matrix(), m_src, m_tgt);
 }
 
 void SparseMatrixMultiply<backend::eckit_linalg, Indexing::layout_left, 1, const double, double>::multiply(

--- a/src/tests/interpolation/test_interpolation_finite_element_cached.cc
+++ b/src/tests/interpolation/test_interpolation_finite_element_cached.cc
@@ -106,7 +106,7 @@ CASE("extract cache, copy it, and move it for use") {
 
     set_field(field_source, grid_source, func);
 
-    eckit::linalg::SparseMatrix matrix = get_or_create_cache(grid_source, grid_target).matrix();
+    atlas::linalg::SparseMatrix matrix = get_or_create_cache(grid_source, grid_target).matrix();
 
     EXPECT(not matrix.empty());
 
@@ -133,7 +133,7 @@ CASE("extract cache, copy it, and pass non-owning pointer") {
 
     set_field(field_source, grid_source, func);
 
-    eckit::linalg::SparseMatrix matrix = get_or_create_cache(grid_source, grid_target).matrix();
+    atlas::linalg::SparseMatrix matrix = get_or_create_cache(grid_source, grid_target).matrix();
 
     EXPECT(not matrix.empty());
 

--- a/src/tests/linalg/CMakeLists.txt
+++ b/src/tests/linalg/CMakeLists.txt
@@ -22,7 +22,7 @@ ecbuild_add_test( TARGET atlas_test_linalg_sparse_matrix
 
 ecbuild_add_test( TARGET atlas_test_linalg_sparse_matrix_gpu
   SOURCES test_linalg_sparse_matrix_gpu.cc
-  LIBS    atlas
+  LIBS    atlas hicsparse
   CONDITION atlas_HAVE_CUDA OR atlas_HAVE_HIP
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )

--- a/src/tests/linalg/CMakeLists.txt
+++ b/src/tests/linalg/CMakeLists.txt
@@ -14,6 +14,19 @@ ecbuild_add_test( TARGET atlas_test_linalg_sparse
     ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
   )
 
+ecbuild_add_test( TARGET atlas_test_linalg_sparse_matrix
+  SOURCES test_linalg_sparse_matrix.cc
+  LIBS    atlas
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
+
+ecbuild_add_test( TARGET atlas_test_linalg_sparse_matrix_gpu
+  SOURCES test_linalg_sparse_matrix_gpu.cc
+  LIBS    atlas
+  CONDITION atlas_HAVE_CUDA OR atlas_HAVE_HIP
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
+
 ecbuild_add_test( TARGET atlas_test_linalg_dense
     SOURCES test_linalg_dense.cc
     LIBS    atlas

--- a/src/tests/linalg/test_linalg_sparse_matrix.cc
+++ b/src/tests/linalg/test_linalg_sparse_matrix.cc
@@ -1,0 +1,137 @@
+/*
+ * (C) Copyright 2024- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "atlas/linalg/SparseMatrix.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using namespace atlas::linalg;
+
+namespace atlas {
+namespace test {
+
+bool operator==(const SparseMatrix& A, const SparseMatrix& B) {
+    if (A.rows() != B.rows() || A.cols() != B.cols() || A.nonZeros() != B.nonZeros()) {
+        return false;
+    }
+    const auto A_data_view = eckit::testing::make_view(A.data(), A.data_size());
+    const auto A_outer_view = eckit::testing::make_view(A.outer(), A.outer_size());
+    const auto A_inner_view = eckit::testing::make_view(A.inner(), A.inner_size());
+    const auto B_data_view = eckit::testing::make_view(B.data(), B.data_size());
+    const auto B_outer_view = eckit::testing::make_view(B.outer(), B.outer_size());
+    const auto B_inner_view = eckit::testing::make_view(B.inner(), B.inner_size());
+    if (A_data_view != B_data_view ||
+        A_outer_view != B_outer_view ||
+        A_inner_view != B_inner_view) {
+        return false;
+    }
+    return true;
+}
+
+CASE("SparseMatrix default constructor") {
+    SparseMatrix A;
+    EXPECT_EQ(A.rows(), 0);
+    EXPECT_EQ(A.cols(), 0);
+    EXPECT_EQ(A.nonZeros(), 0);
+}
+
+CASE("SparseMatrix copy constructor") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}};
+    SparseMatrix B{A};
+    EXPECT(A == B);
+}
+
+CASE("SparseMatrix assignment constructor") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}};
+    auto B = A;
+    EXPECT(A == B);
+}
+
+CASE("SparseMatrix assignment") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}};
+    SparseMatrix B;
+    B = A;
+    EXPECT(A == B);
+}
+
+CASE("SparseMatrix triplet constructor") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}};
+    const auto A_data_view = eckit::testing::make_view(A.data(), A.nonZeros());
+    const auto A_outer_view = eckit::testing::make_view(A.outer(), A.rows()+1);
+    const auto A_inner_view = eckit::testing::make_view(A.inner(), A.nonZeros());
+
+    EXPECT_EQ(A.rows(), 3);
+    EXPECT_EQ(A.cols(), 3);
+    EXPECT_EQ(A.nonZeros(), 4);
+
+    const std::vector<SparseMatrix::Scalar> test_data{2., -3., 2., 2.};
+    const std::vector<SparseMatrix::Index> test_outer{0, 2, 3, 4};
+    const std::vector<SparseMatrix::Index> test_inner{0, 2, 1, 2};
+    const auto test_data_view = eckit::testing::make_view(test_data.data(), test_data.size());
+    const auto test_outer_view = eckit::testing::make_view(test_outer.data(), test_outer.size());
+    const auto test_inner_view = eckit::testing::make_view(test_inner.data(), test_inner.size());
+
+    EXPECT(A_data_view == test_data_view);
+    EXPECT(A_outer_view == test_outer_view);
+    EXPECT(A_inner_view == test_inner_view);
+}
+
+CASE("SparseMatrix triplet constructor 2") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, 0.}, {1, 1, 2.}, {2, 2, 2.}}};
+    const auto A_data_view = eckit::testing::make_view(A.data(), A.nonZeros());
+    const auto A_outer_view = eckit::testing::make_view(A.outer(), A.rows()+1);
+    const auto A_inner_view = eckit::testing::make_view(A.inner(), A.nonZeros());
+
+    EXPECT_EQ(A.rows(), 3);
+    EXPECT_EQ(A.cols(), 3);
+    EXPECT_EQ(A.nonZeros(), 3);
+
+    const std::vector<SparseMatrix::Scalar> test_data{2., 2., 2.};
+    const std::vector<SparseMatrix::Index> test_outer{0, 1, 2, 3};
+    const std::vector<SparseMatrix::Index> test_inner{0, 1, 2};
+    const auto test_data_view = eckit::testing::make_view(test_data.data(), test_data.size());
+    const auto test_outer_view = eckit::testing::make_view(test_outer.data(), test_outer.size());
+    const auto test_inner_view = eckit::testing::make_view(test_inner.data(), test_inner.size());
+
+    EXPECT(A_data_view == test_data_view);
+    EXPECT(A_outer_view == test_outer_view);
+    EXPECT(A_inner_view == test_inner_view);
+}
+
+CASE("SparseMatrix swap") {
+    SparseMatrix A_test{3, 3, {{0, 0, 2.}, {0, 2, 0.}, {1, 1, 2.}, {2, 2, 2.}}};
+    SparseMatrix A{A_test};
+    SparseMatrix B_test{1, 1, {{0, 0, 7.}}};
+    SparseMatrix B{B_test};
+    A.swap(B);
+    EXPECT(A == B_test);
+    EXPECT(B == A_test);
+}
+
+CASE("SparseMatrix transpose") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}};
+    SparseMatrix AT{3, 3, {{0, 0, 2.}, {1, 1, 2.}, {2, 0, -3.}, {2, 2, 2.}}};
+    A.transpose();
+    EXPECT(A == AT);
+}
+
+CASE("SparseMatrix prune") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, 0}, {1, 1, 2.}, {2, 2, 2.}}};
+    SparseMatrix A_pruned{3, 3, {{0, 0, 2.}, {1, 1, 2.}, {2, 2, 2.}}};
+    A.prune();
+    EXPECT(A == A_pruned);
+}
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}

--- a/src/tests/linalg/test_linalg_sparse_matrix_gpu.cc
+++ b/src/tests/linalg/test_linalg_sparse_matrix_gpu.cc
@@ -1,0 +1,49 @@
+/*
+ * (C) Copyright 2024- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "atlas/linalg/SparseMatrix.h"
+
+#include "hic/hic.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using namespace atlas::linalg;
+
+namespace atlas {
+namespace test {
+
+CASE("SparseMatrix update device") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}};
+    
+    A.updateDevice();
+    
+    std::vector<SparseMatrix::Scalar> A_data_cpy(A.data_size());
+    std::vector<SparseMatrix::Index> A_outer_cpy(A.outer_size());
+    std::vector<SparseMatrix::Index> A_inner_cpy(A.inner_size());
+
+    hicMemcpy(A_data_cpy.data(), A.device_data(), A.data_size() * sizeof(SparseMatrix::Scalar), hicMemcpyDeviceToHost);
+    hicMemcpy(A_outer_cpy.data(), A.device_outer(), A.outer_size() * sizeof(SparseMatrix::Index), hicMemcpyDeviceToHost);
+    hicMemcpy(A_inner_cpy.data(), A.device_inner(), A.inner_size() * sizeof(SparseMatrix::Index), hicMemcpyDeviceToHost);
+
+    std::vector<SparseMatrix::Scalar> A_data_test{2., -3., 2., 2.};
+    std::vector<SparseMatrix::Index> A_outer_test{0, 2, 3, 4};
+    std::vector<SparseMatrix::Index> A_inner_test{0, 2, 1, 2};
+
+    EXPECT(A_data_cpy == A_data_test);
+    EXPECT(A_outer_cpy == A_outer_test);
+    EXPECT(A_inner_cpy == A_inner_test);
+}
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}

--- a/src/tests/linalg/test_linalg_sparse_matrix_gpu.cc
+++ b/src/tests/linalg/test_linalg_sparse_matrix_gpu.cc
@@ -11,6 +11,7 @@
 #include "atlas/linalg/SparseMatrix.h"
 
 #include "hic/hic.h"
+#include "hic/hicsparse.h"
 
 #include "tests/AtlasTestEnvironment.h"
 
@@ -25,21 +26,126 @@ CASE("SparseMatrix update device") {
     A.updateDevice();
     
     std::vector<SparseMatrix::Scalar> A_data_cpy(A.data_size());
-    std::vector<SparseMatrix::Index> A_outer_cpy(A.outer_size());
-    std::vector<SparseMatrix::Index> A_inner_cpy(A.inner_size());
+    std::vector<SparseMatrix::Index>  A_outer_cpy(A.outer_size());
+    std::vector<SparseMatrix::Index>  A_inner_cpy(A.inner_size());
 
-    hicMemcpy(A_data_cpy.data(), A.device_data(), A.data_size() * sizeof(SparseMatrix::Scalar), hicMemcpyDeviceToHost);
-    hicMemcpy(A_outer_cpy.data(), A.device_outer(), A.outer_size() * sizeof(SparseMatrix::Index), hicMemcpyDeviceToHost);
-    hicMemcpy(A_inner_cpy.data(), A.device_inner(), A.inner_size() * sizeof(SparseMatrix::Index), hicMemcpyDeviceToHost);
+    hicMemcpy(A_data_cpy.data(),  A.device_data(),  A.data_size()  * sizeof(SparseMatrix::Scalar), hicMemcpyDeviceToHost);
+    hicMemcpy(A_outer_cpy.data(), A.device_outer(), A.outer_size() * sizeof(SparseMatrix::Index),  hicMemcpyDeviceToHost);
+    hicMemcpy(A_inner_cpy.data(), A.device_inner(), A.inner_size() * sizeof(SparseMatrix::Index),  hicMemcpyDeviceToHost);
 
     std::vector<SparseMatrix::Scalar> A_data_test{2., -3., 2., 2.};
-    std::vector<SparseMatrix::Index> A_outer_test{0, 2, 3, 4};
-    std::vector<SparseMatrix::Index> A_inner_test{0, 2, 1, 2};
+    std::vector<SparseMatrix::Index>  A_outer_test{0, 2, 3, 4};
+    std::vector<SparseMatrix::Index>  A_inner_test{0, 2, 1, 2};
 
     EXPECT(A_data_cpy == A_data_test);
     EXPECT(A_outer_cpy == A_outer_test);
     EXPECT(A_inner_cpy == A_inner_test);
 }
+
+void do_hicsparse_matrix_multiply(const SparseMatrix& A, const int N, const double* device_x, double* device_y);
+
+CASE("SparseMatrix hicsparse multiply") {
+    SparseMatrix A{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}};
+    array::ArrayT<double> x(3);
+    array::ArrayT<double> y(3);
+    array::make_host_view<double,1>(x).assign({1.0, 2.0, 3.0});
+
+    A.updateDevice();
+    x.updateDevice();
+    y.allocateDevice();
+
+    do_hicsparse_matrix_multiply(
+            A,
+            x.shape(0),
+            x.device_data<double>(),
+            y.device_data<double>());
+
+    // Check result
+    constexpr int N=3;
+    const double expected_y[N] = {-7.0, 4.0, 6.0};
+    y.updateHost();
+    auto hy = array::make_host_view<double,1>(y);
+    for( int i = 0; i < N; ++i ) {
+        EXPECT_EQ(hy[i], expected_y[i]);
+    }
+}
+
+void do_hicsparse_matrix_multiply(const SparseMatrix& A, const int N, const double* device_x, double* device_y) {
+    // Create sparse library handle
+    hicsparseHandle_t handle;
+    HICSPARSE_CALL( hicsparseCreate(&handle) );
+
+    static_assert(std::is_same_v<SparseMatrix::Index, int>,"Following assumes Index==int");
+    static_assert(std::is_same_v<SparseMatrix::Scalar, double>,"Following assumes Index==int");
+    hicsparseConstSpMatDescr_t matA;
+    HICSPARSE_CALL( hicsparseCreateConstCsr(
+        &matA,
+        A.rows(), A.cols(), A.nonZeros(),
+        A.device_outer(),    // row_offsets
+        A.device_inner(),    // column_indices
+        A.device_data(),     // values
+        HICSPARSE_INDEX_32I,
+        HICSPARSE_INDEX_32I,
+        HICSPARSE_INDEX_BASE_ZERO,
+        HIC_R_64F) );
+
+    // Create dense matrix descriptors
+    hicsparseConstDnVecDescr_t vecX;
+    HICSPARSE_CALL( hicsparseCreateConstDnVec(
+        &vecX,
+        N,
+        device_x,
+        HIC_R_64F) );
+
+    hicsparseDnVecDescr_t vecY;
+    HICSPARSE_CALL( hicsparseCreateDnVec(
+        &vecY,
+        N,
+        device_y,
+        HIC_R_64F) );
+
+    // Set parameters
+    const double alpha = 1.0;
+    const double beta = 0.0;
+
+    // Determine buffer size
+    size_t bufferSize = 0;
+    HICSPARSE_CALL( hicsparseSpMV_bufferSize(
+        handle,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        &alpha,
+        matA,
+        vecX,
+        &beta,
+        vecY,
+        HIC_R_64F,
+        HICSPARSE_SPMV_ALG_DEFAULT,
+        &bufferSize) );
+
+    // Allocate buffer
+    char* buffer;
+    HIC_CALL( hicMalloc(&buffer, bufferSize) );
+
+    // Perform SpMV
+    HICSPARSE_CALL( hicsparseSpMV(
+        handle,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        &alpha,
+        matA,
+        vecX,
+        &beta,
+        vecY,
+        HIC_R_64F,
+        HICSPARSE_SPMV_ALG_DEFAULT,
+        buffer) );
+
+    HIC_CALL( hicFree(buffer) );
+    HICSPARSE_CALL( hicsparseDestroyDnVec(vecY) );
+    HICSPARSE_CALL( hicsparseDestroyDnVec(vecX) );
+    HICSPARSE_CALL( hicsparseDestroySpMat(matA) );
+    HICSPARSE_CALL( hicsparseDestroy(handle) );
+}
+
 
 }  // namespace test
 }  // namespace atlas


### PR DESCRIPTION
This PR adds a sparse matrix class, with GPU memory management functionality similar to Array. The class uses eckit's SparseMatrix class internally for host-side memory storage and expose an interface similar to that of eckit's SparseMatrix class.