### PR TITLE
Use pluto default memory resources in atlas::array

### DIFF
--- a/pluto/src/pluto/memory_resource.h
+++ b/pluto/src/pluto/memory_resource.h
@@ -38,8 +38,14 @@ void set_label(std::string_view);
 void unset_label();
 class scoped_label {
 public:
-    scoped_label(std::string_view s) { set_label(s); }
-    ~scoped_label() { unset_label(); }
+    scoped_label(std::string_view s) :
+        previous_(get_label()) {
+        set_label(s); }
+    ~scoped_label() {
+        set_label(previous_);
+    }
+private:
+    std::string previous_;
 };
 
 using memory_resource = STD_PMR::memory_resource;

--- a/src/atlas/array/ArraySpec.cc
+++ b/src/atlas/array/ArraySpec.cc
@@ -185,5 +185,16 @@ void ArraySpec::allocate_fortran_specs() {
     }
 }
 
+
+static thread_local std::string label_;
+
+std::string_view label::get() {
+    return label_;
+}
+
+void label::set(std::string_view s) {
+    label_.assign(s.data(),s.size());
+}
+
 }  // namespace array
 }  // namespace atlas

--- a/src/atlas/array/ArraySpec.h
+++ b/src/atlas/array/ArraySpec.h
@@ -12,6 +12,8 @@
 
 #include <stddef.h>
 #include <vector>
+#include <string_view>
+#include <string>
 
 #include "atlas/array/ArrayIdx.h"
 #include "atlas/array/ArrayLayout.h"
@@ -73,6 +75,23 @@ public:
 
 private:
     void allocate_fortran_specs();
+};
+
+// --------------------------------------------------------------------------------------------
+
+class label {
+public:
+    label(std::string_view s) {
+        previous_ = get();
+        set(s);
+    }
+    ~label() {
+        set(previous_);
+    }
+    static std::string_view get();
+    static void set(std::string_view);
+private:
+    std::string previous_;
 };
 
 //------------------------------------------------------------------------------------------------------

