### PR TITLE
Add distribution of serial interpolation matrix

### DIFF
--- a/python/atlaslib-ecmwf/pre-compile.sh
+++ b/python/atlaslib-ecmwf/pre-compile.sh
@@ -13,7 +13,14 @@ set -euo pipefail
 
 mkdir -p python/atlaslib-ecmwf/src/copying
 
-bash ./tools/install-qhull.sh --prefix /tmp/qhull/target
+# NOTE we dont use that since we dont want to work with the brew installation as it is unreliable
+# bash ./tools/install-qhull.sh --prefix /tmp/qhull/target
+mkdir -p /tmp/qhull/build && cd /tmp/qhull/build
+git clone https://github.com/qhull/qhull /tmp/qhull/src
+cmake /tmp/qhull/src -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/tmp/qhull/target
+make -j8 && make install
+cd -
+
 # copy the libs, instead of having auditwheel done it later. This is a bit risky because cmake will later write in this
 # very directory... but it works
 if [ "$(uname)" != "Darwin" ] ; then
@@ -21,13 +28,8 @@ if [ "$(uname)" != "Darwin" ] ; then
     cp /tmp/qhull/target/lib/libqhull_r.* /tmp/atlas/target/atlas/lib64/
 else
     mkdir -p /tmp/atlas/target/atlas/lib
-    for e in $(brew list qhull | grep '/lib/' | grep dylib) ; do
-        cp $e /tmp/atlas/target/atlas/lib
-    done
+    cp /tmp/qhull/target/lib/libqhull_r.* /tmp/atlas/target/atlas/lib/
 fi
 
 wget https://raw.githubusercontent.com/qhull/qhull/master/COPYING.txt -O python/atlaslib-ecmwf/src/copying/libqhull.txt
 echo '{"libqhull_r": {"path": "copying/libqhull.txt", "home": "https://github.com/qhull/qhull"}}' > python/atlaslib-ecmwf/src/copying/list.json
-
-
-

