### PR TITLE
Fix creation of spectral function space from TransLocal (fixes #249)

### DIFF
--- a/src/tests/trans/fctest_trans_unstructured.F90
+++ b/src/tests/trans/fctest_trans_unstructured.F90
@@ -65,6 +65,7 @@ TEST( test_trans )
   FCTEST_CHECK_EQUAL( trans%truncation(), truncation )
 
   spectral = trans%spectral()
+  FCTEST_CHECK_EQUAL( spectral%truncation(), truncation )
 
   sp_scal_field = spectral%create_field(name="spectral_scalar",kind=atlas_real(8))
   sp_vor_field  = spectral%create_field(name="spectral_vorticity",kind=atlas_real(8))


### PR DESCRIPTION
This fixes #249 .
The problem was that the functionspace::Spectral created via the TransLocal api was creating a new functionspace with truncation == 1. 
This was due to an older removed API that could create the Spectral functionspace using a Trans object. An implicit conversion to 1 of this object resulted in truncation == 1.