--- a/src/atlas/field/detail/FieldImpl.cc
+++ b/src/atlas/field/detail/FieldImpl.cc
@@ -61,6 +61,7 @@ FieldImpl::FieldImpl(const std::string& name, array::DataType datatype, const ar
     :functionspace_(new FunctionSpace())
 #endif
 {
+    array::label label(name);
     array_ = array::Array::create(datatype, shape);
     array_->attach();
     rename(name);
@@ -73,6 +74,7 @@ FieldImpl::FieldImpl(const std::string& name, array::DataType datatype, array::A
     :functionspace_(new FunctionSpace())
 #endif
 {
+    array::label label(name);
     array_ = array::Array::create(datatype, std::move(spec));
     array_->attach();
     rename(name);

--- a/src/tests/field/CMakeLists.txt
+++ b/src/tests/field/CMakeLists.txt
@@ -18,6 +18,12 @@ ecbuild_add_test( TARGET atlas_test_field_missingvalue
     ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )
 
+ecbuild_add_test( TARGET atlas_test_field_memory_resource
+    SOURCES     test_field_memory_resource.cc
+    LIBS        atlas
+    ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
+
 ecbuild_add_test( TARGET atlas_test_field_foreach
   SOURCES  test_field_foreach.cc
   LIBS     atlas

--- a/src/tests/field/test_field_memory_resource.cc
+++ b/src/tests/field/test_field_memory_resource.cc
@@ -1,0 +1,103 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+
+#include <sstream>
+
+#include "pluto/pluto.h"
+#include "atlas/field.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+
+namespace atlas {
+namespace test {
+
+CASE("default resource") {
+    std::stringstream pluto_trace_stream;
+    
+    pluto::trace::enable(true);
+    pluto::trace::set(pluto_trace_stream);
+    Field field_1("field_1", make_datatype<double>(), array::make_shape(20, 5));
+    {
+        Field field_2("field_2", make_datatype<double>(), array::make_shape(200, 5));
+    }
+    Field field_3("field_3", make_datatype<double>(), array::make_shape(20, 10));
+
+    EXPECT_EQ( pluto::memory::host.total_allocations() , 3 );
+    EXPECT_EQ( pluto::memory::host.allocations() , 2 );
+    EXPECT_EQ( pluto::memory::host.bytes() , 2400 );
+    EXPECT_EQ( pluto::memory::host.high_watermark() , 8800 );
+
+    auto pluto_trace = pluto_trace_stream.str();
+    std::cout << "pluto_trace:\n" << pluto_trace << std::endl;
+
+    auto pluto_trace_contains = [&pluto_trace](const std::string& str) {
+        return (pluto_trace.find(str) != std::string::npos);
+    };
+
+    EXPECT(pluto_trace_contains("PLUTO_TRACE pluto::host_resource::allocate(label=field_1, bytes=800.00B, alignment=256)"));
+    EXPECT(pluto_trace_contains("PLUTO_TRACE pluto::host_resource::allocate(label=field_2, bytes=7.81K, alignment=256)"));
+    EXPECT(pluto_trace_contains("PLUTO_TRACE pluto::host_resource::deallocate(label=field_2"));
+    EXPECT(pluto_trace_contains("PLUTO_TRACE pluto::host_resource::allocate(label=field_3, bytes=1.56K, alignment=256)"));
+
+    pluto::trace::enable(false);
+}
+
+CASE("pinned_pool_resource") {
+
+    pluto::host::set_default_resource("pluto::pinned_pool_resource");
+
+    std::stringstream pluto_trace_stream;
+    
+    pluto::trace::enable(true);
+    pluto::trace::set(pluto_trace_stream);
+    Field field_1("field_1", make_datatype<double>(), array::make_shape(20, 5));
+    {
+        Field field_2("field_2", make_datatype<double>(), array::make_shape(200, 5));
+    }
+    Field field_3("field_3", make_datatype<double>(), array::make_shape(20, 10));
+
+    EXPECT_EQ( pluto::memory::pinned.total_allocations() , 1 );
+    EXPECT_EQ( pluto::memory::pinned.allocations() , 1 );
+    EXPECT_EQ( pluto::memory::pinned.bytes() , 256*1024*1024 ); // 256 mb
+    EXPECT_EQ( pluto::memory::pinned.high_watermark() , 256*1024*1024 );
+
+    EXPECT_EQ( pluto::memory::pinned_pool.total_allocations() , 3 );
+    EXPECT_EQ( pluto::memory::pinned_pool.allocations() , 2 );
+    EXPECT_EQ( pluto::memory::pinned_pool.bytes() , 2400 );
+    EXPECT_EQ( pluto::memory::pinned_pool.high_watermark() , 8800 );
+
+    auto pluto_trace = pluto_trace_stream.str();
+    std::cout << "pluto_trace:\n" << pluto_trace << std::endl;
+
+    auto pluto_trace_contains = [&pluto_trace](const std::string& str) {
+        return (pluto_trace.find(str) != std::string::npos);
+    };
+
+    EXPECT(pluto_trace_contains("PLUTO_TRACE pluto::pinned_resource::allocate(label=pool_chunk, bytes=256.00M, alignment=256)"));
+    EXPECT(pluto_trace_contains("PLUTO_TRACE pluto::pinned_pool_resource::allocate(label=field_1, bytes=800.00B, alignment=256)"));
+    EXPECT(pluto_trace_contains("PLUTO_TRACE pluto::pinned_pool_resource::allocate(label=field_2, bytes=7.81K, alignment=256)"));
+    EXPECT(pluto_trace_contains("PLUTO_TRACE pluto::pinned_pool_resource::deallocate(label=field_2"));
+    EXPECT(pluto_trace_contains("PLUTO_TRACE pluto::pinned_pool_resource::allocate(label=field_3, bytes=1.56K, alignment=256)"));
+
+    pluto::trace::enable(false);
+
+}
+
+
+}  // namespace test
+}  // namespace atlas
+
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}


### PR DESCRIPTION
NOTE, this PR applies only to `atlas::array::Array`, which also underpins `atlas::Field`!

Until now atlas was using a fixed strategy for host and device allocations in the atlas::array::Array
- host -> At least 64-byte aligned memory allocation, via `posix_memalign` (before #270) or 256-byte aligned `pluto::host_resource()` after.
- device -> `cudaMalloc` or `hipMalloc` via `hicMalloc` (before #270) or `pluto::device_resource()` after.

With this PR we now use:
- host -> `pluto::host::get_default_resource()`
- device -> `pluto::device::get_default_resource()` 

### Example use case 1
Suppose we want to use a pool of pinned memory for the host, and a pool of device memory for device. This makes for fast host-device memory transfers.

We can setup this up with C++:
 - Using `pluto::memory_resource*` argument: 
   ```c++
   pluto::host::set_default_resource(pluto::pinned_pool_resource());
   pluto::device::set_default_resource(pluto::device_pool_resource());
   ```
 - Using string argument to registered names:
    ```c++
    pluto::host::set_default_resource("pluto::pinned_pool_resource");
    pluto::device::set_default_resource("pluto::device_pool_resource()");
    ```
 
 Or with Fortran:
 * Using `type(pluto_memory_resource)` argument: 
    ```Fortran 
    call pluto%host%set_default_resource(pluto%pinned_pool_resource())
    call pluto%device%set_default_resource(pluto%device_pool_resource())
    ````
 - Using string argument to registered names:
    ```Fortran 
    call pluto%host%set_default_resource("pluto::pinned_pool_resource")
    call pluto%device%set_default_resource("pluto::device_pool_resource")
    ````

Initial values for `pluto::host::get_default_resource()` and `pluto::device::get_default_resource()` are respectively `pluto::host_resource()` and `pluto::device_resource()`.
These initial values are also configurable via environment variables:
  `export PLUTO_HOST_MEMORY_RESOURCE=pluto::pinned_pool_resource`
  `export PLUTO_DEVICE_MEMORY_RESOURCE=pluto::device_pool_resource`

Pluto provides following memory_resources, accessible by name or function:
- `pluto::host_resource`,  `pluto::host_pool_resource`
- `pluto::pinned_resource`, `pluto::pinned_pool_resource`
- `pluto::managed_resource`, `pluto::managed_pool_resource`
- `pluto::device_resource`, `pluto::device_pool_resource`

### Example use case 2
Using zero-copy approach or managed memory for device:
When following is retrieved for the `pluto::device::get_default_resource()`
-  `pluto::pinned_resource`, `pluto::pinned_pool_resource`
- `pluto::managed_resource`, `pluto::managed_pool_resource`

Then we assume the memory access for host and device is shared (a.k.a. unified): 
- The host-data will be allocated using the configured device memory_resource
- The device data will point to the host-data.


This PR also adds a `label` to the atlas::Array creation via `Field`, and passes this to pluto for tracing reasons.