--- a/src/atlas/interpolation/AssembleGlobalMatrix.cc
+++ b/src/atlas/interpolation/AssembleGlobalMatrix.cc
@@ -201,7 +201,6 @@ void distribute_global_matrix(const linalg::SparseMatrixView<ViewValue,ViewIndex
     cols.resize(nnz_loc);
     vals.resize(nnz_loc);
 
-    size_t idx = 0;
     if (mpi_rank == mpi_root) {
         std::vector<std::vector<Index>> send_rows(mpi_size);
         std::vector<std::vector<Index>> send_cols(mpi_size);
@@ -242,10 +241,6 @@ void distribute_global_matrix(const linalg::SparseMatrixView<ViewValue,ViewIndex
 
 linalg::SparseMatrixStorage distribute_global_matrix(const FunctionSpace& src_fs, const FunctionSpace& tgt_fs, const linalg::SparseMatrixStorage& gmatrix, int mpi_root) {
     ATLAS_TRACE("distribute_global_matrix");
-    const auto src_part = array::make_view<int, 1>(src_fs.partition());
-    const auto tgt_part = array::make_view<int, 1>(tgt_fs.partition());
-    const auto tgt_ridx = array::make_indexview<int, 1>(tgt_fs.remote_index());
-
     Field field_tgt_part_glb = tgt_fs.createField(tgt_fs.partition(), option::global(mpi_root));
     ATLAS_TRACE_SCOPE("gather partition") {
         tgt_fs.gather(tgt_fs.partition(), field_tgt_part_glb);

--- a/src/atlas/interpolation/AssembleGlobalMatrix.cc
+++ b/src/atlas/interpolation/AssembleGlobalMatrix.cc
@@ -11,6 +11,8 @@
 
 #include "AssembleGlobalMatrix.h"
 
+#include <unordered_map>
+
 #include "eckit/linalg/types.h"
 
 #include "atlas/array.h"
@@ -164,6 +166,7 @@ linalg::SparseMatrixStorage assemble_global_matrix(const Interpolation& interpol
 template <typename ViewValue, typename ViewIndex, typename Value, typename Index> 
 void distribute_global_matrix(const linalg::SparseMatrixView<ViewValue,ViewIndex>& global_matrix,
     const array::Array& partition, std::vector<Index>& rows, std::vector<Index>& cols, std::vector<Value>& vals, int mpi_root) {
+    ATLAS_TRACE("distribute_global_matrix_lowlevel");
 
     const auto tgt_part_glb = array::make_view<int,1>(partition);
     
@@ -238,12 +241,15 @@ void distribute_global_matrix(const linalg::SparseMatrixView<ViewValue,ViewIndex
 }
 
 linalg::SparseMatrixStorage distribute_global_matrix(const FunctionSpace& src_fs, const FunctionSpace& tgt_fs, const linalg::SparseMatrixStorage& gmatrix, int mpi_root) {
+    ATLAS_TRACE("distribute_global_matrix");
     const auto src_part = array::make_view<int, 1>(src_fs.partition());
     const auto tgt_part = array::make_view<int, 1>(tgt_fs.partition());
     const auto tgt_ridx = array::make_indexview<int, 1>(tgt_fs.remote_index());
 
     Field field_tgt_part_glb = tgt_fs.createField(tgt_fs.partition(), option::global(mpi_root));
-    tgt_fs.gather(tgt_fs.partition(), field_tgt_part_glb);
+    ATLAS_TRACE_SCOPE("gather partition") {
+        tgt_fs.gather(tgt_fs.partition(), field_tgt_part_glb);
+    }
 
     using Index = eckit::linalg::Index;
     using Value = eckit::linalg::Scalar;
@@ -252,38 +258,40 @@ linalg::SparseMatrixStorage distribute_global_matrix(const FunctionSpace& src_fs
     distribute_global_matrix(atlas::linalg::make_host_view<Value, Index>(gmatrix), field_tgt_part_glb, rows, cols, vals, mpi_root);
 
     // map global index to local index
-    std::map<gidx_t, idx_t> to_local_rows;
-    std::map<gidx_t, idx_t> to_local_cols;
+    std::unordered_map<gidx_t, idx_t> to_local_rows;
+    std::unordered_map<gidx_t, idx_t> to_local_cols;
 
-    auto tgt_gidx_exchanged = tgt_fs.createField(tgt_fs.global_index());
-    tgt_gidx_exchanged.array().copy(tgt_fs.global_index());
-    tgt_fs.haloExchange(tgt_gidx_exchanged);
-    const auto tgt_global_index = array::make_view<gidx_t, 1>(tgt_gidx_exchanged);
-    const auto tgt_ghost = array::make_view<int,1>(tgt_fs.ghost());
+    ATLAS_TRACE_SCOPE("convert to local indexing") {
+        auto tgt_gidx_exchanged = tgt_fs.createField(tgt_fs.global_index());
+        tgt_gidx_exchanged.array().copy(tgt_fs.global_index());
+        tgt_fs.haloExchange(tgt_gidx_exchanged);
+        const auto tgt_global_index = array::make_view<gidx_t, 1>(tgt_gidx_exchanged);
+        const auto tgt_ghost = array::make_view<int,1>(tgt_fs.ghost());
 
-    auto src_gidx_exchanged = src_fs.createField(src_fs.global_index());
-    src_gidx_exchanged.array().copy(src_fs.global_index());
-    src_fs.haloExchange(src_gidx_exchanged);
-    const auto src_global_index = array::make_view<gidx_t, 1>(src_gidx_exchanged);
-    const auto src_ghost = array::make_view<int,1>(src_fs.ghost());
+        auto src_gidx_exchanged = src_fs.createField(src_fs.global_index());
+        src_gidx_exchanged.array().copy(src_fs.global_index());
+        src_fs.haloExchange(src_gidx_exchanged);
+        const auto src_global_index = array::make_view<gidx_t, 1>(src_gidx_exchanged);
+        const auto src_ghost = array::make_view<int,1>(src_fs.ghost());
 
-    for (idx_t r = 0; r < tgt_global_index.size(); ++r) {
-        auto gr = tgt_global_index(r);
-        if (to_local_rows.find(gr) != to_local_rows.end() && tgt_ghost(r)) {
-            continue;
+        for (idx_t r = 0; r < tgt_global_index.size(); ++r) {
+            auto gr = tgt_global_index(r);
+            if (tgt_ghost(r) && to_local_rows.find(gr) != to_local_rows.end()) {
+                continue;
+            }
+            to_local_rows[gr] = r;
         }
-        to_local_rows[gr] = r;
-    }
-    for (idx_t c = 0; c < src_global_index.size(); ++c) {
-        auto gc = src_global_index(c);
-        if (to_local_cols.find(gc) != to_local_cols.end() && src_ghost(c)) {
-            continue;
+        for (idx_t c = 0; c < src_global_index.size(); ++c) {
+            auto gc = src_global_index(c);
+            if (src_ghost(c) && to_local_cols.find(gc) != to_local_cols.end()) {
+                continue;
+            }
+            to_local_cols[gc] = c;
         }
-        to_local_cols[gc] = c;
-    }
-    for (int r = 0; r < rows.size(); ++r) {
-        rows[r] = to_local_rows[rows[r] + 1];
-        cols[r] = to_local_cols[cols[r] + 1];
+        for (int r = 0; r < rows.size(); ++r) {
+            rows[r] = to_local_rows[rows[r] + 1];
+            cols[r] = to_local_cols[cols[r] + 1];
+        }
     }
 
     linalg::SparseMatrixStorage matrix;

--- a/src/atlas/interpolation/AssembleGlobalMatrix.cc
+++ b/src/atlas/interpolation/AssembleGlobalMatrix.cc
@@ -18,7 +18,6 @@
 #include "atlas/array.h"
 #include "atlas/linalg/sparse/SparseMatrixToTriplets.h"
 #include "atlas/functionspace/StructuredColumns.h"
-#include "atlas/interpolation/Cache.h"
 
 namespace atlas::interpolation {
 

--- a/src/atlas/interpolation/AssembleGlobalMatrix.cc
+++ b/src/atlas/interpolation/AssembleGlobalMatrix.cc
@@ -235,8 +235,6 @@ linalg::SparseMatrixStorage distribute_global_matrix(const FunctionSpace& src_fs
     const auto tgt_part         = array::make_view<int, 1>(tgt_fs.partition());
 
     Field field_tgt_part_glb = tgt_fs.createField(tgt_fs.partition(), option::global(mpi_root));
-    ATLAS_DEBUG_VAR(field_tgt_part_glb.size());
-    ATLAS_DEBUG_VAR(tgt_fs.partition().size());
     tgt_fs.gather(tgt_fs.partition(), field_tgt_part_glb);
 
     using Index = eckit::linalg::Index;

--- a/src/atlas/interpolation/AssembleGlobalMatrix.h
+++ b/src/atlas/interpolation/AssembleGlobalMatrix.h
@@ -17,6 +17,6 @@ namespace atlas::interpolation {
 
     atlas::linalg::SparseMatrixStorage assemble_global_matrix(const Interpolation& interpolation, int mpi_root = 0);
 
-    linalg::SparseMatrixStorage distribute_global_matrix(const FunctionSpace& src_fs, const FunctionSpace& tgt_fs, const linalg::SparseMatrixStorage&, int mpi_root = 0);
+    atlas::linalg::SparseMatrixStorage distribute_global_matrix(const FunctionSpace& src_fs, const FunctionSpace& tgt_fs, const linalg::SparseMatrixStorage&, int mpi_root = 0);
 
 } // namespace atlas::interpolation

--- a/src/atlas/interpolation/AssembleGlobalMatrix.h
+++ b/src/atlas/interpolation/AssembleGlobalMatrix.h
@@ -17,4 +17,6 @@ namespace atlas::interpolation {
 
     atlas::linalg::SparseMatrixStorage assemble_global_matrix(const Interpolation& interpolation, int mpi_root = 0);
 
+    linalg::SparseMatrixStorage distribute_global_matrix(const FunctionSpace& src_fs, const FunctionSpace& tgt_fs, const linalg::SparseMatrixStorage&, int mpi_root = 0);
+
 } // namespace atlas::interpolation

--- a/src/atlas/interpolation/Interpolation.cc
+++ b/src/atlas/interpolation/Interpolation.cc
@@ -121,6 +121,16 @@ Interpolation::Interpolation(const Interpolation::Config& config, const Grid& so
         return impl;
     }()) {}
 
+Interpolation::Interpolation(const Interpolation::Config& config, const FunctionSpace& fs_in, const FunctionSpace& fs_out,
+                             const Interpolation::Cache& cache):
+    Handle([&]() -> Implementation* {
+        std::string type;
+        ATLAS_ASSERT(config.get("type", type));
+        Implementation* impl = interpolation::MethodFactory::build(type, config);
+        impl->setup(fs_in, fs_out, cache);
+        return impl;
+    }()) {}
+
 extern "C" {
 Interpolation::Implementation* atlas__Interpolation__new(const eckit::Parametrisation* config,
                                                          const functionspace::FunctionSpaceImpl* source,

--- a/src/atlas/interpolation/Interpolation.h
+++ b/src/atlas/interpolation/Interpolation.h
@@ -70,6 +70,8 @@ public:
 
     Interpolation(const Config&, const Grid& source, const Grid& target, const Cache&) noexcept(false);
 
+    Interpolation(const Config&, const FunctionSpace& source, const FunctionSpace& target, const Cache&) noexcept(false);
+
     friend std::ostream& operator<<(std::ostream& out, const Interpolation& i) {
         i.print(out);
         return out;

--- a/src/atlas/interpolation/method/Method.cc
+++ b/src/atlas/interpolation/method/Method.cc
@@ -295,6 +295,11 @@ void Method::setup(const Grid& source, const Grid& target, const Cache& cache) {
     this->do_setup(source, target, cache);
 }
 
+void Method::setup(const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
+    ATLAS_TRACE("atlas::interpolation::method::Method::setup(FunctionSpace, FunctionSpace, Cache)");
+    this->do_setup(source, target, cache);
+}
+
 Method::Metadata Method::execute(const FieldSet& source, FieldSet& target) const {
     ATLAS_TRACE("atlas::interpolation::method::Method::execute(FieldSet, FieldSet)");
     Metadata metadata;

--- a/src/atlas/interpolation/method/Method.h
+++ b/src/atlas/interpolation/method/Method.h
@@ -57,6 +57,7 @@ public:
     void setup(const FunctionSpace& source, const Field& target);
     void setup(const FunctionSpace& source, const FieldSet& target);
     void setup(const Grid& source, const Grid& target, const Cache&);
+    void setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&);
 
     Metadata execute(const FieldSet& source, FieldSet& target) const;
     Metadata execute(const Field& source, Field& target) const;
@@ -136,6 +137,7 @@ protected:
 
     virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target) = 0;
     virtual void do_setup(const Grid& source, const Grid& target, const Cache&)     = 0;
+    virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) = 0;
     virtual void do_setup(const FunctionSpace& source, const Field& target);
     virtual void do_setup(const FunctionSpace& source, const FieldSet& target);
 

--- a/src/atlas/interpolation/method/binning/Binning.cc
+++ b/src/atlas/interpolation/method/binning/Binning.cc
@@ -53,6 +53,12 @@ void Binning::do_setup(const Grid& source,
   ATLAS_NOTIMPLEMENTED;
 }
 
+void Binning::do_setup(const FunctionSpace& source,
+                       const FunctionSpace& target,
+                       const Cache&) {
+  ATLAS_NOTIMPLEMENTED;
+}
+
 
 void Binning::do_setup(const FunctionSpace& source,
                        const FunctionSpace& target) {

--- a/src/atlas/interpolation/method/binning/Binning.h
+++ b/src/atlas/interpolation/method/binning/Binning.h
@@ -59,6 +59,7 @@ class Binning : public Method {
   void do_setup(const FunctionSpace& source,
                 const FunctionSpace& target) override;
   void do_setup(const Grid& source, const Grid& target, const Cache&) override;
+  void do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) override;
 
   std::vector<double> getAreaWeights(const FunctionSpace& source) const;
 

--- a/src/atlas/interpolation/method/cubedsphere/CubedSphereBilinear.cc
+++ b/src/atlas/interpolation/method/cubedsphere/CubedSphereBilinear.cc
@@ -24,6 +24,10 @@ void CubedSphereBilinear::do_setup(const Grid& source, const Grid& target, const
     ATLAS_NOTIMPLEMENTED;
 }
 
+void CubedSphereBilinear::do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) {
+    ATLAS_NOTIMPLEMENTED;
+}
+
 void CubedSphereBilinear::do_setup(const FunctionSpace& source, const FunctionSpace& target) {
     source_ = source;
     target_ = target;

--- a/src/atlas/interpolation/method/cubedsphere/CubedSphereBilinear.h
+++ b/src/atlas/interpolation/method/cubedsphere/CubedSphereBilinear.h
@@ -42,6 +42,7 @@ private:
     using Method::do_setup;
     void do_setup(const FunctionSpace& source, const FunctionSpace& target) override;
     void do_setup(const Grid& source, const Grid& target, const Cache&) override;
+     void do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) override;
 
     FunctionSpace source_;
     FunctionSpace target_;

--- a/src/atlas/interpolation/method/cubedsphere/CubedSphereBilinear.h
+++ b/src/atlas/interpolation/method/cubedsphere/CubedSphereBilinear.h
@@ -42,7 +42,7 @@ private:
     using Method::do_setup;
     void do_setup(const FunctionSpace& source, const FunctionSpace& target) override;
     void do_setup(const Grid& source, const Grid& target, const Cache&) override;
-     void do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) override;
+    void do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) override;
 
     FunctionSpace source_;
     FunctionSpace target_;

--- a/src/atlas/interpolation/method/knn/GridBoxMethod.cc
+++ b/src/atlas/interpolation/method/knn/GridBoxMethod.cc
@@ -184,16 +184,16 @@ void GridBoxMethod::do_setup(const Grid& source, const Grid& target, const Cache
 void GridBoxMethod::do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
     ATLAS_TRACE("GridBoxMethod::setup()");
 
-    source_ = source;
-    target_ = target;
     if (not matrixFree_ && interpolation::MatrixCache(cache)) {
         setMatrix(cache);
+        source_ = source;
+        target_ = target;
         ATLAS_ASSERT(matrix().rows() == target.size());
         ATLAS_ASSERT(matrix().cols() == source.size());
         return;
     }
 
-    // setup only with cache
+    Log::warning() << "Can not create GridBoxMethod from (FunctionSpace, FunctionSpace, Cache). Use (Grid, Grid, Cache)";
     ATLAS_NOTIMPLEMENTED;
 }
 

--- a/src/atlas/interpolation/method/knn/GridBoxMethod.cc
+++ b/src/atlas/interpolation/method/knn/GridBoxMethod.cc
@@ -181,6 +181,21 @@ void GridBoxMethod::do_setup(const Grid& source, const Grid& target, const Cache
     }
 }
 
+void GridBoxMethod::do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
+    ATLAS_TRACE("GridBoxMethod::setup()");
+
+    source_ = source;
+    target_ = target;
+    if (not matrixFree_ && interpolation::MatrixCache(cache)) {
+        setMatrix(cache);
+        ATLAS_ASSERT(matrix().rows() == target.size());
+        ATLAS_ASSERT(matrix().cols() == source.size());
+        return;
+    }
+
+    // setup only with cache
+    ATLAS_NOTIMPLEMENTED;
+}
 
 void GridBoxMethod::giveUp(const std::forward_list<size_t>& failures) {
     Log::warning() << "Failed to intersect grid boxes: ";

--- a/src/atlas/interpolation/method/knn/GridBoxMethod.h
+++ b/src/atlas/interpolation/method/knn/GridBoxMethod.h
@@ -40,6 +40,7 @@ protected:
      */
     virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target) override;
     virtual void do_setup(const Grid& source, const Grid& target, const Cache&) override;
+    virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) override;
 
     virtual const FunctionSpace& source() const override { return source_; }
     virtual const FunctionSpace& target() const override { return target_; }

--- a/src/atlas/interpolation/method/knn/KNearestNeighbours.cc
+++ b/src/atlas/interpolation/method/knn/KNearestNeighbours.cc
@@ -63,15 +63,18 @@ void KNearestNeighbours::do_setup(const Grid& source, const Grid& target, const 
 }
 
 void KNearestNeighbours::do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
-    setMatrix(cache);
-    do_setup(source, target);
+    if (interpolation::MatrixCache(cache)) {
+        setMatrix(cache);
+        source_ = source;
+        target_ = target;
+        buildPointSearchTree(source);
+    }
 }
 
 void KNearestNeighbours::do_setup(const FunctionSpace& source, const FunctionSpace& target) {
     source_                        = source;
     target_                        = target;
 
-    // build point-search tree
     buildPointSearchTree(source);
 
     array::ArrayView<double, 2> lonlat = array::make_view<double, 2>(target.lonlat());

--- a/src/atlas/interpolation/method/knn/KNearestNeighbours.cc
+++ b/src/atlas/interpolation/method/knn/KNearestNeighbours.cc
@@ -67,7 +67,9 @@ void KNearestNeighbours::do_setup(const FunctionSpace& source, const FunctionSpa
         setMatrix(cache);
         source_ = source;
         target_ = target;
-        buildPointSearchTree(source);
+    }
+    else {
+        do_setup(source, target);
     }
 }
 

--- a/src/atlas/interpolation/method/knn/KNearestNeighbours.cc
+++ b/src/atlas/interpolation/method/knn/KNearestNeighbours.cc
@@ -62,6 +62,11 @@ void KNearestNeighbours::do_setup(const Grid& source, const Grid& target, const 
     do_setup(functionspace(source), functionspace(target));
 }
 
+void KNearestNeighbours::do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
+    setMatrix(cache);
+    do_setup(source, target);
+}
+
 void KNearestNeighbours::do_setup(const FunctionSpace& source, const FunctionSpace& target) {
     source_                        = source;
     target_                        = target;

--- a/src/atlas/interpolation/method/knn/KNearestNeighbours.h
+++ b/src/atlas/interpolation/method/knn/KNearestNeighbours.h
@@ -39,6 +39,7 @@ private:
     using KNearestNeighboursBase::do_setup;
     virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target) override;
     virtual void do_setup(const Grid& source, const Grid& target, const Cache&) override;
+    virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) override;
 
     FunctionSpace source_;
     FunctionSpace target_;

--- a/src/atlas/interpolation/method/knn/KNearestNeighboursBase.cc
+++ b/src/atlas/interpolation/method/knn/KNearestNeighboursBase.cc
@@ -31,7 +31,6 @@ void KNearestNeighboursBase::buildPointSearchTree(Mesh& meshSource, const mesh::
     ATLAS_TRACE();
     eckit::TraceTimer<Atlas> tim("KNearestNeighboursBase::buildPointSearchTree()");
 
-
     auto lonlat = array::make_view<double, 2>(meshSource.nodes().lonlat());
     auto halo   = array::make_view<int, 1>(meshSource.nodes().halo());
     int h       = _halo.size();
@@ -47,7 +46,6 @@ void KNearestNeighboursBase::buildPointSearchTree(Mesh& meshSource, const mesh::
         }
     }
     pTree_.build();
-
 
 //    // generate 3D point coordinates
 //    mesh::actions::BuildXYZField("xyz")(meshSource);

--- a/src/atlas/interpolation/method/knn/NearestNeighbour.cc
+++ b/src/atlas/interpolation/method/knn/NearestNeighbour.cc
@@ -43,13 +43,8 @@ void NearestNeighbour::do_setup(const FunctionSpace& source, const FunctionSpace
         setMatrix(cache);
         source_ = source;
         target_ = target;
-        return;
+        buildPointSearchTree(source);
     }
-    if (functionspace::NodeColumns(source) && functionspace::NodeColumns(target)) {
-        do_setup(source, target);
-        return;
-    }
-    ATLAS_NOTIMPLEMENTED;
 }
 
 void NearestNeighbour::do_setup(const Grid& source, const Grid& target, const Cache&) {

--- a/src/atlas/interpolation/method/knn/NearestNeighbour.cc
+++ b/src/atlas/interpolation/method/knn/NearestNeighbour.cc
@@ -39,8 +39,17 @@ MethodBuilder<NearestNeighbour> __builder("nearest-neighbour");
 }  // namespace
 
 void NearestNeighbour::do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
-    setMatrix(cache);
-    do_setup(source, target);
+    if (interpolation::MatrixCache(cache)) {
+        setMatrix(cache);
+        source_ = source;
+        target_ = target;
+        return;
+    }
+    if (functionspace::NodeColumns(source) && functionspace::NodeColumns(target)) {
+        do_setup(source, target);
+        return;
+    }
+    ATLAS_NOTIMPLEMENTED;
 }
 
 void NearestNeighbour::do_setup(const Grid& source, const Grid& target, const Cache&) {

--- a/src/atlas/interpolation/method/knn/NearestNeighbour.cc
+++ b/src/atlas/interpolation/method/knn/NearestNeighbour.cc
@@ -43,7 +43,9 @@ void NearestNeighbour::do_setup(const FunctionSpace& source, const FunctionSpace
         setMatrix(cache);
         source_ = source;
         target_ = target;
-        buildPointSearchTree(source);
+    }
+    else {
+        do_setup(source, target);
     }
 }
 

--- a/src/atlas/interpolation/method/knn/NearestNeighbour.cc
+++ b/src/atlas/interpolation/method/knn/NearestNeighbour.cc
@@ -38,6 +38,11 @@ MethodBuilder<NearestNeighbour> __builder("nearest-neighbour");
 
 }  // namespace
 
+void NearestNeighbour::do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
+    setMatrix(cache);
+    do_setup(source, target);
+}
+
 void NearestNeighbour::do_setup(const Grid& source, const Grid& target, const Cache&) {
     if (mpi::size() > 1) {
         ATLAS_NOTIMPLEMENTED;

--- a/src/atlas/interpolation/method/knn/NearestNeighbour.h
+++ b/src/atlas/interpolation/method/knn/NearestNeighbour.h
@@ -39,8 +39,8 @@ private:
    * @param target functionspace containing target points
    */
     virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target) override;
-
     virtual void do_setup(const Grid& source, const Grid& target, const Cache&) override;
+    virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) override;
 
     FunctionSpace source_;
     FunctionSpace target_;

--- a/src/atlas/interpolation/method/sphericalvector/SphericalVector.cc
+++ b/src/atlas/interpolation/method/sphericalvector/SphericalVector.cc
@@ -53,6 +53,11 @@ void SphericalVector::do_setup(const Grid& source, const Grid& target,
   ATLAS_NOTIMPLEMENTED;
 }
 
+void SphericalVector::do_setup(const FunctionSpace& source, const FunctionSpace& target,
+                               const Cache&) {
+  ATLAS_NOTIMPLEMENTED;
+}
+
 void SphericalVector::do_setup(const FunctionSpace& source,
                                const FunctionSpace& target) {
   ATLAS_TRACE("interpolation::method::SphericalVector::do_setup");

--- a/src/atlas/interpolation/method/sphericalvector/SphericalVector.h
+++ b/src/atlas/interpolation/method/sphericalvector/SphericalVector.h
@@ -70,6 +70,7 @@ class SphericalVector : public Method {
   void do_setup(const FunctionSpace& source,
                 const FunctionSpace& target) override;
   void do_setup(const Grid& source, const Grid& target, const Cache&) override;
+  void do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) override;
 
   eckit::LocalConfiguration interpolationScheme_{};
 

--- a/src/atlas/interpolation/method/structured/RegionalLinear2D.cc
+++ b/src/atlas/interpolation/method/structured/RegionalLinear2D.cc
@@ -29,6 +29,11 @@ void RegionalLinear2D::do_setup(const Grid& source, const Grid& target,
   ATLAS_NOTIMPLEMENTED;
 }
 
+void RegionalLinear2D::do_setup(const FunctionSpace& source, const FunctionSpace& target,
+                                const Cache&) {
+  ATLAS_NOTIMPLEMENTED;
+}
+
 void RegionalLinear2D::do_setup(const FunctionSpace& source,
                                 const FunctionSpace& target) {
   ATLAS_TRACE("interpolation::method::RegionalLinear2D::do_setup");

--- a/src/atlas/interpolation/method/structured/RegionalLinear2D.h
+++ b/src/atlas/interpolation/method/structured/RegionalLinear2D.h
@@ -51,6 +51,7 @@ class RegionalLinear2D : public Method {
   using Method::do_setup;
   void do_setup(const FunctionSpace& source, const FunctionSpace& target) override;
   void do_setup(const Grid& source, const Grid& target, const Cache&) override;
+  void do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) override;
 
   FunctionSpace source_{};
   FunctionSpace target_{};

--- a/src/atlas/interpolation/method/structured/StructuredInterpolation2D.h
+++ b/src/atlas/interpolation/method/structured/StructuredInterpolation2D.h
@@ -51,6 +51,8 @@ protected:
 private:
     virtual void do_setup(const Grid& source, const Grid& target, const Cache&) override;
 
+    virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) override;
+
     virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target) override;
 
     virtual void do_setup(const FunctionSpace& source, const Field& target) override;

--- a/src/atlas/interpolation/method/structured/StructuredInterpolation2D.tcc
+++ b/src/atlas/interpolation/method/structured/StructuredInterpolation2D.tcc
@@ -267,7 +267,7 @@ void StructuredInterpolation2D<Kernel>::do_setup( const Grid& source, const Grid
 template <typename Kernel>
 void StructuredInterpolation2D<Kernel>::do_setup( const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
     ATLAS_TRACE( "StructuredInterpolation2D<" + Kernel::className() + ">::do_setup(FunctionSpace source, FunctionSpace target)" );
-    if (interpolation::MatrixCache(cache)) {
+    if (! matrix_free_ && interpolation::MatrixCache(cache)) {
         setMatrix(cache);
         source_ = source;
         target_ = target;
@@ -275,11 +275,9 @@ void StructuredInterpolation2D<Kernel>::do_setup( const FunctionSpace& source, c
         ATLAS_ASSERT(matrix().cols() == source.size());
         return;
     }
-    if (functionspace::NodeColumns(source) && functionspace::PointCloud(target)) {
+    else {
         do_setup(source, target);
-        return;
     }
-    ATLAS_NOTIMPLEMENTED;
 }
 
 template <typename Kernel>

--- a/src/atlas/interpolation/method/structured/StructuredInterpolation2D.tcc
+++ b/src/atlas/interpolation/method/structured/StructuredInterpolation2D.tcc
@@ -265,6 +265,12 @@ void StructuredInterpolation2D<Kernel>::do_setup( const Grid& source, const Grid
 
 
 template <typename Kernel>
+void StructuredInterpolation2D<Kernel>::do_setup( const FunctionSpace& source, const FunctionSpace& target, const Cache& ) {
+    ATLAS_TRACE( "StructuredInterpolation2D<" + Kernel::className() + ">::do_setup(FunctionSpace source, FunctionSpace target)" );
+    do_setup( source, target );
+}
+
+template <typename Kernel>
 void StructuredInterpolation2D<Kernel>::do_setup( const FunctionSpace& source, const FunctionSpace& target ) {
     ATLAS_TRACE( "StructuredInterpolation2D<" + Kernel::className() + ">::do_setup(FS source, FS target)" );
 

--- a/src/atlas/interpolation/method/structured/StructuredInterpolation2D.tcc
+++ b/src/atlas/interpolation/method/structured/StructuredInterpolation2D.tcc
@@ -265,9 +265,21 @@ void StructuredInterpolation2D<Kernel>::do_setup( const Grid& source, const Grid
 
 
 template <typename Kernel>
-void StructuredInterpolation2D<Kernel>::do_setup( const FunctionSpace& source, const FunctionSpace& target, const Cache& ) {
+void StructuredInterpolation2D<Kernel>::do_setup( const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
     ATLAS_TRACE( "StructuredInterpolation2D<" + Kernel::className() + ">::do_setup(FunctionSpace source, FunctionSpace target)" );
-    do_setup( source, target );
+    if (interpolation::MatrixCache(cache)) {
+        setMatrix(cache);
+        source_ = source;
+        target_ = target;
+        ATLAS_ASSERT(matrix().rows() == target.size());
+        ATLAS_ASSERT(matrix().cols() == source.size());
+        return;
+    }
+    if (functionspace::NodeColumns(source) && functionspace::PointCloud(target)) {
+        do_setup(source, target);
+        return;
+    }
+    ATLAS_NOTIMPLEMENTED;
 }
 
 template <typename Kernel>

--- a/src/atlas/interpolation/method/structured/StructuredInterpolation3D.h
+++ b/src/atlas/interpolation/method/structured/StructuredInterpolation3D.h
@@ -48,6 +48,8 @@ protected:
 private:
     virtual void do_setup(const Grid& source, const Grid& target, const Cache&) override;
 
+    virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) override;
+
     virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target) override;
 
     virtual void do_setup(const FunctionSpace& source, const Field& target) override;

--- a/src/atlas/interpolation/method/structured/StructuredInterpolation3D.tcc
+++ b/src/atlas/interpolation/method/structured/StructuredInterpolation3D.tcc
@@ -63,8 +63,6 @@ void StructuredInterpolation3D<Kernel>::do_setup( const Grid& source, const Grid
     if ( mpi::size() > 1 ) {
         ATLAS_NOTIMPLEMENTED;
     }
-
-
     ATLAS_ASSERT( StructuredGrid( source ) );
     FunctionSpace source_fs = functionspace::StructuredColumns( source, option::halo( kernel_->stencil_halo() ) );
     FunctionSpace target_fs = functionspace::PointCloud( target );
@@ -72,6 +70,14 @@ void StructuredInterpolation3D<Kernel>::do_setup( const Grid& source, const Grid
     do_setup( source_fs, target_fs );
 }
 
+template <typename Kernel>
+void StructuredInterpolation3D<Kernel>::do_setup( const FunctionSpace& source, const FunctionSpace& target, const Cache& ) {
+    if ( mpi::size() > 1 ) {
+        ATLAS_NOTIMPLEMENTED;
+    }
+
+    do_setup( source, target );
+}
 
 template <typename Kernel>
 void StructuredInterpolation3D<Kernel>::do_setup( const FunctionSpace& source, const FunctionSpace& target ) {

--- a/src/atlas/interpolation/method/structured/StructuredInterpolation3D.tcc
+++ b/src/atlas/interpolation/method/structured/StructuredInterpolation3D.tcc
@@ -73,7 +73,7 @@ void StructuredInterpolation3D<Kernel>::do_setup( const Grid& source, const Grid
 template <typename Kernel>
 void StructuredInterpolation3D<Kernel>::do_setup( const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
     ATLAS_TRACE( "StructuredInterpolation3D<" + Kernel::className() + ">::do_setup(FunctionSpace source, FunctionSpace target, const Cache)" );
-    if (interpolation::MatrixCache(cache)) {
+    if (! matrix_free_ && interpolation::MatrixCache(cache)) {
         setMatrix(cache);
         source_ = source;
         target_ = target;
@@ -81,11 +81,9 @@ void StructuredInterpolation3D<Kernel>::do_setup( const FunctionSpace& source, c
         ATLAS_ASSERT(matrix().cols() == source.size());
         return;
     }
-    if (functionspace::StructuredColumns(source) && functionspace::PointCloud(target)) {
+    else {
         do_setup( source, target );
-        return;
     }
-    ATLAS_NOTIMPLEMENTED;
 }
 
 template <typename Kernel>

--- a/src/atlas/interpolation/method/structured/StructuredInterpolation3D.tcc
+++ b/src/atlas/interpolation/method/structured/StructuredInterpolation3D.tcc
@@ -71,12 +71,21 @@ void StructuredInterpolation3D<Kernel>::do_setup( const Grid& source, const Grid
 }
 
 template <typename Kernel>
-void StructuredInterpolation3D<Kernel>::do_setup( const FunctionSpace& source, const FunctionSpace& target, const Cache& ) {
-    if ( mpi::size() > 1 ) {
-        ATLAS_NOTIMPLEMENTED;
+void StructuredInterpolation3D<Kernel>::do_setup( const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
+    ATLAS_TRACE( "StructuredInterpolation3D<" + Kernel::className() + ">::do_setup(FunctionSpace source, FunctionSpace target, const Cache)" );
+    if (interpolation::MatrixCache(cache)) {
+        setMatrix(cache);
+        source_ = source;
+        target_ = target;
+        ATLAS_ASSERT(matrix().rows() == target.size());
+        ATLAS_ASSERT(matrix().cols() == source.size());
+        return;
     }
-
-    do_setup( source, target );
+    if (functionspace::StructuredColumns(source) && functionspace::PointCloud(target)) {
+        do_setup( source, target );
+        return;
+    }
+    ATLAS_NOTIMPLEMENTED;
 }
 
 template <typename Kernel>

--- a/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
+++ b/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
@@ -663,18 +663,12 @@ void ConservativeSphericalPolygonInterpolation::do_setup(const FunctionSpace& so
                                                          const interpolation::Cache& cache) {
     ATLAS_TRACE("ConservativeSphericalPolygonInterpolation::do_setup(FunctionSpace, FunctionSpace, Cache)");
 
-    src_fs_ = source;
-    tgt_fs_ = target;
-
     if (not matrix_free_) {
         auto matrix_cache = interpolation::MatrixCache(cache);
         if (matrix_cache) {
             if (matrix_cache.uid() == std::to_string(order_) || matrix_cache.uid().empty()) {
                 Log::debug() << "Matrix found in cache -> no setup required at all" << std::endl;
-                src_fs_ = source;
-                tgt_fs_ = target;
                 setMatrix(matrix_cache);
-                return;
             }
         }
     }

--- a/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
+++ b/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
@@ -698,6 +698,7 @@ void ConservativeSphericalPolygonInterpolation::do_setup(const FunctionSpace& so
             return;
         }
     }
+
     do_setup(source, target);
 }
 

--- a/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
+++ b/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
@@ -669,7 +669,13 @@ void ConservativeSphericalPolygonInterpolation::do_setup(const FunctionSpace& so
             if (matrix_cache.uid() == std::to_string(order_) || matrix_cache.uid().empty()) {
                 Log::debug() << "Matrix found in cache -> no setup required at all" << std::endl;
                 setMatrix(matrix_cache);
+                src_fs_ = source;
+                tgt_fs_ = target;
+                return;
             }
+        }
+        else {
+            Log::warning() << "Could not find matrix in cache" << std::endl;
         }
     }
 
@@ -677,17 +683,9 @@ void ConservativeSphericalPolygonInterpolation::do_setup(const FunctionSpace& so
         Log::debug() << "Interpolation data found in cache -> no polygon intersections required" << std::endl;
         cache_ = Cache(cache);
         data_  = cache_.get();
-        sharable_data_.reset();
-
-        if (not data_->tgt_fs_) {
-            tgt_fs_                 = target;
-            sharable_data_->tgt_fs_ = target;
-        }
-        if (not data_->src_fs_) {
-            src_fs_                 = source;
-            sharable_data_->src_fs_ = source;
-        }
-
+        sharable_data_.reset(new Data());
+        tgt_fs_                 = target;
+        src_fs_                 = source;
         src_cell_data_ = functionspace::CellColumns(src_fs_);
         tgt_cell_data_ = functionspace::CellColumns(tgt_fs_);
 

--- a/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.h
+++ b/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.h
@@ -144,8 +144,8 @@ public:
 
     void print(std::ostream& out) const override;
 
-    const FunctionSpace& source() const override { return data_->src_fs_; }
-    const FunctionSpace& target() const override { return data_->tgt_fs_; }
+    const FunctionSpace& source() const override { return src_fs_; }
+    const FunctionSpace& target() const override { return tgt_fs_; }
 
     inline const PointXYZ& src_points(size_t id) const { return data_->src_points_[id]; }
     inline const PointXYZ& tgt_points(size_t id) const { return data_->tgt_points_[id]; }

--- a/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.h
+++ b/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.h
@@ -138,6 +138,7 @@ public:
     using Method::do_setup;
     void do_setup(const FunctionSpace& src_fs, const FunctionSpace& tgt_fs) override;
     void do_setup(const Grid& src_grid, const Grid& tgt_grid, const interpolation::Cache&) override;
+    void do_setup(const FunctionSpace& source, const FunctionSpace& target, const interpolation::Cache&) override;
     void do_execute(const Field& src_field, Field& tgt_field, Metadata&) const override;
     void do_execute(const FieldSet& src_fields, FieldSet& tgt_fields, Metadata&) const override;
 

--- a/src/atlas/interpolation/method/unstructured/FiniteElement.cc
+++ b/src/atlas/interpolation/method/unstructured/FiniteElement.cc
@@ -92,11 +92,7 @@ void FiniteElement::do_setup(const FunctionSpace& source, const FunctionSpace& t
         ATLAS_ASSERT(matrix().cols() == source.size());
         return;
     }
-    if (functionspace::NodeColumns(source) && functionspace::PointCloud(target)) {
-        do_setup(source, target);
-        return;
-    }
-    ATLAS_NOTIMPLEMENTED;
+    do_setup(source, target);
 }
 
 void FiniteElement::do_setup(const FunctionSpace& source, const FunctionSpace& target) {

--- a/src/atlas/interpolation/method/unstructured/FiniteElement.cc
+++ b/src/atlas/interpolation/method/unstructured/FiniteElement.cc
@@ -83,6 +83,18 @@ void FiniteElement::do_setup(const Grid& source, const Grid& target, const Cache
     do_setup(make_nodecolumns(source), functionspace::PointCloud{target});
 }
 
+void FiniteElement::do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
+    source_ = source;
+    target_ = target;
+    if (interpolation::MatrixCache(cache)) {
+        setMatrix(cache);
+        ATLAS_ASSERT(matrix().rows() == target.size());
+        ATLAS_ASSERT(matrix().cols() == source.size());
+        return;
+    }
+    do_setup(source, target);
+}
+
 void FiniteElement::do_setup(const FunctionSpace& source, const FunctionSpace& target) {
     ATLAS_TRACE("atlas::interpolation::method::FiniteElement::do_setup()");
 

--- a/src/atlas/interpolation/method/unstructured/FiniteElement.cc
+++ b/src/atlas/interpolation/method/unstructured/FiniteElement.cc
@@ -83,16 +83,20 @@ void FiniteElement::do_setup(const Grid& source, const Grid& target, const Cache
     do_setup(make_nodecolumns(source), functionspace::PointCloud{target});
 }
 
-void FiniteElement::do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
-    source_ = source;
-    target_ = target;
+void FiniteElement::do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) { 
     if (interpolation::MatrixCache(cache)) {
         setMatrix(cache);
+        source_ = source;
+        target_ = target;
         ATLAS_ASSERT(matrix().rows() == target.size());
         ATLAS_ASSERT(matrix().cols() == source.size());
         return;
     }
-    do_setup(source, target);
+    if (functionspace::NodeColumns(source) && functionspace::PointCloud(target)) {
+        do_setup(source, target);
+        return;
+    }
+    ATLAS_NOTIMPLEMENTED;
 }
 
 void FiniteElement::do_setup(const FunctionSpace& source, const FunctionSpace& target) {

--- a/src/atlas/interpolation/method/unstructured/FiniteElement.h
+++ b/src/atlas/interpolation/method/unstructured/FiniteElement.h
@@ -65,8 +65,8 @@ protected:
 private:
     using Method::do_setup;
     virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target) override;
-
     virtual void do_setup(const Grid& source, const Grid& target, const Cache&) override;
+    virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) override;
 
 protected:
     mesh::MultiBlockConnectivity* connectivity_;

--- a/src/atlas/interpolation/method/unstructured/UnstructuredBilinearLonLat.cc
+++ b/src/atlas/interpolation/method/unstructured/UnstructuredBilinearLonLat.cc
@@ -91,11 +91,7 @@ void UnstructuredBilinearLonLat::do_setup(const FunctionSpace& source, const Fun
         ATLAS_ASSERT(matrix().cols() == source.size());
         return;
     }
-    if (functionspace::NodeColumns(source) && functionspace::PointCloud(target)) {
-        do_setup(source, target);
-        return;
-    }
-    ATLAS_NOTIMPLEMENTED;
+    do_setup(source, target);
 }
 
 void UnstructuredBilinearLonLat::do_setup(const FunctionSpace& source, const FunctionSpace& target) {

--- a/src/atlas/interpolation/method/unstructured/UnstructuredBilinearLonLat.cc
+++ b/src/atlas/interpolation/method/unstructured/UnstructuredBilinearLonLat.cc
@@ -83,11 +83,16 @@ void UnstructuredBilinearLonLat::do_setup(const Grid& source, const Grid& target
 void UnstructuredBilinearLonLat::do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
     allow_halo_exchange_ = false;
     //  no halo_exchange because we don't have any halo with delaunay or 3d structured meshgenerator
-
     if (interpolation::MatrixCache(cache)) {
         setMatrix(cache);
+        source_ = source;
+        target_ = target;
         ATLAS_ASSERT(matrix().rows() == target.size());
         ATLAS_ASSERT(matrix().cols() == source.size());
+        return;
+    }
+    if (functionspace::NodeColumns(source) && functionspace::PointCloud(target)) {
+        do_setup(source, target);
         return;
     }
     ATLAS_NOTIMPLEMENTED;

--- a/src/atlas/interpolation/method/unstructured/UnstructuredBilinearLonLat.cc
+++ b/src/atlas/interpolation/method/unstructured/UnstructuredBilinearLonLat.cc
@@ -80,6 +80,19 @@ void UnstructuredBilinearLonLat::do_setup(const Grid& source, const Grid& target
     do_setup(make_nodecolumns(source), functionspace::PointCloud{target});
 }
 
+void UnstructuredBilinearLonLat::do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache& cache) {
+    allow_halo_exchange_ = false;
+    //  no halo_exchange because we don't have any halo with delaunay or 3d structured meshgenerator
+
+    if (interpolation::MatrixCache(cache)) {
+        setMatrix(cache);
+        ATLAS_ASSERT(matrix().rows() == target.size());
+        ATLAS_ASSERT(matrix().cols() == source.size());
+        return;
+    }
+    ATLAS_NOTIMPLEMENTED;
+}
+
 void UnstructuredBilinearLonLat::do_setup(const FunctionSpace& source, const FunctionSpace& target) {
     ATLAS_TRACE("atlas::interpolation::method::BilinearRemapping::do_setup()");
 

--- a/src/atlas/interpolation/method/unstructured/UnstructuredBilinearLonLat.h
+++ b/src/atlas/interpolation/method/unstructured/UnstructuredBilinearLonLat.h
@@ -63,6 +63,7 @@ private:
     virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target) override;
 
     virtual void do_setup(const Grid& source, const Grid& target, const Cache&) override;
+    virtual void do_setup(const FunctionSpace& source, const FunctionSpace& target, const Cache&) override;
 
 protected:
     mesh::MultiBlockConnectivity* connectivity_;

--- a/src/atlas/linalg/sparse/SparseMatrixStorage.h
+++ b/src/atlas/linalg/sparse/SparseMatrixStorage.h
@@ -243,6 +243,9 @@ SparseMatrixStorage make_sparse_matrix_storage(SparseMatrixStorage&& other) {
 
 template<typename Value, typename Index = eckit::linalg::Index>
 inline SparseMatrixView<Value,Index> make_host_view(const SparseMatrixStorage& m) {
+    if(m.rows() == 0 && m.cols() == 0) {
+        return SparseMatrixView<Value,Index>();
+    }
     if( m.value().datatype().kind() != DataType::kind<Value>() || m.outer().datatype().kind() != DataType::kind<Index>() ) {
         ATLAS_THROW_EXCEPTION("Cannot make_host_view<" + DataType::str<Value>() + "," << DataType::str<Index>() +
             ">(const SparseMatrixStorage&) from SparseMatrixStorage containing values of type <" + m.value().datatype().str() + "> and indices of type <" + m.outer().datatype().str() +">" );
@@ -261,6 +264,9 @@ inline SparseMatrixView<Value,Index> make_host_view(const SparseMatrixStorage& m
 
 template<typename Value, typename Index = eckit::linalg::Index>
 inline SparseMatrixView<Value,Index> make_device_view(const SparseMatrixStorage& m) {
+    if(m.rows() == 0 && m.cols() == 0) {
+        return SparseMatrixView<Value,Index>();
+    }
     if( m.value().datatype().kind() != DataType::kind<Value>() || m.outer().datatype().kind() != DataType::kind<Index>() ) {
         ATLAS_THROW_EXCEPTION("Cannot make_device_view<" + DataType::str<Value>() + "," << DataType::str<Index>() +
             ">(const SparseMatrixStorage&) from SparseMatrixStorage containing values of type <" + m.value().datatype().str() + "> and indices of type <" + m.outer().datatype().str() +">" );

--- a/src/atlas/linalg/sparse/SparseMatrixToTriplets.h
+++ b/src/atlas/linalg/sparse/SparseMatrixToTriplets.h
@@ -122,7 +122,7 @@ SparseMatrixStorage make_sparse_matrix_storage_from_rows_columns_values(std::siz
     std::size_t nnz = vals.size();
     ATLAS_ASSERT(rows.size() == nnz);
     ATLAS_ASSERT(cols.size() == nnz);
-    return make_sparse_matrix_storage_from_rows_columns_values<SparseMatrixValue,SparseMatrixIndex>(nr, nc, nnz, rows.data(), cols.data(), vals.data(), index_base, is_sorted);
+    return make_sparse_matrix_storage_from_rows_columns_values<SparseMatrixValue, SparseMatrixIndex>(nr, nc, nnz, rows.data(), cols.data(), vals.data(), index_base, is_sorted);
 }
 
 

--- a/src/atlas/linalg/sparse/SparseMatrixToTriplets.h
+++ b/src/atlas/linalg/sparse/SparseMatrixToTriplets.h
@@ -16,6 +16,7 @@
 #include "atlas/linalg/sparse/SparseMatrixStorage.h"
 #include "atlas/linalg/sparse/SparseMatrixView.h"
 #include "atlas/util/DataType.h"
+#include "atlas/runtime/Trace.h"
 
 namespace atlas::linalg {
 
@@ -119,6 +120,7 @@ SparseMatrixStorage make_sparse_matrix_storage_from_rows_columns_values(std::siz
 
 template<typename SparseMatrixValue = eckit::linalg::Scalar, typename SparseMatrixIndex = eckit::linalg::Index, typename Value, typename Index, typename IndexBase>
 SparseMatrixStorage make_sparse_matrix_storage_from_rows_columns_values(std::size_t nr, std::size_t nc, const std::vector<Index>& rows, const std::vector<Index>& cols, const std::vector<Value>& vals, const IndexBase index_base = 0, bool is_sorted = true) {
+    ATLAS_TRACE("make_sparse_matrix_storage_from_rows_columns_values partition");
     std::size_t nnz = vals.size();
     ATLAS_ASSERT(rows.size() == nnz);
     ATLAS_ASSERT(cols.size() == nnz);

--- a/src/tests/interpolation/CMakeLists.txt
+++ b/src/tests/interpolation/CMakeLists.txt
@@ -150,12 +150,18 @@ ecbuild_add_test( TARGET atlas_test_interpolation_binning
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )
 
-ecbuild_add_test( TARGET atlas_test_interpolation_global_matrix
+ecbuild_add_test( TARGET atlas_test_par_interpolation_global_matrix
   SOURCES  test_interpolation_global_matrix.cc
   LIBS     atlas
   CONDITION eckit_HAVE_MPI AND MPI_SLOTS GREATER_EQUAL 6
   MPI      6
   OMP      1
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
+
+ecbuild_add_test( TARGET atlas_test_interpolation_global_matrix
+  SOURCES  test_interpolation_global_matrix.cc
+  LIBS     atlas
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )
 

--- a/src/tests/interpolation/CMakeLists.txt
+++ b/src/tests/interpolation/CMakeLists.txt
@@ -153,8 +153,9 @@ ecbuild_add_test( TARGET atlas_test_interpolation_binning
 ecbuild_add_test( TARGET atlas_test_interpolation_global_matrix
   SOURCES  test_interpolation_global_matrix.cc
   LIBS     atlas
-  CONDITION eckit_HAVE_MPI AND MPI_SLOTS GREATER_EQUAL 3
-  MPI      3
+  CONDITION eckit_HAVE_MPI AND MPI_SLOTS GREATER_EQUAL 6
+  MPI      6
+  OMP      1
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )
 

--- a/src/tests/interpolation/test_interpolation_global_matrix.cc
+++ b/src/tests/interpolation/test_interpolation_global_matrix.cc
@@ -268,7 +268,7 @@ using SparseMatrixStorage = atlas::linalg::SparseMatrixStorage;
         do_assemble_distribute_matrix("unstructured-bilinear-lonlat", input_grid, output_grid, mpi_root);
     };
 
-    test_matrix_assemble_distribute(Grid("O128"), Grid("F128"));
+    test_matrix_assemble_distribute(Grid("O48"), Grid("F48"));
 }
 
 }  // namespace

--- a/src/tests/interpolation/test_interpolation_global_matrix.cc
+++ b/src/tests/interpolation/test_interpolation_global_matrix.cc
@@ -20,7 +20,6 @@
 #include "atlas/interpolation/AssembleGlobalMatrix.h"
 #include "atlas/mesh/Mesh.h"
 #include "atlas/meshgenerator.h"
-#include "atlas/output/Gmsh.h"
 #include "atlas/util/CoordinateEnums.h"
 #include "atlas/util/function/VortexRollup.h"
 #include "atlas/linalg/sparse.h"
@@ -240,12 +239,6 @@ using SparseMatrixStorage = atlas::linalg::SparseMatrixStorage;
                 for (gidx_t p = 0; p < fdiff_v.size(); ++p) {
                     fdiff_v(p) = tfield_global_v(p) - tgt_data[p];
                 }
-                mpi::Scope scope("self");
-                output::Gmsh gmsh("mesh.msh");
-                auto mesh = Mesh(output_grid);
-                auto fs = functionspace::NodeColumns(mesh);
-                gmsh.write(mesh);
-                gmsh.write(fdiff, fs);
             }
         }
     };

--- a/src/tests/interpolation/test_interpolation_global_matrix.cc
+++ b/src/tests/interpolation/test_interpolation_global_matrix.cc
@@ -153,32 +153,29 @@ using SparseMatrixStorage = atlas::linalg::SparseMatrixStorage;
         return std::make_tuple(fs_in, fs_out, std::move(matrix));
     };
 
-    auto distribute_global_matrix = [&](const FunctionSpace& fs_in, const FunctionSpace& fs_out, const SparseMatrixStorage& gmatrix, int mpi_root) {
-        return interpolation::distribute_global_matrix(fs_in, fs_out, gmatrix, mpi_root);
-    };
-
     auto do_assemble_distribute_matrix = [&](const std::string scheme_str, const Grid& input_grid, const Grid& output_grid, const int mpi_root) {
         FunctionSpace fs_in;
         FunctionSpace fs_out;
         SparseMatrixStorage gmatrix;
         std::tie(fs_in, fs_out, gmatrix) = assemble_global_matrix(scheme_str, input_grid, output_grid, mpi_root);
-        SparseMatrixStorage matrix = distribute_global_matrix(fs_in, fs_out, gmatrix, mpi_root);
+        SparseMatrixStorage matrix = interpolation::distribute_global_matrix(fs_in, fs_out, gmatrix, mpi_root);
         
         // createinterpolator
-
+        Config config;
+        config.set("type", "finite-element");
+        interpolation::MatrixCache cache(std::move(matrix));
+        //auto interp = Interpolation(config, input_grid, output_grid, cache);
     };
 
     auto test_matrix_assemble_distribute = [&](const Grid& input_grid, const Grid& output_grid) {
         int mpi_root = 0;
         do_assemble_distribute_matrix("linear", input_grid, output_grid, mpi_root);
 
-    return;
-
         mpi_root = mpi::size() - 1;
         do_assemble_distribute_matrix("linear", input_grid, output_grid, mpi_root);
         do_assemble_distribute_matrix("cubic", input_grid, output_grid, mpi_root);
         do_assemble_distribute_matrix("quasicubic", input_grid, output_grid, mpi_root);
-        do_assemble_distribute_matrix("conservative", input_grid, output_grid, mpi_root);
+        //do_assemble_distribute_matrix("conservative", input_grid, output_grid, mpi_root);
         do_assemble_distribute_matrix("finite-element", input_grid, output_grid, mpi_root);
     };
 

--- a/src/tests/interpolation/test_interpolation_global_matrix.cc
+++ b/src/tests/interpolation/test_interpolation_global_matrix.cc
@@ -159,20 +159,24 @@ using SparseMatrixStorage = atlas::linalg::SparseMatrixStorage;
         // nothing yet
     };
 
-    auto test_matrix_assemble_distribute = [&](const Grid& input_grid, const Grid& output_grid) {
-        int mpi_root = 0;
+    auto do_assemble_distribute_matrix = [&](const std::string scheme_str, const Grid& input_grid, const Grid& output_grid, const int mpi_root) {
         FunctionSpace* fs_in;
         FunctionSpace* fs_out;
         SparseMatrixStorage* gmatrix;
-        std::tie(fs_in, fs_out, gmatrix) = assemble_global_matrix("linear", input_grid, output_grid, mpi_root);
+        std::tie(fs_in, fs_out, gmatrix) = assemble_global_matrix(scheme_str, input_grid, output_grid, mpi_root);
         distribute_global_matrix(*fs_in, *fs_out, *gmatrix);
+    };
 
-        int mpi_root = 0; mpi::size() - 1;
-        assemble_global_matrix("linear", input_grid, output_grid, mpi_root);
-        assemble_global_matrix("cubic", input_grid, output_grid, mpi_root);
-        assemble_global_matrix("quasicubic", input_grid, output_grid, mpi_root);
-        assemble_global_matrix("conservative", input_grid, output_grid, mpi_root);
-        assemble_global_matrix("finite-element", input_grid, output_grid, mpi_root);
+    auto test_matrix_assemble_distribute = [&](const Grid& input_grid, const Grid& output_grid) {
+        int mpi_root = 0;
+        do_assemble_distribute_matrix("linear", input_grid, output_grid, mpi_root);
+
+        mpi_root = mpi::size() - 1;
+        do_assemble_distribute_matrix("linear", input_grid, output_grid, mpi_root);
+        do_assemble_distribute_matrix("cubic", input_grid, output_grid, mpi_root);
+        do_assemble_distribute_matrix("quasicubic", input_grid, output_grid, mpi_root);
+        do_assemble_distribute_matrix("conservative", input_grid, output_grid, mpi_root);
+        do_assemble_distribute_matrix("finite-element", input_grid, output_grid, mpi_root);
     };
 
     test_matrix_assemble_distribute(Grid("O16"), Grid("F32"));

--- a/src/tests/interpolation/test_interpolation_global_matrix.cc
+++ b/src/tests/interpolation/test_interpolation_global_matrix.cc
@@ -227,11 +227,6 @@ using SparseMatrixStorage = atlas::linalg::SparseMatrixStorage;
             }
             interpolator.execute(field_in, tgt_field);
 
-            auto tfield_v = array::make_view<double, 1>(tgt_field);
-            for (gidx_t i = 0; i < tfield_v.size(); ++i) {
-                EXPECT_APPROX_EQ(tgt_data[i], tfield_v(i), 1.e-14);
-            }
-
             tgt_field.haloExchange();
             interpolator.target().gather(tgt_field, tgt_field_global);
         }


### PR DESCRIPTION
1. add method 'distribute_global_matrix (src_fs, tgt_fs, global_matrix, mpi_root)' to return local interpolation matrices
2. make sure that interpolation method in Atlas which take cache matrix as an argument actually use that cache
3. extend test_interpolation_global_matrix to: 1) create a global matrix from a parallel interpolator (was there before); 2) distribute the global matrix to task-local matrices (new); 3) compare the remapped field gathered in a global field on the single task with the global-matrix remapped global field.
4. extend sandbox/atlas-global-matrix to be able to read from the disc and distribute matrix to the parallel interpolator