### PR TITLE
Support nvidia 24.5

### DIFF
--- a/pluto/tests/CMakeLists.txt
+++ b/pluto/tests/CMakeLists.txt
@@ -14,9 +14,9 @@ ecbuild_add_test( TARGET pluto_test_memory_pool SOURCES pluto_test_memory_pool.c
 ecbuild_add_test( TARGET pluto_test_alignment   SOURCES pluto_test_alignment.cc   LIBS pluto )
 
 if( HAVE_FORTRAN )
-  ecbuild_add_test( TARGET pluto_test_fortran_memory_resource        SOURCES fortran/test_fortran_memory_resource.F90       LIBS pluto_f )
-  ecbuild_add_test( TARGET pluto_test_fortran_allocator              SOURCES fortran/test_fortran_allocator.F90             LIBS pluto_f )
-  ecbuild_add_test( TARGET pluto_test_fortran_memory_pool_resource   SOURCES fortran/test_fortran_memory_pool_resource.F90  LIBS pluto_f )
-  ecbuild_add_test( TARGET pluto_test_fortran_scope                  SOURCES fortran/test_fortran_scope.F90                 LIBS pluto_f )
+  ecbuild_add_test( TARGET pluto_test_fortran_memory_resource        SOURCES fortran/test_fortran_memory_resource.F90       LIBS pluto_f hic LINKER_LANGUAGE Fortran)
+  ecbuild_add_test( TARGET pluto_test_fortran_allocator              SOURCES fortran/test_fortran_allocator.F90             LIBS pluto_f hic LINKER_LANGUAGE Fortran)
+  ecbuild_add_test( TARGET pluto_test_fortran_memory_pool_resource   SOURCES fortran/test_fortran_memory_pool_resource.F90  LIBS pluto_f hic LINKER_LANGUAGE Fortran)
+  ecbuild_add_test( TARGET pluto_test_fortran_scope                  SOURCES fortran/test_fortran_scope.F90                 LIBS pluto_f hic LINKER_LANGUAGE Fortran)
 endif()
 

--- a/src/atlas/field/detail/MultiFieldInterface.cc
+++ b/src/atlas/field/detail/MultiFieldInterface.cc
@@ -8,9 +8,10 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <cmath>
-#include <cstring>
-#include <sstream>
+#include <algorithm>
+#include <vector>
+#include <string>
+#include <string_view>
 
 #include "atlas/library/config.h"
 #include "atlas/field/MultiField.h"
@@ -34,18 +35,16 @@ MultiFieldImpl* atlas__MultiField__create_shape(int kind, int rank, int shapef[]
     array::ArrayShape shape;
     shape.resize(rank);
     for (idx_t j = 0, jf = rank - 1; j < rank; ++j) {
-        shape[j]   = shapef[jf--];
+        shape[j] = shapef[jf--];
     }
 
     std::vector<std::string> var_names_str;
     for (size_t jj = 0; jj < size; ++jj) {
-        std::unique_ptr<char[]> str(new char[length + 1]);
-        ATLAS_ASSERT(snprintf(str.get(), length, "%s", var_names + jj * length ) >= 0);
-        std::string sstr(str.get());
-        sstr.erase(std::find_if(sstr.rbegin(), sstr.rend(), [](unsigned char ch) {
+        std::string str(std::string_view(var_names + jj * length, length));
+        str.erase(std::find_if(str.rbegin(), str.rend(), [](unsigned char ch) {
            return !std::isspace(ch);
-        }).base(), sstr.end());
-        var_names_str.push_back(sstr);
+        }).base(), str.end());
+        var_names_str.push_back(str);
     }
 
     auto multifield = new MultiField(array::DataType{kind}, shape, var_names_str);

--- a/src/atlas/functionspace/Spectral.h
+++ b/src/atlas/functionspace/Spectral.h
@@ -123,7 +123,7 @@ public:
             idx_t index = 0;
             if (global) {
                 if (owner == mpi::rank()) {
-                    atlas_omp_parallel_for(int m = 0; m <= truncation; ++m) {
+                    for(int m = 0; m <= truncation; ++m) {
                         for (int n = m; n <= truncation; ++n) {
                             f(index, index + 1, n, m);
                             index += 2;
@@ -133,7 +133,7 @@ public:
             }
             else {
                 const int nb_zonal_wavenumbers{static_cast<int>(zonal_wavenumbers.size())};
-                atlas_omp_parallel_for(int jm = 0; jm < nb_zonal_wavenumbers; ++jm) {
+                for(int jm = 0; jm < nb_zonal_wavenumbers; ++jm) {
                     const int m = zonal_wavenumbers(jm);
                     for (int n = m; n <= truncation; ++n) {
                         f(index, index + 1, n, m);
@@ -149,7 +149,7 @@ public:
             idx_t index = 0;
             if (global) {
                 if (owner == mpi::rank()) {
-                    atlas_omp_parallel_for(int m = 0; m <= truncation; ++m) {
+                    for(int m = 0; m <= truncation; ++m) {
                         for (int n = m; n <= truncation; ++n) {
                             f(index, index + 1, n);
                             index += 2;
@@ -159,7 +159,7 @@ public:
             }
             else {
                 const int nb_zonal_wavenumbers{static_cast<int>(zonal_wavenumbers.size())};
-                atlas_omp_parallel_for(int jm = 0; jm < nb_zonal_wavenumbers; ++jm) {
+                for(int jm = 0; jm < nb_zonal_wavenumbers; ++jm) {
                     const int m = zonal_wavenumbers(jm);
                     for (int n = m; n <= truncation; ++n) {
                         f(index, index + 1, n);

--- a/src/tests/field/fctest_multifield_ifs.F90
+++ b/src/tests/field/fctest_multifield_ifs.F90
@@ -42,8 +42,8 @@ END_TESTSUITE_FINALIZE
 TEST( test_multifield )
     implicit none
 
-    type(atlas_MultiField)  :: mfield(2)
-    type(atlas_FieldSet)    :: fieldset(2)
+    type(atlas_MultiField)  :: mfield_1, mfield_2
+    type(atlas_FieldSet)    :: fieldset_1, fieldset_2
     type(atlas_Field)       :: field
     type(atlas_config)      :: config
     integer, pointer :: fdata_int_2d(:,:)
@@ -73,39 +73,39 @@ TEST( test_multifield )
 
     call config%set("nlev", 0); ! surface fields
     call config%set("datatype", "real32");
-    mfield(1) = atlas_MultiField(config)
+    mfield_1 = atlas_MultiField(config)
 
     call config%set("nlev", 4); ! fields are 3d
     call config%set("datatype", "real64");
-    mfield(2) = atlas_MultiField(config)
+    mfield_2 = atlas_MultiField(config)
 
-    fieldset(1) = mfield(1)%fieldset()
-    FCTEST_CHECK_EQUAL(mfield(1)%size(), 5)
-    FCTEST_CHECK_EQUAL(fieldset(1)%size(), 5)
+    fieldset_1 = mfield_1%fieldset()
+    FCTEST_CHECK_EQUAL(mfield_1%size(), 5)
+    FCTEST_CHECK_EQUAL(fieldset_1%size(), 5)
 
-    fieldset(2) = atlas_FieldSet()
-    call fieldset(2)%add(mfield(1)%fieldset())
-    field = fieldset(2)%field("density")
+    fieldset_2 = atlas_FieldSet()
+    call fieldset_2%add(mfield_1%fieldset())
+    field = fieldset_2%field("density")
     call field%data(fdata_f2d)
     fdata_f2d(1,1) = 2.
     call field%rename("dens")
 
     ! check data access directly though multifield
-    call fieldset(1)%data("dens", fdata_f2d)
+    call fieldset_1%data("dens", fdata_f2d)
     fdata_f2d(1,1) = 3.
 
     ! check access to the renamed variable
-    field = fieldset(1)%field("dens")
+    field = fieldset_1%field("dens")
     call field%data(fdata_f2d)
     FCTEST_CHECK_EQUAL(fdata_f2d(1,1), 3._c_float)
 
     ! check dimesionality
-    fieldset(2) = mfield(2)%fieldset()
-    call fieldset(2)%data("density", fdata_d3d)
+    fieldset_2 = mfield_2%fieldset()
+    call fieldset_2%data("density", fdata_d3d)
     fdata_d3d(1,1,1) = 4.
-    fieldset(2) = atlas_FieldSet()
-    call fieldset(2)%add(mfield(2)%fieldset())
-    field = fieldset(2)%field("density")
+    fieldset_2 = atlas_FieldSet()
+    call fieldset_2%add(mfield_2%fieldset())
+    field = fieldset_2%field("density")
     call field%data(fdata_d3d)
     FCTEST_CHECK_EQUAL(fdata_d3d(1,1,1), 4._c_double)
 END_TEST
@@ -114,8 +114,8 @@ END_TEST
 TEST( test_multifield_array_direct_constructor )
     implicit none
 
-    type(atlas_MultiField)  :: mfield(2)
-    type(atlas_FieldSet)    :: fieldset(3)
+    type(atlas_MultiField)  :: mfield_1, mfield_2
+    type(atlas_FieldSet)    :: fieldset_1, fieldset_2, fieldset_3
     type(atlas_Field)       :: field
     type(atlas_config)      :: config
     real(c_float), pointer  :: fdata_f2d(:,:)
@@ -131,29 +131,29 @@ TEST( test_multifield_array_direct_constructor )
     character(len=64), parameter, dimension(2) :: var_names_dp = [ character(64) :: &
         "clv", "wind_u" ]
 
-    mfield(1) = atlas_MultiField(atlas_real(c_float), [nproma, -1, nblk], var_names_sp)
-    mfield(2) = atlas_MultiField(atlas_real(c_double), [nproma, nlev, -1, nblk], var_names_dp)
+    mfield_1 = atlas_MultiField(atlas_real(c_float), [nproma, -1, nblk], var_names_sp)
+    mfield_2 = atlas_MultiField(atlas_real(c_double), [nproma, nlev, -1, nblk], var_names_dp)
 
-    FCTEST_CHECK_EQUAL(mfield(1)%size(), 3)
-    FCTEST_CHECK_EQUAL(mfield(2)%size(), 2)
+    FCTEST_CHECK_EQUAL(mfield_1%size(), 3)
+    FCTEST_CHECK_EQUAL(mfield_2%size(), 2)
 
-    fieldset(1) = mfield(1)%fieldset()
-    FCTEST_CHECK_EQUAL(fieldset(1)%size(), 3)
+    fieldset_1 = mfield_1%fieldset()
+    FCTEST_CHECK_EQUAL(fieldset_1%size(), 3)
 
-    call fieldset(1)%data("density", fdata_f2d)
+    call fieldset_1%data("density", fdata_f2d)
     fdata_f2d(1,1) = 3._c_float
 
-    fieldset(2) = atlas_FieldSet()
-    call fieldset(2)%add(mfield(2)%fieldset())
-    call fieldset(2)%data("wind_u", fdata_d3d)
+    fieldset_2 = atlas_FieldSet()
+    call fieldset_2%add(mfield_2%fieldset())
+    call fieldset_2%data("wind_u", fdata_d3d)
     fdata_d3d(1,1,1) = 4._c_double
 
-    fieldset(3) = atlas_FieldSet()
-    call fieldset(3)%add(mfield(1)%fieldset())
-    call fieldset(3)%add(mfield(2)%fieldset())
+    fieldset_3 = atlas_FieldSet()
+    call fieldset_3%add(mfield_1%fieldset())
+    call fieldset_3%add(mfield_2%fieldset())
 
-    call fieldset(3)%data("density", fdata_f2d)
-    call fieldset(3)%data("wind_u", fdata_d3d)
+    call fieldset_3%data("density", fdata_f2d)
+    call fieldset_3%data("wind_u", fdata_d3d)
     FCTEST_CHECK_EQUAL(fdata_f2d(1,1), 3._c_float)
     FCTEST_CHECK_EQUAL(fdata_d3d(1,1,1), 4._c_double)
 
@@ -163,8 +163,8 @@ END_TEST
 TEST( test_multifield_array_config_constuctor )
     implicit none
 
-    type(atlas_MultiField)  :: mfield(2)
-    type(atlas_FieldSet)    :: fieldset(2)
+    type(atlas_MultiField)  :: mfield_1, mfield_2
+    type(atlas_FieldSet)    :: fieldset_1, fieldset_2
     type(atlas_Field)       :: field
     type(atlas_config)      :: config
     integer, pointer :: fdata_int_2d(:,:)
@@ -192,40 +192,40 @@ TEST( test_multifield_array_config_constuctor )
     ! surface fields
     call config%set("shape", [nproma, -1, nblk]);
     call config%set("datatype", "real32");
-    mfield(1) = atlas_MultiField(config)
+    mfield_1 = atlas_MultiField(config)
 
     ! fields are 3d
     call config%set("shape", [nproma, nlev, -1, nblk]);
     call config%set("datatype", "real64");
-    mfield(2) = atlas_MultiField(config)
+    mfield_2 = atlas_MultiField(config)
 
-    fieldset(1) = mfield(1)%fieldset()
-    FCTEST_CHECK_EQUAL(mfield(1)%size(), 9)
-    FCTEST_CHECK_EQUAL(fieldset(1)%size(), 9)
+    fieldset_1 = mfield_1%fieldset()
+    FCTEST_CHECK_EQUAL(mfield_1%size(), 9)
+    FCTEST_CHECK_EQUAL(fieldset_1%size(), 9)
 
-    fieldset(2) = atlas_FieldSet()
-    call fieldset(2)%add(mfield(1)%fieldset())
-    field = fieldset(2)%field("density")
+    fieldset_2 = atlas_FieldSet()
+    call fieldset_2%add(mfield_1%fieldset())
+    field = fieldset_2%field("density")
     call field%data(fdata_f2d)
     fdata_f2d(1,1) = 2.
     call field%rename("dens")
 
     ! check data access directly though multifield
-    call fieldset(1)%data("dens", fdata_f2d)
+    call fieldset_1%data("dens", fdata_f2d)
     fdata_f2d(1,1) = 3.
 
     ! check access to the renamed variable
-    field = fieldset(1)%field("dens")
+    field = fieldset_1%field("dens")
     call field%data(fdata_f2d)
     FCTEST_CHECK_EQUAL(fdata_f2d(1,1), 3._c_float)
 
     ! check dimesionality
-    fieldset(2) = mfield(2)%fieldset()
-    call fieldset(2)%data("density", fdata_d3d)
+    fieldset_2 = mfield_2%fieldset()
+    call fieldset_2%data("density", fdata_d3d)
     fdata_d3d(1,1,1) = 4.
-    fieldset(2) = atlas_FieldSet()
-    call fieldset(2)%add(mfield(2)%fieldset())
-    field = fieldset(2)%field("density")
+    fieldset_2 = atlas_FieldSet()
+    call fieldset_2%add(mfield_2%fieldset())
+    field = fieldset_2%field("density")
     call field%data(fdata_d3d)
     FCTEST_CHECK_EQUAL(fdata_d3d(1,1,1), 4._c_double)
 END_TEST

--- a/src/tests/grid/test_largegrid.cc
+++ b/src/tests/grid/test_largegrid.cc
@@ -48,14 +48,14 @@ CASE("test resources for cropping large grids") {
     std::vector<std::string> gridnames{"L40000x20000", "N8000", "O8000"};
 
     for (auto& gridname : gridnames) {
-        EXPECT(Trace::peakMemory() < 128 * MB);
+        EXPECT(Trace::peakMemory() < 256 * MB);
 
         SECTION(std::string("section") + gridname) {
             Trace trace(Here(), "Grid{" + gridname + ", GlobalDomain{-180}}");
             auto grid = Grid{gridname, GlobalDomain{-180}};
             trace.stopAndReport();
             EXPECT(trace.elapsed() < 10.);
-            EXPECT(trace.peakMemory() < 128 * MB);
+            EXPECT(trace.peakMemory() < 256 * MB);
         }
     }
 }

--- a/src/tests/projection/CMakeLists.txt
+++ b/src/tests/projection/CMakeLists.txt
@@ -16,8 +16,7 @@ foreach(test
 endforeach()
 
 ecbuild_add_test( TARGET atlas_test_jacobian SOURCES test_jacobian.cc LIBS atlas
-    ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-                ATLAS_FPE=FE_OVERFLOW,FE_DIVBYZERO ) # FE_INVALID wrongly raised in release build of e.g. PGI 20.9
+    ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )
 
 if(atlas_HAVE_PROJ)
     ecbuild_add_test( TARGET atlas_test_proj SOURCES test_proj.cc LIBS atlas ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )

--- a/src/tests/trans/CMakeLists.txt
+++ b/src/tests/trans/CMakeLists.txt
@@ -43,8 +43,6 @@ ecbuild_add_test( TARGET atlas_test_trans
   CONDITION atlas_HAVE_ECTRANS AND eckit_HAVE_MPI AND ( transi_HAVE_MPI OR ectrans_HAVE_MPI ) AND MPI_SLOTS GREATER_EQUAL 4
   LIBS      atlas transi
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-              # There seems to be a issue with vd2uv raising FE_INVALID, only on specific arch (bamboo-leap42-gnu63)
-              ATLAS_FPE=FE_OVERFLOW,FE_DIVBYZERO
 )
 
 ecbuild_add_test( TARGET atlas_test_trans_serial
@@ -52,8 +50,6 @@ ecbuild_add_test( TARGET atlas_test_trans_serial
   CONDITION atlas_HAVE_ECTRANS
   LIBS      atlas transi
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-              # There seems to be a issue with vd2uv raising FE_INVALID, only on specific arch (bamboo-leap42-gnu63)
-              ATLAS_FPE=FE_OVERFLOW,FE_DIVBYZERO
 )
 
 ecbuild_add_test( TARGET atlas_test_trans_invtrans_grad

--- a/src/tests/trans/test_trans.cc
+++ b/src/tests/trans/test_trans.cc
@@ -353,7 +353,7 @@ CASE("test_nomesh") {
 
     array::ArrayView<double, 1> spg = array::make_view<double, 1>(spfg);
 
-    spectral.parallel_for(option::global(), [&](int real, int imag, int n, int m) {
+    spectral.parallel_for(option::global(), [&](idx_t real, idx_t imag, int n, int m) {
         spg(real) = +m * spectral.truncation() + n;
         spg(imag) = (n == 0 ? 0 : -m * spectral.truncation() + n);
     });
@@ -374,8 +374,8 @@ CASE("test_nomesh") {
     array::ArrayView<double, 1> sp = array::make_view<double, 1>(spf);
 
     spectral.parallel_for([&](idx_t real, idx_t imag, int n, int m) {
-        EXPECT(int(sp(real)) == +m * spectral.truncation() + n);
-        EXPECT(int(sp(imag)) == (n == 0 ? 0 : -m * spectral.truncation() + n));
+        EXPECT_EQ(int(sp(real)), +m * spectral.truncation() + n);
+        EXPECT_EQ(int(sp(imag)), (n == 0 ? 0 : -m * spectral.truncation() + n));
 
         sp(real) = (n == 0 ? 4. : 0.);
         sp(imag) = 0.;


### PR DESCRIPTION
There are a number of issues when using nvidia 24.5, mostly with the RelWithDebInfo build type.
Some are compiler or linker bugs, but some are also due to bad practice or real bugs.