### PR TITLE
Fix for using default CUDA host compiler

### DIFF
--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -1027,8 +1027,10 @@ if( HAVE_ACC AND CMAKE_Fortran_COMPILER_ID MATCHES NVHPC )
   target_link_options( atlas INTERFACE
       $<$<LINK_LANG_AND_ID:C,NVHPC>:SHELL:${ACC_LINK_OPTIONS}>
       $<$<LINK_LANG_AND_ID:CXX,NVHPC>:SHELL:${ACC_LINK_OPTIONS}>
-      $<$<LINK_LANG_AND_ID:Fortran,NVHPC>:SHELL:${ACC_LINK_OPTIONS}>
-      $<$<LINK_LANG_AND_ID:CUDA,NVIDIA>:SHELL:${ACC_LINK_OPTIONS}> )
+      $<$<LINK_LANG_AND_ID:Fortran,NVHPC>:SHELL:${ACC_LINK_OPTIONS}> )
+      #   $<$<LINK_LANG_AND_ID:CUDA,NVIDIA>:SHELL:${ACC_LINK_OPTIONS}>
+      #      This only works when CUDA HOST COMPILER is NVIDIA, by default it is g++ so we cannot rely on this.
+      #      CUDA executables should set LINKER_LANGUAGE to C or CXX instead, which will have ACC_LINK_OPTIONS
 endif()
 
 target_compile_features( atlas PUBLIC cxx_std_17 )

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -67,10 +67,11 @@ macro( atlas_add_hic_test )
       set_source_files_properties(${_PAR_SOURCES} PROPERTIES LANGUAGE HIP)
     endif()
 
-    ecbuild_add_test( TARGET      ${_PAR_TARGET}
-                      SOURCES     ${_PAR_SOURCES}
-                      LIBS        ${_libs}
-                      ENVIRONMENT ${_PAR_ENVIRONMENT} )
+    ecbuild_add_test( TARGET          ${_PAR_TARGET}
+                      SOURCES         ${_PAR_SOURCES}
+                      LIBS            ${_libs}
+                      LINKER_LANGUAGE CXX
+                      ENVIRONMENT     ${_PAR_ENVIRONMENT} )
     set_tests_properties(${_PAR_TARGET} PROPERTIES LABELS "gpu")
 
   endif()

--- a/src/tests/linalg/test_linalg_sparse_matrix_gpu.cc
+++ b/src/tests/linalg/test_linalg_sparse_matrix_gpu.cc
@@ -181,9 +181,9 @@ void check_matrix(const SparseMatrixStorage& m) {
     std::vector<Index>  host_inner(host_matrix_view.inner_size());
     std::vector<Value>  host_value(host_matrix_view.value_size());
 
-    hicMemcpy(host_outer.data(), device_matrix_view.outer(), device_matrix_view.outer_size() * sizeof(Index),  hicMemcpyDeviceToHost);
-    hicMemcpy(host_inner.data(), device_matrix_view.inner(), device_matrix_view.inner_size() * sizeof(Index),  hicMemcpyDeviceToHost);
-    hicMemcpy(host_value.data(), device_matrix_view.value(), device_matrix_view.value_size() * sizeof(Value),  hicMemcpyDeviceToHost);
+    HIC_CALL(hicMemcpy(host_outer.data(), device_matrix_view.outer(), device_matrix_view.outer_size() * sizeof(Index),  hicMemcpyDeviceToHost));
+    HIC_CALL(hicMemcpy(host_inner.data(), device_matrix_view.inner(), device_matrix_view.inner_size() * sizeof(Index),  hicMemcpyDeviceToHost));
+    HIC_CALL(hicMemcpy(host_value.data(), device_matrix_view.value(), device_matrix_view.value_size() * sizeof(Value),  hicMemcpyDeviceToHost));
 
     EXPECT(host_outer == expected_outer);
     EXPECT(host_inner == expected_inner);


### PR DESCRIPTION
When not defining CUDAHOSTCXX , nvcc uses by default "g++" as the host compiler.
CMake does not have any introspection on the CUDA_HOST_COMPILER, and so we cannot add linker options that could be specific for CUDA - linked executables. 
This PR makes the HIC (so CUDA) tests link with the C++ linker, and avoids passing ACC_LINK_OPTIONS to the CUDA_HOST_COMPILER
