### PR TITLE
Add a hicsparse backend to linalg sparse

### DIFF
--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -712,6 +712,8 @@ linalg/sparse/SparseMatrixMultiply.h
 linalg/sparse/SparseMatrixMultiply.tcc
 linalg/sparse/SparseMatrixMultiply_EckitLinalg.h
 linalg/sparse/SparseMatrixMultiply_EckitLinalg.cc
+linalg/sparse/SparseMatrixMultiply_HicSparse.h
+linalg/sparse/SparseMatrixMultiply_HicSparse.cc
 linalg/sparse/SparseMatrixMultiply_OpenMP.h
 linalg/sparse/SparseMatrixMultiply_OpenMP.cc
 linalg/sparse/SparseMatrixStorage.cc
@@ -1007,6 +1009,7 @@ ecbuild_add_library( TARGET atlas
     eckit_option
     atlas_io
     hic
+    hicsparse
     $<${atlas_HAVE_EIGEN}:Eigen3::Eigen>
     $<${atlas_HAVE_OMP_CXX}:OpenMP::OpenMP_CXX>
     $<${atlas_HAVE_GRIDTOOLS_STORAGE}:GridTools::gridtools>

--- a/src/atlas/linalg/sparse/Backend.cc
+++ b/src/atlas/linalg/sparse/Backend.cc
@@ -99,6 +99,13 @@ bool Backend::available() const {
     if (t == backend::openmp::type()) {
         return true;
     }
+    if (t == backend::hicsparse::type()) {
+#if ATLAS_HAVE_GPU
+        return true;
+#else
+        return false;
+#endif
+    }
     if (t == backend::eckit_linalg::type()) {
         if (has("backend")) {
 #if ATLAS_ECKIT_HAVE_ECKIT_585

--- a/src/atlas/linalg/sparse/Backend.h
+++ b/src/atlas/linalg/sparse/Backend.h
@@ -43,6 +43,11 @@ struct eckit_linalg : Backend {
     static std::string type() { return "eckit_linalg"; }
     eckit_linalg(): Backend(type()) {}
 };
+
+struct hicsparse : Backend {
+    static std::string type() { return "hicsparse"; }
+    hicsparse(): Backend(type()) {}
+};
 }  // namespace backend
 
 

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply.h
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply.h
@@ -114,3 +114,4 @@ struct SparseMatrixMultiply {
 #include "SparseMatrixMultiply.tcc"
 #include "SparseMatrixMultiply_EckitLinalg.h"
 #include "SparseMatrixMultiply_OpenMP.h"
+#include "SparseMatrixMultiply_HicSparse.h"

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply.tcc
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply.tcc
@@ -164,6 +164,9 @@ void sparse_matrix_multiply( const Matrix& matrix, const SourceView& src, Target
 #endif
         sparse::dispatch_sparse_matrix_multiply<sparse::backend::eckit_linalg>( matrix, src, tgt, indexing, util::Config("backend",type)  );
     }
+    else if ( type == sparse::backend::hicsparse::type() ) {
+        sparse::dispatch_sparse_matrix_multiply<sparse::backend::hicsparse>( matrix, src, tgt, indexing, config  );
+    }
     else {
         throw_NotImplemented( "sparse_matrix_multiply cannot be performed with unsupported backend [" + type + "]",
                               Here() );
@@ -201,6 +204,9 @@ void sparse_matrix_multiply_add( const Matrix& matrix, const SourceView& src, Ta
     else if( eckit::linalg::LinearAlgebra::hasBackend(type) ) {
 #endif
         sparse::dispatch_sparse_matrix_multiply_add<sparse::backend::eckit_linalg>( matrix, src, tgt, indexing, util::Config("backend",type)  );
+    }
+    else if ( type == sparse::backend::hicsparse::type() ) {
+        sparse::dispatch_sparse_matrix_multiply_add<sparse::backend::hicsparse>( matrix, src, tgt, indexing, config  );
     }
     else {
         throw_NotImplemented( "sparse_matrix_multiply_add cannot be performed with unsupported backend [" + type + "]",

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_HicSparse.cc
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_HicSparse.cc
@@ -1,0 +1,329 @@
+/*
+ * (C) Copyright 2024 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "atlas/linalg/sparse/SparseMatrixMultiply_HicSparse.h"
+
+#include "atlas/parallel/omp/omp.h"
+#include "atlas/runtime/Exception.h"
+
+#include "hic/hic.h"
+#include "hic/hic_library_types.h"
+#include "hic/hicsparse.h"
+
+namespace {
+
+class HicSparseHandleRAIIWrapper {
+public:
+    HicSparseHandleRAIIWrapper() { hicsparseCreate(&handle_); };
+    ~HicSparseHandleRAIIWrapper() { hicsparseDestroy(handle_); }
+    hicsparseHandle_t value() { return handle_; }
+private:
+    hicsparseHandle_t handle_;
+};
+
+hicsparseHandle_t getDefaultHicSparseHandle() {
+    static auto handle = HicSparseHandleRAIIWrapper();
+    return handle.value();
+}
+
+template<typename T>
+constexpr hicsparseIndexType_t getHicsparseIndexType() {
+    using base_type = std::remove_const_t<T>;
+    if constexpr (std::is_same_v<base_type, int>) {
+        return HICSPARSE_INDEX_32I;
+    } else {
+        static_assert(std::is_same_v<base_type, long>, "Unsupported index type");
+        return HICSPARSE_INDEX_64I;
+    }
+}
+
+template<typename T>
+constexpr auto getHicsparseValueType() {
+    using base_type = std::remove_const_t<T>;
+    if constexpr (std::is_same_v<base_type, float>) {
+        return HIC_R_32F;
+    } else {
+        static_assert(std::is_same_v<base_type, double>, "Unsupported value type");\
+        return HIC_R_64F;
+    }
+}
+
+template<atlas::linalg::Indexing IndexLayout, typename T>
+hicsparseOrder_t getHicsparseOrder(const atlas::linalg::View<T, 2>& v) {
+    constexpr int row_idx = (IndexLayout == atlas::linalg::Indexing::layout_left) ? 0 : 1;
+    constexpr int col_idx = (IndexLayout == atlas::linalg::Indexing::layout_left) ? 1 : 0;
+
+    if (v.stride(row_idx) == 1) {
+        return HICSPARSE_ORDER_COL;
+    } else if (v.stride(col_idx) == 1) {
+        return HICSPARSE_ORDER_ROW;
+    } else {
+        atlas::throw_Exception("Unsupported dense matrix memory order", Here());
+        return HICSPARSE_ORDER_COL;
+    }
+}
+
+template<typename T>
+int64_t getLeadingDimension(const atlas::linalg::View<T, 2>& v) {
+    if (v.stride(0) == 1) {
+        return v.stride(1);
+    } else if (v.stride(1) == 1) {
+        return v.stride(0);
+    } else {
+        atlas::throw_Exception("Unsupported dense matrix memory order", Here());
+        return 0;
+    }
+}
+
+}
+
+namespace atlas {
+namespace linalg {
+namespace sparse {
+
+template <typename Value>
+void hsSpMV(const SparseMatrixView<Value>& W, const View<const Value, 1>& src, Value beta, View<Value, 1>& tgt) {
+    // Assume that W, src, and tgt are all device views
+
+    using Index = typename SparseMatrixView<Value>::index_type;
+
+    ATLAS_ASSERT(src.shape(0) >= W.cols());
+    ATLAS_ASSERT(tgt.shape(0) >= W.rows());
+
+    auto handle = getDefaultHicSparseHandle();
+
+    // Create a sparse matrix descriptor
+    hicsparseConstSpMatDescr_t matA;
+    HICSPARSE_CALL(hicsparseCreateConstCsr(
+        &matA,
+        W.rows(), W.cols(), W.nnz(),
+        W.outer(),    // row_offsets
+        W.inner(),    // column_indices
+        W.value(),    // values
+        getHicsparseIndexType<Index>(),
+        getHicsparseIndexType<Index>(),  
+        HICSPARSE_INDEX_BASE_ZERO,
+        getHicsparseValueType<Value>()));
+
+    // Create dense matrix descriptors
+    hicsparseConstDnVecDescr_t vecX;
+    HICSPARSE_CALL(hicsparseCreateConstDnVec(
+        &vecX,
+        static_cast<int64_t>(W.cols()), 
+        src.data(),
+        getHicsparseValueType<Value>()));
+
+    hicsparseDnVecDescr_t vecY;
+    HICSPARSE_CALL(hicsparseCreateDnVec(
+        &vecY,
+        W.rows(),
+        tgt.data(),
+        getHicsparseValueType<Value>()));
+
+    const Value alpha = 1;
+
+    // Determine buffer size
+    size_t bufferSize = 0;
+    HICSPARSE_CALL(hicsparseSpMV_bufferSize(
+        handle,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        &alpha,
+        matA,
+        vecX,
+        &beta,
+        vecY,
+        getHicsparseValueType<Value>(),
+        HICSPARSE_SPMV_ALG_DEFAULT,
+        &bufferSize));
+
+    // Allocate buffer
+    char* buffer;
+    HIC_CALL(hicMalloc(&buffer, bufferSize));
+    
+    // Perform SpMV
+    HICSPARSE_CALL(hicsparseSpMV(
+        handle,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        &alpha,
+        matA,
+        vecX,
+        &beta,
+        vecY,
+        getHicsparseValueType<Value>(),
+        HICSPARSE_SPMV_ALG_DEFAULT,
+        buffer));
+
+    HIC_CALL(hicFree(buffer));
+    HICSPARSE_CALL(hicsparseDestroyDnVec(vecX));
+    HICSPARSE_CALL(hicsparseDestroyDnVec(vecY));
+    HICSPARSE_CALL(hicsparseDestroySpMat(matA));
+
+    HIC_CALL(hicDeviceSynchronize());
+}
+
+
+template <Indexing IndexLayout, typename Value>
+void hsSpMM(const SparseMatrixView<Value>& W, const View<const Value, 2>& src, Value beta, View<Value, 2>& tgt) {
+    // Assume that W, src, and tgt are all device views
+
+    using Index = typename SparseMatrixView<Value>::index_type;
+
+    constexpr int row_idx = (IndexLayout == Indexing::layout_left) ? 0 : 1;
+    constexpr int col_idx = (IndexLayout == Indexing::layout_left) ? 1 : 0;
+
+    ATLAS_ASSERT(src.shape(row_idx) >= W.cols());
+    ATLAS_ASSERT(tgt.shape(row_idx) >= W.rows());
+    ATLAS_ASSERT(src.shape(col_idx) == tgt.shape(col_idx));
+
+    auto handle = getDefaultHicSparseHandle();
+
+    // Create a sparse matrix descriptor
+    hicsparseConstSpMatDescr_t matA;
+    HICSPARSE_CALL(hicsparseCreateConstCsr(
+        &matA,
+        W.rows(), W.cols(), W.nnz(),
+        W.outer(),    // row_offsets
+        W.inner(),    // column_indices
+        W.value(),    // values
+        getHicsparseIndexType<Index>(),
+        getHicsparseIndexType<Index>(),
+        HICSPARSE_INDEX_BASE_ZERO,
+        getHicsparseValueType<Value>()));
+
+    // Create dense matrix descriptors
+    hicsparseConstDnMatDescr_t matB;
+    HICSPARSE_CALL(hicsparseCreateConstDnMat(
+        &matB,
+        W.cols(), src.shape(col_idx),
+        getLeadingDimension(src),
+        src.data(),
+        getHicsparseValueType<Value>(),
+        getHicsparseOrder<IndexLayout>(src)));
+
+    hicsparseDnMatDescr_t matC;
+    HICSPARSE_CALL(hicsparseCreateDnMat(
+        &matC,
+        W.rows(), tgt.shape(col_idx),
+        getLeadingDimension(tgt),
+        tgt.data(),
+        getHicsparseValueType<Value>(),
+        getHicsparseOrder<IndexLayout>(tgt)));
+
+    const Value alpha = 1;
+
+    // Determine buffer size
+    size_t bufferSize = 0;
+    HICSPARSE_CALL(hicsparseSpMM_bufferSize(
+        handle,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        &alpha,
+        matA,
+        matB,
+        &beta,
+        matC,
+        getHicsparseValueType<Value>(),
+        HICSPARSE_SPMM_ALG_DEFAULT,
+        &bufferSize));
+
+    // Allocate buffer
+    char* buffer;
+    HIC_CALL(hicMalloc(&buffer, bufferSize));
+
+    // Perform SpMM
+    HICSPARSE_CALL(hicsparseSpMM(
+        handle,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        HICSPARSE_OPERATION_NON_TRANSPOSE,
+        &alpha,
+        matA,
+        matB,
+        &beta,
+        matC,
+        getHicsparseValueType<Value>(),
+        HICSPARSE_SPMM_ALG_DEFAULT,
+        buffer));
+
+    HIC_CALL(hicFree(buffer));
+    HICSPARSE_CALL(hicsparseDestroyDnMat(matC));
+    HICSPARSE_CALL(hicsparseDestroyDnMat(matB));
+    HICSPARSE_CALL(hicsparseDestroySpMat(matA));
+
+    HIC_CALL(hicDeviceSynchronize());
+}
+
+template <typename ScalarValue>
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 1, ScalarValue, const ScalarValue, ScalarValue>::multiply(
+    const SparseMatrixView<ScalarValue>& W, const View<ScalarValue const, 1>& src, View<ScalarValue, 1>& tgt, const Configuration&) {
+    ScalarValue beta = 0;
+    hsSpMV(W, src, beta, tgt);
+}
+
+template <typename ScalarValue>
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 1, ScalarValue, const ScalarValue, ScalarValue>::multiply_add(
+    const SparseMatrixView<ScalarValue>& W, const View<ScalarValue const, 1>& src, View<ScalarValue, 1>& tgt, const Configuration&) {
+    ScalarValue beta = 1;
+    hsSpMV(W, src, beta, tgt);
+}
+
+template <typename ScalarValue>
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 2, ScalarValue, const ScalarValue, ScalarValue>::multiply(
+    const SparseMatrixView<ScalarValue>& W, const View<ScalarValue const, 2>& src, View<ScalarValue, 2>& tgt, const Configuration&) {
+    ScalarValue beta = 0;
+    hsSpMM<Indexing::layout_left>(W, src, beta, tgt);
+}
+
+template <typename ScalarValue>
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 2, ScalarValue, const ScalarValue, ScalarValue>::multiply_add(
+    const SparseMatrixView<ScalarValue>& W, const View<ScalarValue const, 2>& src, View<ScalarValue, 2>& tgt, const Configuration&) {
+    ScalarValue beta = 1;
+    hsSpMM<Indexing::layout_left>(W, src, beta, tgt);
+}
+
+template <typename ScalarValue>
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 1, ScalarValue, const ScalarValue, ScalarValue>::multiply(
+    const SparseMatrixView<ScalarValue>& W, const View<ScalarValue const, 1>& src, View<ScalarValue, 1>& tgt, const Configuration&) {
+    ScalarValue beta = 0;
+    hsSpMV(W, src, beta, tgt);
+}
+
+template <typename ScalarValue>
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 1, ScalarValue, const ScalarValue, ScalarValue>::multiply_add(
+    const SparseMatrixView<ScalarValue>& W, const View<ScalarValue const, 1>& src, View<ScalarValue, 1>& tgt, const Configuration&) {
+    ScalarValue beta = 1;
+    hsSpMV(W, src, beta, tgt);
+}
+
+template <typename ScalarValue>
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 2, ScalarValue, const ScalarValue, ScalarValue>::multiply(
+    const SparseMatrixView<ScalarValue>& W, const View<ScalarValue const, 2>& src, View<ScalarValue, 2>& tgt, const Configuration&) {
+    ScalarValue beta = 0;
+    hsSpMM<Indexing::layout_right>(W, src, beta, tgt);
+}
+
+template <typename ScalarValue>
+void SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 2, ScalarValue, const ScalarValue, ScalarValue>::multiply_add(
+    const SparseMatrixView<ScalarValue>& W, const View<ScalarValue const, 2>& src, View<ScalarValue, 2>& tgt, const Configuration&) {
+    ScalarValue beta = 1;
+    hsSpMM<Indexing::layout_right>(W, src, beta, tgt);
+}
+
+#define EXPLICIT_TEMPLATE_INSTANTIATION(TYPE)                                                                 \
+    template struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left,  1, TYPE, TYPE const, TYPE>; \
+    template struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left,  2, TYPE, TYPE const, TYPE>; \
+    template struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 1, TYPE, TYPE const, TYPE>; \
+    template struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 2, TYPE, TYPE const, TYPE>;
+
+EXPLICIT_TEMPLATE_INSTANTIATION(double);
+EXPLICIT_TEMPLATE_INSTANTIATION(float);
+
+}  // namespace sparse
+}  // namespace linalg
+}  // namespace atlas

--- a/src/atlas/linalg/sparse/SparseMatrixMultiply_HicSparse.h
+++ b/src/atlas/linalg/sparse/SparseMatrixMultiply_HicSparse.h
@@ -1,0 +1,53 @@
+/*
+ * (C) Copyright 2024 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#pragma once
+
+#include "atlas/linalg/sparse/SparseMatrixMultiply.h"
+
+namespace atlas {
+namespace linalg {
+namespace sparse {
+
+template <typename ScalarValue>
+struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 1, ScalarValue, const ScalarValue, ScalarValue> {
+    static void multiply(const SparseMatrixView<ScalarValue>& W, const View<const ScalarValue, 1>& src, View<ScalarValue, 1>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrixView<ScalarValue>& W, const View<const ScalarValue, 1>& src, View<ScalarValue, 1>& tgt,
+                      const Configuration&);
+};
+
+template <typename ScalarValue>
+struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_left, 2, ScalarValue, const ScalarValue, ScalarValue> {
+    static void multiply(const SparseMatrixView<ScalarValue>& W, const View<const ScalarValue, 2>& src, View<ScalarValue, 2>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrixView<ScalarValue>& W, const View<const ScalarValue, 2>& src, View<ScalarValue, 2>& tgt,
+                      const Configuration&);
+};
+
+template <typename ScalarValue>
+struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 1, ScalarValue, const ScalarValue, ScalarValue> {
+    static void multiply(const SparseMatrixView<ScalarValue>& W, const View<const ScalarValue, 1>& src, View<ScalarValue, 1>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrixView<ScalarValue>& W, const View<const ScalarValue, 1>& src, View<ScalarValue, 1>& tgt,
+                      const Configuration&);
+};
+
+template <typename ScalarValue>
+struct SparseMatrixMultiply<backend::hicsparse, Indexing::layout_right, 2, ScalarValue, const ScalarValue, ScalarValue> {
+    static void multiply(const SparseMatrixView<ScalarValue>& W, const View<const ScalarValue, 2>& src, View<ScalarValue, 2>& tgt,
+                      const Configuration&);
+    static void multiply_add(const SparseMatrixView<ScalarValue>& W, const View<const ScalarValue, 2>& src, View<ScalarValue, 2>& tgt,
+                      const Configuration&);
+};
+
+}  // namespace sparse
+}  // namespace linalg
+}  // namespace atlas

--- a/src/tests/linalg/CMakeLists.txt
+++ b/src/tests/linalg/CMakeLists.txt
@@ -8,6 +8,16 @@
 
 if( atlas_HAVE_ATLAS_FUNCTIONSPACE )
 
+ecbuild_add_test( TARGET atlas_test_linalg_sparse_gpu
+    SOURCES test_linalg_sparse_gpu.cc
+    LIBS    atlas
+    ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+    CONDITION HAVE_CUDA OR HAVE_HIP
+)
+if( TARGET atlas_test_linalg_sparse_gpu )
+  set_tests_properties( atlas_test_linalg_sparse_gpu PROPERTIES LABELS "gpu")
+endif()
+
 ecbuild_add_test( TARGET atlas_test_linalg_sparse
     SOURCES test_linalg_sparse.cc
     LIBS    atlas

--- a/src/tests/linalg/helper_linalg_sparse.h
+++ b/src/tests/linalg/helper_linalg_sparse.h
@@ -1,0 +1,128 @@
+/*
+ * (C) Copyright 2024- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <vector>
+
+#include "eckit/linalg/Matrix.h"
+#include "eckit/linalg/Vector.h"
+
+#include "atlas/array.h"
+#include "atlas/linalg/sparse.h"
+
+using namespace atlas::linalg;
+
+namespace atlas {
+namespace test {
+
+class Vector : public eckit::linalg::Vector {
+public:
+    using Scalar = eckit::linalg::Scalar;
+    using eckit::linalg::Vector::Vector;
+    Vector(const std::initializer_list<Scalar>& v): eckit::linalg::Vector::Vector(v.size()) {
+        size_t i = 0;
+        for (auto& s : v) {
+            operator[](i++) = s;
+        }
+    }
+};
+
+class Matrix : public eckit::linalg::Matrix {
+public:
+    using Scalar = eckit::linalg::Scalar;
+    using eckit::linalg::Matrix::Matrix;
+
+    Matrix(const std::initializer_list<std::vector<Scalar>>& m):
+        eckit::linalg::Matrix::Matrix(m.size(), m.size() ? m.begin()->size() : 0) {
+        size_t r = 0;
+        for (auto& row : m) {
+            for (size_t c = 0; c < cols(); ++c) {
+                operator()(r, c) = row[c];
+            }
+            ++r;
+        }
+    }
+};
+
+// 2D array constructable from eckit::linalg::Matrix
+// Indexing/memorylayout and data type can be customized for testing
+template <typename Value, Indexing indexing = Indexing::layout_left>
+struct ArrayMatrix {
+    array::ArrayView<Value, 2> view() {
+        return host_view();
+    }
+    array::ArrayView<Value, 2> host_view() {
+        array.updateHost();
+        return array::make_host_view<Value, 2>(array);
+    }
+    array::ArrayView<Value, 2> device_view() {
+        array.updateDevice();
+        return array::make_device_view<Value, 2>(array);
+    }
+    ArrayMatrix(const eckit::linalg::Matrix& m): ArrayMatrix(m.rows(), m.cols()) {
+        auto view_ = array::make_view<Value, 2>(array);
+        for (int r = 0; r < m.rows(); ++r) {
+            for (int c = 0; c < m.cols(); ++c) {
+                auto& v = layout_left ? view_(r, c) : view_(c, r);
+                v       = m(r, c);
+            }
+        }
+    }
+    ArrayMatrix(int r, int c): array(make_shape(r, c)) {}
+
+private:
+    static constexpr bool layout_left = (indexing == Indexing::layout_left);
+    static array::ArrayShape make_shape(int rows, int cols) {
+        return layout_left ? array::make_shape(rows, cols) : array::make_shape(cols, rows);
+    }
+    array::ArrayT<Value> array;
+};
+
+// 1D array constructable from eckit::linalg::Vector
+template <typename Value>
+struct ArrayVector {
+    array::ArrayView<Value, 1> view() {
+        return host_view();
+    }
+    array::ArrayView<Value, 1> host_view() {
+        array.updateHost();
+        return array::make_host_view<Value, 1>(array);
+    }
+    array::ArrayView<Value, 1> device_view() {
+        array.updateDevice();
+        return array::make_device_view<Value, 1>(array);
+    }
+    ArrayVector(const eckit::linalg::Vector& v): ArrayVector(v.size()) {
+        auto view_ = array::make_view<Value, 1>(array);
+        for (int n = 0; n < v.size(); ++n) {
+            view_[n] = v[n];
+        }
+    }
+    ArrayVector(int size): array(size) {}
+
+private:
+    array::ArrayT<Value> array;
+};
+
+//----------------------------------------------------------------------------------------------------------------------
+
+template <typename T>
+void expect_equal(T* v, T* r, size_t s) {
+    EXPECT(is_approximately_equal(eckit::testing::make_view(v, s), eckit::testing::make_view(r, s), T(1.e-5)));
+}
+
+template <class T1, class T2>
+void expect_equal(const T1& v, const T2& r) {
+    expect_equal(v.data(), r.data(), std::min(v.size(), r.size()));
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace atlas

--- a/src/tests/linalg/test_linalg_sparse.cc
+++ b/src/tests/linalg/test_linalg_sparse.cc
@@ -8,16 +8,8 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <tuple>
-#include <vector>
-
-#include "eckit/linalg/Matrix.h"
-#include "eckit/linalg/Vector.h"
-
-#include "atlas/array.h"
-#include "atlas/linalg/sparse.h"
-
 #include "tests/AtlasTestEnvironment.h"
+#include "tests/linalg/helper_linalg_sparse.h"
 
 
 using namespace atlas::linalg;
@@ -32,92 +24,7 @@ using SparseMatrix = eckit::linalg::SparseMatrix;
 // strings to be used in the tests
 static std::string eckit_linalg = sparse::backend::eckit_linalg::type();
 static std::string openmp       = sparse::backend::openmp::type();
-
-//----------------------------------------------------------------------------------------------------------------------
-
-// Only reason to define these derived classes is for nicer constructors and convenience in the tests
-
-class Vector : public eckit::linalg::Vector {
-public:
-    using Scalar = eckit::linalg::Scalar;
-    using eckit::linalg::Vector::Vector;
-    Vector(const std::initializer_list<Scalar>& v): eckit::linalg::Vector::Vector(v.size()) {
-        size_t i = 0;
-        for (auto& s : v) {
-            operator[](i++) = s;
-        }
-    }
-};
-
-class Matrix : public eckit::linalg::Matrix {
-public:
-    using Scalar = eckit::linalg::Scalar;
-    using eckit::linalg::Matrix::Matrix;
-
-    Matrix(const std::initializer_list<std::vector<Scalar>>& m):
-        eckit::linalg::Matrix::Matrix(m.size(), m.size() ? m.begin()->size() : 0) {
-        size_t r = 0;
-        for (auto& row : m) {
-            for (size_t c = 0; c < cols(); ++c) {
-                operator()(r, c) = row[c];
-            }
-            ++r;
-        }
-    }
-};
-
-// 2D array constructable from eckit::linalg::Matrix
-// Indexing/memorylayout and data type can be customized for testing
-template <typename Value, Indexing indexing = Indexing::layout_left>
-struct ArrayMatrix {
-    array::ArrayView<Value, 2>& view() { return view_; }
-    ArrayMatrix(const eckit::linalg::Matrix& m): ArrayMatrix(m.rows(), m.cols()) {
-        for (int r = 0; r < m.rows(); ++r) {
-            for (int c = 0; c < m.cols(); ++c) {
-                auto& v = layout_left ? view_(r, c) : view_(c, r);
-                v       = m(r, c);
-            }
-        }
-    }
-    ArrayMatrix(int r, int c): array(make_shape(r, c)), view_(array::make_view<Value, 2>(array)) {}
-
-private:
-    static constexpr bool layout_left = (indexing == Indexing::layout_left);
-    static array::ArrayShape make_shape(int rows, int cols) {
-        return layout_left ? array::make_shape(rows, cols) : array::make_shape(cols, rows);
-    }
-    array::ArrayT<Value> array;
-    array::ArrayView<Value, 2> view_;
-};
-
-// 1D array constructable from eckit::linalg::Vector
-template <typename Value>
-struct ArrayVector {
-    array::ArrayView<Value, 1>& view() { return view_; }
-    ArrayVector(const eckit::linalg::Vector& v): ArrayVector(v.size()) {
-        for (int n = 0; n < v.size(); ++n) {
-            view_[n] = v[n];
-        }
-    }
-    ArrayVector(int size): array(size), view_(array::make_view<Value, 1>(array)) {}
-
-private:
-    array::ArrayT<Value> array;
-    array::ArrayView<Value, 1> view_;
-};
-
-
-//----------------------------------------------------------------------------------------------------------------------
-
-template <typename T>
-void expect_equal(T* v, T* r, size_t s) {
-    EXPECT(is_approximately_equal(eckit::testing::make_view(v, s), eckit::testing::make_view(r, s), T(1.e-5)));
-}
-
-template <class T1, class T2>
-void expect_equal(const T1& v, const T2& r) {
-    expect_equal(v.data(), r.data(), std::min(v.size(), r.size()));
-}
+static std::string hicsparse    = sparse::backend::hicsparse::type();
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -185,15 +92,21 @@ CASE("test backend functionalities") {
     EXPECT_EQ(sparse::current_backend().getString("backend", "undefined"), "undefined");
     EXPECT_EQ(sparse::default_backend(eckit_linalg).getString("backend"), "default");
 
+    sparse::current_backend(hicsparse);
+    EXPECT_EQ(sparse::current_backend().type(), "hicsparse");
+    EXPECT_EQ(sparse::current_backend().getString("backend", "undefined"), "undefined");
+
     sparse::default_backend(eckit_linalg).set("backend", "generic");
     EXPECT_EQ(sparse::default_backend(eckit_linalg).getString("backend"), "generic");
 
     const sparse::Backend backend_default      = sparse::Backend();
     const sparse::Backend backend_openmp       = sparse::backend::openmp();
     const sparse::Backend backend_eckit_linalg = sparse::backend::eckit_linalg();
-    EXPECT_EQ(backend_default.type(), openmp);
+    const sparse::Backend backend_hicsparse    = sparse::backend::hicsparse();
+    EXPECT_EQ(backend_default.type(), hicsparse);
     EXPECT_EQ(backend_openmp.type(), openmp);
     EXPECT_EQ(backend_eckit_linalg.type(), eckit_linalg);
+    EXPECT_EQ(backend_hicsparse.type(), hicsparse);
 
     EXPECT_EQ(std::string(backend_openmp), openmp);
     EXPECT_EQ(std::string(backend_eckit_linalg), eckit_linalg);
@@ -252,29 +165,36 @@ CASE("sparse_matrix vector multiply (spmv)") {
         SECTION("View of atlas::Array [backend=" + backend + "]") {
             ArrayVector<double> x(Vector{1., 2., 3.});
             ArrayVector<double> y(3);
-            sparse_matrix_multiply(A, x.view(), y.view());
+            auto x_view = x.view();
+            auto y_view = y.view();
+            sparse_matrix_multiply(A, x_view, y_view);
             expect_equal(y.view(), Vector{-7., 4., 6.});
             // sparse_matrix_multiply of sparse matrix and vector of non-matching sizes should fail
             {
                 ArrayVector<double> x2(2);
-                EXPECT_THROWS_AS(sparse_matrix_multiply(A, x2.view(), y.view()), eckit::AssertionFailed);
+                auto x2_view = x2.view();
+                EXPECT_THROWS_AS(sparse_matrix_multiply(A, x2_view, y_view), eckit::AssertionFailed);
             }
         }
 
         SECTION("View of atlas::Array [backend=" + backend + "]") {
             ArrayVector<double> x(Vector{1., 2., 3.});
             ArrayVector<double> y(3);
+            auto x_view = x.view();
+            auto y_view = y.view();
             auto spmm = SparseMatrixMultiply{backend};
-            spmm(A, x.view(), y.view());
-            expect_equal(y.view(), Vector{-7., 4., 6.});
+            spmm(A, x_view, y_view);
+            expect_equal(y_view, Vector{-7., 4., 6.});
         }
 
         SECTION("View of atlas::Array [backend=" + backend + "]") {
             ArrayVector<double> x(Vector{1., 2., 3.});
             ArrayVector<double> y(3);
+            auto x_view = x.view();
+            auto y_view = y.view();
             auto spmm = SparseMatrixMultiply{backend};
-            spmm.multiply(A, x.view(), y.view());
-            expect_equal(y.view(), Vector{-7., 4., 6.});
+            spmm.multiply(A, x_view, y_view);
+            expect_equal(y_view, Vector{-7., 4., 6.});
         }
     }
 }
@@ -294,21 +214,26 @@ CASE("sparse_matrix vector multiply-add (spmv)") {
         SECTION("View of atlas::Array [backend=" + backend + "]") {
             ArrayVector<double> x(Vector{1., 2., 3.});
             ArrayVector<double> y(Vector{4., 5., 6.});
-            sparse_matrix_multiply_add(A, x.view(), y.view());
+            auto x_view = x.view();
+            auto y_view = y.view();
+            sparse_matrix_multiply_add(A, x_view, y_view);
             expect_equal(y.view(), Vector{-3., 9., 12.});
             // sparse_matrix_multiply_add of sparse matrix and vector of non-matching sizes should fail
             {
                 ArrayVector<double> x2(2);
-                EXPECT_THROWS_AS(sparse_matrix_multiply_add(A, x2.view(), y.view()), eckit::AssertionFailed);
+                auto x2_view = x2.view();
+                EXPECT_THROWS_AS(sparse_matrix_multiply_add(A, x2_view, y_view), eckit::AssertionFailed);
             }
         }
 
         SECTION("sparse_matrix_multiply_add [backend=" + backend + "]") {
             ArrayVector<double> x(Vector{1., 2., 3.});
             ArrayVector<double> y(Vector{1., 2., 3.});
+            auto x_view = x.view();
+            auto y_view = y.view();
             auto spmm = SparseMatrixMultiply{sparse::backend::openmp()};
-            spmm.multiply_add(A, x.view(), y.view());
-            expect_equal(y.view(), Vector{-6., 6., 9.});
+            spmm.multiply_add(A, x_view, y_view);
+            expect_equal(y_view, Vector{-6., 6., 9.});
         }
     }
 }
@@ -347,8 +272,10 @@ CASE("sparse_matrix matrix multiply (spmm)") {
         SECTION("View of atlas::Array PointsRight [backend=" + sparse::current_backend().type() + "]") {
             ArrayMatrix<double, Indexing::layout_right> ma(m);
             ArrayMatrix<double, Indexing::layout_right> c(3, 2);
-            sparse_matrix_multiply(A, ma.view(), c.view(), Indexing::layout_right);
-            expect_equal(c.view(), c_exp);
+            auto ma_view = ma.view();
+            auto c_view  = c.view();
+            sparse_matrix_multiply(A, ma_view, c_view, Indexing::layout_right);
+            expect_equal(c_view, c_exp);
         }
     }
 
@@ -357,8 +284,10 @@ CASE("sparse_matrix matrix multiply (spmm)") {
         auto backend = sparse::backend::openmp();
         ArrayMatrix<float> ma(m);
         ArrayMatrix<float> c(3, 2);
-        sparse_matrix_multiply(A, ma.view(), c.view(), backend);
-        expect_equal(c.view(), ArrayMatrix<float>(c_exp).view());
+        auto ma_view = ma.view();
+        auto c_view  = c.view();
+        sparse_matrix_multiply(A, ma_view, c_view, backend);
+        expect_equal(c_view, ArrayMatrix<float>(c_exp).view());
     }
 
     SECTION("SparseMatrixMultiply [backend=openmp] 1") {
@@ -366,8 +295,10 @@ CASE("sparse_matrix matrix multiply (spmm)") {
         auto spmm = SparseMatrixMultiply{sparse::backend::openmp()};
         ArrayMatrix<float> ma(m);
         ArrayMatrix<float> c(3, 2);
-        spmm(A, ma.view(), c.view());
-        expect_equal(c.view(), ArrayMatrix<float>(c_exp).view());
+        auto ma_view = ma.view();
+        auto c_view  = c.view();
+        spmm(A, ma_view, c_view);
+        expect_equal(c_view, ArrayMatrix<float>(c_exp).view());
     }
 
     SECTION("SparseMatrixMultiply [backend=openmp] 2") {
@@ -375,8 +306,10 @@ CASE("sparse_matrix matrix multiply (spmm)") {
         auto spmm = SparseMatrixMultiply{openmp};
         ArrayMatrix<float> ma(m);
         ArrayMatrix<float> c(3, 2);
-        spmm(A, ma.view(), c.view());
-        expect_equal(c.view(), ArrayMatrix<float>(c_exp).view());
+        auto ma_view = ma.view();
+        auto c_view  = c.view();
+        spmm(A, ma_view, c_view);
+        expect_equal(c_view, ArrayMatrix<float>(c_exp).view());
     }
 
     SECTION("SparseMatrixMultiply::multiply [backend=openmp]") {
@@ -384,8 +317,10 @@ CASE("sparse_matrix matrix multiply (spmm)") {
         auto spmm = SparseMatrixMultiply{openmp};
         ArrayMatrix<float> ma(m);
         ArrayMatrix<float> c(3, 2);
-        spmm.multiply(A, ma.view(), c.view());
-        expect_equal(c.view(), ArrayMatrix<float>(c_exp).view());
+        auto ma_view = ma.view();
+        auto c_view  = c.view();
+        spmm.multiply(A, ma_view, c_view);
+        expect_equal(c_view, ArrayMatrix<float>(c_exp).view());
     }
 }
 
@@ -404,24 +339,30 @@ CASE("sparse_matrix matrix multiply-add (spmm)") {
         SECTION("View of atlas::Array PointsRight [backend=" + sparse::current_backend().type() + "]") {
             ArrayMatrix<double, Indexing::layout_right> x(m);
             ArrayMatrix<double, Indexing::layout_right> y(m);
-            sparse_matrix_multiply_add(A, x.view(), y.view(), Indexing::layout_right);
-            expect_equal(y.view(), y_exp);
+            auto x_view = x.view();
+            auto y_view = y.view();
+            sparse_matrix_multiply_add(A, x_view, y_view, Indexing::layout_right);
+            expect_equal(y_view, y_exp);
         }
     }
 
     SECTION("sparse_matrix_multiply_add [backend=openmp]") {
         ArrayMatrix<double> x(m);
         ArrayMatrix<double> y(m);
-        sparse_matrix_multiply_add(A, x.view(), y.view(), sparse::backend::openmp());
-        expect_equal(y.view(), ArrayMatrix<double>(y_exp).view());
+        auto x_view = x.view();
+        auto y_view = y.view();
+        sparse_matrix_multiply_add(A, x_view, y_view, sparse::backend::openmp());
+        expect_equal(y_view, ArrayMatrix<double>(y_exp).view());
     }
 
     SECTION("SparseMatrixMultiply::multiply_add [backend=openmp]") {
         auto spmm = SparseMatrixMultiply{sparse::backend::openmp()};
         ArrayMatrix<double> x(m);
         ArrayMatrix<double> y(m);
-        spmm.multiply_add(A, x.view(), y.view());
-        expect_equal(y.view(), ArrayMatrix<double>(y_exp).view());
+        auto x_view = x.view();
+        auto y_view = y.view();
+        spmm.multiply_add(A, x_view, y_view);
+        expect_equal(y_view, ArrayMatrix<double>(y_exp).view());
     }
 }
 

--- a/src/tests/linalg/test_linalg_sparse_gpu.cc
+++ b/src/tests/linalg/test_linalg_sparse_gpu.cc
@@ -1,0 +1,210 @@
+/*
+ * (C) Copyright 2024- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "tests/AtlasTestEnvironment.h"
+#include "tests/linalg/helper_linalg_sparse.h"
+
+
+using namespace atlas::linalg;
+
+namespace atlas {
+namespace test {
+
+using SparseMatrix = eckit::linalg::SparseMatrix;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// strings to be used in the tests
+static std::string hicsparse = sparse::backend::hicsparse::type();
+
+//----------------------------------------------------------------------------------------------------------------------
+
+template<typename ValueTy>
+atlas::linalg::SparseMatrixStorage createSparseMatrixStorage() {
+    auto S = make_sparse_matrix_storage<ValueTy>(
+        eckit::linalg::SparseMatrix{3, 3, {{0, 0, 2.}, {0, 2, -3.}, {1, 1, 2.}, {2, 2, 2.}}}
+    );
+    S.updateDevice();
+    return S;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+CASE("sparse-matrix vector multiply (spmv) in double [backend=hicsparse]") {
+    // "square" matrix
+    // A =  2  . -3
+    //      .  2  .
+    //      .  .  2
+    // x = 1 2 3
+    // y = 1 2 3
+    
+    sparse::current_backend(hicsparse);
+    
+    auto A = createSparseMatrixStorage<double>();
+    auto A_device_view = make_device_view<double,int>(A);
+    
+    SECTION("View of atlas::Array [backend=hicsparse]") {
+        ArrayVector<double> x(Vector{1., 2., 3.});
+        ArrayVector<double> y(3);
+        const auto x_device_view = x.device_view();
+        auto y_device_view = y.device_view();
+        sparse_matrix_multiply(A_device_view, x_device_view, y_device_view);
+        expect_equal(y.host_view(), ArrayVector<double>(Vector{-7., 4., 6.}).host_view());
+        // sparse_matrix_multiply of sparse matrix and vector of non-matching sizes should fail
+        {
+            ArrayVector<double> x2(2);
+            auto x2_device_view = x2.device_view();
+            EXPECT_THROWS_AS(sparse_matrix_multiply(A_device_view, x2_device_view, y_device_view), eckit::AssertionFailed);
+        }
+    }
+
+    SECTION("sparse_matrix_multiply_add [backend=hicsparse]") {
+        ArrayVector<double> x(Vector{1., 2., 3.});
+        ArrayVector<double> y(Vector{4., 5., 6.});
+        auto x_device_view = x.device_view();
+        auto y_device_view = y.device_view();
+        sparse_matrix_multiply_add(A_device_view, x_device_view, y_device_view);
+        expect_equal(y.host_view(), ArrayVector<double>(Vector{-3., 9., 12.}).host_view());
+        // sparse_matrix_multiply of sparse matrix and vector of non-matching sizes should fail
+        {
+            ArrayVector<double> x2(2);
+            auto x2_device_view = x2.device_view();
+            EXPECT_THROWS_AS(sparse_matrix_multiply_add(A_device_view, x2_device_view, y_device_view), eckit::AssertionFailed);
+        }
+    }
+}
+
+CASE("sparse-matrix vector multiply (spmv) in float [backend=hicsparse]") {
+    // "square" matrix
+    // A =  2  . -3
+    //      .  2  .
+    //      .  .  2
+    // x = 1 2 3
+    // y = 1 2 3
+    
+    sparse::current_backend(hicsparse);
+    
+    auto A = createSparseMatrixStorage<float>();
+    auto A_device_view = make_device_view<float,int>(A);
+    
+    SECTION("View of atlas::Array [backend=hicsparse]") {
+        ArrayVector<float> x(Vector{1., 2., 3.});
+        ArrayVector<float> y(3);
+        const auto x_device_view = x.device_view();
+        auto y_device_view = y.device_view();
+        sparse_matrix_multiply(A_device_view, x_device_view, y_device_view);
+        expect_equal(y.host_view(), ArrayVector<float>(Vector{-7., 4., 6.}).host_view());
+        // sparse_matrix_multiply of sparse matrix and vector of non-matching sizes should fail
+        {
+            ArrayVector<float> x2(2);
+            auto x2_device_view = x2.device_view();
+            EXPECT_THROWS_AS(sparse_matrix_multiply(A_device_view, x2_device_view, y_device_view), eckit::AssertionFailed);
+        }
+    }
+}
+
+
+
+CASE("sparse-matrix matrix multiply (spmm) in double [backend=hicsparse]") {
+    // "square"
+    // A =  2  . -3
+    //      .  2  .
+    //      .  .  2
+    // x = 1 2 3
+    // y = 1 2 3
+    sparse::current_backend(hicsparse);
+
+    auto A = createSparseMatrixStorage<double>();
+    auto A_device_view = make_device_view<double,int>(A);
+    Matrix m{{1., 2.}, {3., 4.}, {5., 6.}};
+    Matrix c_exp{{-13., -14.}, {6., 8.}, {10., 12.}};
+
+    SECTION("View of atlas::Array PointsRight [backend=hicsparse]") {
+        ArrayMatrix<double, Indexing::layout_right> ma(m);
+        ArrayMatrix<double, Indexing::layout_right> c(3, 2);
+        auto ma_device_view = ma.device_view();
+        auto c_device_view = c.device_view();
+        sparse_matrix_multiply(A_device_view, ma_device_view, c_device_view, Indexing::layout_right);
+        expect_equal(c.host_view(), ArrayMatrix<double, Indexing::layout_right>(c_exp).host_view());
+    }
+
+    SECTION("sparse_matrix_multiply [backend=hicsparse]") {
+        auto backend = sparse::backend::hicsparse();
+        ArrayMatrix<double> ma(m);
+        ArrayMatrix<double> c(3, 2);
+        auto ma_device_view = ma.device_view();
+        auto c_device_view = c.device_view();
+        sparse_matrix_multiply(A_device_view, ma_device_view, c_device_view, backend);
+        expect_equal(c.host_view(), ArrayMatrix<double>(c_exp).host_view());
+    }
+
+    SECTION("SparseMatrixMultiply [backend=hicsparse] 1") {
+        auto spmm = SparseMatrixMultiply{sparse::backend::hicsparse()};
+        ArrayMatrix<double> ma(m);
+        ArrayMatrix<double> c(3, 2);
+        auto ma_device_view = ma.device_view();
+        auto c_device_view = c.device_view();
+        spmm(A_device_view, ma_device_view, c_device_view);
+        expect_equal(c.host_view(), ArrayMatrix<double>(c_exp).host_view());
+    }
+
+    SECTION("SparseMatrixMultiply [backend=hicsparse] 2") {
+        auto spmm = SparseMatrixMultiply{hicsparse};
+        ArrayMatrix<double> ma(m);
+        ArrayMatrix<double> c(3, 2);
+        auto ma_device_view = ma.device_view();
+        auto c_device_view = c.device_view();
+        spmm(A_device_view, ma_device_view, c_device_view);
+        expect_equal(c.host_view(), ArrayMatrix<double>(c_exp).host_view());
+    }
+
+    SECTION("sparse_matrix_multiply_add [backend=hicsparse]") {
+        ArrayMatrix<double> x(m);
+        ArrayMatrix<double> y(m);
+        Matrix y_exp{{-12., -12.}, {9., 12.}, {15., 18.}};
+        auto x_device_view = x.device_view();
+        auto y_device_view = y.device_view();
+        sparse_matrix_multiply_add(A_device_view, x_device_view, y_device_view, sparse::backend::hicsparse());
+        expect_equal(y.host_view(), ArrayMatrix<double>(y_exp).host_view());
+    }
+}
+
+CASE("sparse-matrix matrix multiply (spmm) in float [backend=hicsparse]") {
+    // "square"
+    // A =  2  . -3
+    //      .  2  .
+    //      .  .  2
+    // x = 1 2 3
+    // y = 1 2 3
+    sparse::current_backend(hicsparse);
+
+    auto A = createSparseMatrixStorage<float>();
+    auto A_device_view = make_device_view<float,int>(A);
+    Matrix m{{1., 2.}, {3., 4.}, {5., 6.}};
+    Matrix c_exp{{-13., -14.}, {6., 8.}, {10., 12.}};
+
+    SECTION("View of atlas::Array PointsRight [backend=hicsparse]") {
+        ArrayMatrix<float, Indexing::layout_right> ma(m);
+        ArrayMatrix<float, Indexing::layout_right> c(3, 2);
+        auto ma_device_view = ma.device_view();
+        auto c_device_view = c.device_view();
+        sparse_matrix_multiply(A_device_view, ma_device_view, c_device_view, Indexing::layout_right);
+        expect_equal(c.host_view(), ArrayMatrix<float, Indexing::layout_right>(c_exp).host_view());
+    }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}


### PR DESCRIPTION
This PR adds a hicsparse backend to the sparse matrix multiplication routines of linalg sparse.

This PR depends on https://github.com/ecmwf/atlas/pull/247 and the branch of this PR is currently based on the branch of https://github.com/ecmwf/atlas/pull/247.

Notes:
- This PR previously depended on https://github.com/ecmwf/atlas/pull/241 but that dependency is nolonger necessary as https://github.com/ecmwf/atlas/pull/247 will superseded the former PR.