### PR TITLE
Add offloading of discontiguous arrays

### DIFF
--- a/src/atlas/array/native/NativeArray.cc
+++ b/src/atlas/array/native/NativeArray.cc
@@ -61,8 +61,7 @@ Array* Array::wrap(Value* data, const ArrayShape& shape) {
 }
 template <typename Value>
 Array* Array::wrap(Value* data, const ArraySpec& spec) {
-    size_t size = spec.size();
-    return new ArrayT<Value>(new native::WrappedDataStore<Value>(data, size), spec);
+    return new ArrayT<Value>(new native::WrappedDataStore<Value>(data, spec), spec);
 }
 
 Array::~Array() = default;


### PR DESCRIPTION
This allows to offload existing wrapped data which may discontiguous as a slice of a larger array. This is e.g. the case when using a Multifield.

It makes use of HIC.

This is co-developed with @sbrdar
