### PR TITLE
Feature/spectral updates

### DIFF
--- a/src/atlas/functionspace/Spectral.cc
+++ b/src/atlas/functionspace/Spectral.cc
@@ -237,6 +237,13 @@ Field Spectral::createField(const eckit::Configuration& options) const {
         array_shape.push_back(levels);
     }
 
+    idx_t variables = 0;
+    if (options.get("variables",variables)) {
+        if (variables) {
+            array_shape.push_back(variables);
+        }
+    }
+
     Field field = Field(config_name(options), config_datatype(options), array_shape);
 
     set_field_metadata(options, field);

--- a/src/atlas/grid/detail/partitioner/CheckerboardPartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/CheckerboardPartitioner.cc
@@ -39,13 +39,33 @@ CheckerboardPartitioner::CheckerboardPartitioner(int N, const eckit::Parametrisa
     Partitioner(N, config) {
     config.get("bands", nbands_);
     config.get("regular", regular_);
+    if (regular_) {
+        split_x_ = false;
+        split_y_ = false;
+    }
+    config.get("split_x", split_x_);
+    config.get("split_y", split_y_);
 }
 
 CheckerboardPartitioner::CheckerboardPartitioner(const eckit::Parametrisation& config) :
     Partitioner(config) {
     config.get("bands", nbands_);
     config.get("regular", regular_);
+    if (regular_) {
+        split_x_ = false;
+        split_y_ = false;
+    }
+    config.get("split_x", split_x_);
+    config.get("split_y", split_y_);
 }
+
+
+std::array<int,2> CheckerboardPartitioner::checkerboardDimensions(const Grid& grid) {
+    int nbands = checkerboard(grid).nbands;
+    int nparts = nb_partitions(); 
+    return {nparts/nbands, nbands};
+}
+
 
 // CheckerboardPartitioner::CheckerboardPartitioner(int N, int nbands): Partitioner(N), nbands_{nbands} {}
 
@@ -146,8 +166,9 @@ Number of procs per band
         ++npartsb[iband];
     }
 
-    bool split_lons = not regular_;
-    bool split_lats = not regular_;
+    bool split_lons = split_x_;
+    bool split_lats = split_y_;
+
     /*
 Number of gridpoints per band
 */

--- a/src/atlas/grid/detail/partitioner/CheckerboardPartitioner.h
+++ b/src/atlas/grid/detail/partitioner/CheckerboardPartitioner.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <vector>
+#include <array>
 
 #include "atlas/grid/detail/partitioner/Partitioner.h"
 
@@ -42,6 +43,8 @@ public:
 
     virtual std::string type() const { return "checkerboard"; }
 
+    std::array<int,2> checkerboardDimensions(const Grid&);
+
 private:
     struct Checkerboard {
         idx_t nbands;  // number of bands
@@ -62,6 +65,8 @@ private:
 private:
     idx_t nbands_      = 0;  // number of bands from configuration
     bool regular_      = false;
+    bool split_x_      = true;
+    bool split_y_      = true;
     bool checkerboard_ = true;  // exact (true) or approximate (false) checkerboard
 };
 

--- a/src/atlas/grid/detail/partitioner/TransPartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/TransPartitioner.cc
@@ -14,6 +14,7 @@
 #include "atlas/grid/Grid.h"
 #include "atlas/grid/detail/partitioner/EqualRegionsPartitioner.h"
 #include "atlas/grid/detail/partitioner/TransPartitioner.h"
+#include "atlas/option/TransOptions.h"
 #include "atlas/parallel/mpi/mpi.h"
 #include "atlas/runtime/Exception.h"
 #include "atlas/runtime/Trace.h"
@@ -43,7 +44,7 @@ void TransPartitioner::partition(const Grid& grid, int part[]) const {
         throw_Exception("Grid is not a grid::Structured type. Cannot partition using IFS trans", Here());
     }
 
-    trans::TransIFS t(grid);
+    trans::TransIFS t(grid, option::split_y(split_y_));
     if (nb_partitions() != idx_t(t.nproc())) {
         std::stringstream msg;
         msg << "Requested to partition grid with TransPartitioner in " << nb_partitions()

--- a/src/atlas/grid/detail/partitioner/TransPartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/TransPartitioner.cc
@@ -25,30 +25,12 @@ namespace detail {
 namespace partitioner {
 
 TransPartitioner::TransPartitioner(): Partitioner() {
-    EqualRegionsPartitioner eqreg(nb_partitions());
-    nbands_ = eqreg.nb_bands();
-    nregions_.resize(nbands_);
-    for (size_t b = 0; b < nbands_; ++b) {
-        nregions_[b] = eqreg.nb_regions(b);
-    }
 }
 
 TransPartitioner::TransPartitioner(const eckit::Parametrisation& config): Partitioner(config) {
-    EqualRegionsPartitioner eqreg(config);
-    nbands_ = eqreg.nb_bands();
-    nregions_.resize(nbands_);
-    for (size_t b = 0; b < nbands_; ++b) {
-        nregions_[b] = eqreg.nb_regions(b);
-    }
 }
 
 TransPartitioner::TransPartitioner(const idx_t N, const eckit::Parametrisation& config): Partitioner(N,config) {
-    EqualRegionsPartitioner eqreg(nb_partitions());
-    nbands_ = eqreg.nb_bands();
-    nregions_.resize(nbands_);
-    for (size_t b = 0; b < nbands_; ++b) {
-        nregions_[b] = eqreg.nb_regions(b);
-    }
 }
 
 TransPartitioner::~TransPartitioner() = default;
@@ -110,14 +92,6 @@ void TransPartitioner::partition(const Grid& grid, int part[]) const {
             ++iproc;
         }
     }
-}
-
-int TransPartitioner::nb_bands() const {
-    return nbands_;
-}
-
-int TransPartitioner::nb_regions(int b) const {
-    return nregions_[b];
 }
 
 }  // namespace partitioner

--- a/src/atlas/grid/detail/partitioner/TransPartitioner.h
+++ b/src/atlas/grid/detail/partitioner/TransPartitioner.h
@@ -44,6 +44,8 @@ public:
 
     virtual std::string type() const { return "ectrans"; }
 
+private:
+    bool split_y_{true};
 };
 
 }  // namespace partitioner

--- a/src/atlas/grid/detail/partitioner/TransPartitioner.h
+++ b/src/atlas/grid/detail/partitioner/TransPartitioner.h
@@ -42,15 +42,8 @@ public:
     /// of the spectral coefficients (LDGRIDONLY=TRUE)
     virtual void partition(const Grid&, int part[]) const;
 
-    int nb_bands() const;
-
-    int nb_regions(int b) const;
-
     virtual std::string type() const { return "ectrans"; }
 
-private:
-    size_t nbands_;
-    std::vector<size_t> nregions_;
 };
 
 }  // namespace partitioner

--- a/src/atlas/option/TransOptions.cc
+++ b/src/atlas/option/TransOptions.cc
@@ -45,8 +45,8 @@ fft::fft(const std::string& fft) {
     set("fft", fft);
 }
 
-split_latitudes::split_latitudes(bool split_latitudes) {
-    set("split_latitudes", split_latitudes);
+split_y::split_y(bool split_y) {
+    set("split_y", split_y);
 }
 
 write_legendre::write_legendre(const eckit::PathName& filepath) {

--- a/src/atlas/option/TransOptions.h
+++ b/src/atlas/option/TransOptions.h
@@ -73,9 +73,9 @@ public:
 
 // ----------------------------------------------------------------------------
 
-class split_latitudes : public util::Config {
+class split_y : public util::Config {
 public:
-    split_latitudes(bool);
+    split_y(bool);
 };
 
 // ----------------------------------------------------------------------------

--- a/src/atlas/trans/ifs/TransIFS.cc
+++ b/src/atlas/trans/ifs/TransIFS.cc
@@ -62,7 +62,7 @@ public:
 
     bool vorticity_divergence_fields() const { return config_.getBool("vorticity_divergence_fields", false); }
 
-    bool split_latitudes() const { return config_.getBool("split_latitudes", true); }
+    bool split_y() const { return config_.getBool("split_y", true); }
 
     int fft() const {
         static const std::map<std::string, int> string_to_FFT = {{"FFT992", TRANS_FFT992}, {"FFTW", TRANS_FFTW}};
@@ -1197,7 +1197,7 @@ void TransIFS::ctor_rgg(const long nlat, const idx_t pl[], long truncation, cons
     }
 
     trans_->fft    = p.fft();
-    trans_->lsplit = p.split_latitudes();
+    trans_->lsplit = p.split_y();
     trans_->flt    = p.flt();
     ATLAS_TRACE_SCOPE("trans_setup") { TRANS_CHECK(::trans_setup(trans_.get())); }
 }
@@ -1227,7 +1227,7 @@ void TransIFS::ctor_lonlat(const long nlon, const long nlat, long truncation, co
     }
 
     trans_->fft    = p.fft();
-    trans_->lsplit = p.split_latitudes();
+    trans_->lsplit = p.split_y();
     trans_->flt    = p.flt();
 
     TRANS_CHECK(::trans_setup(trans_.get()));

--- a/src/tests/trans/test_trans.cc
+++ b/src/tests/trans/test_trans.cc
@@ -165,7 +165,7 @@ CASE("test_trans_distribution_matches_atlas") {
 }
 
 CASE("test_trans_options") {
-    util::Config opts(option::fft("FFTW") | option::split_latitudes(false) | option::read_legendre("readfile"));
+    util::Config opts(option::fft("FFTW") | option::split_y(false) | option::read_legendre("readfile"));
     Log::info() << "trans_opts = " << opts << std::endl;
 }
 

--- a/src/tests/trans/test_trans.cc
+++ b/src/tests/trans/test_trans.cc
@@ -133,6 +133,7 @@ CASE("test_trans_distribution_matches_atlas") {
 
     if (mpi::comm().rank() == 0)  // all tasks do the same, so only one needs to check
     {
+#if 0
         int max_nb_regions_EW(0);
         for (int j = 0; j < trans_partitioner->nb_bands(); ++j) {
             max_nb_regions_EW = std::max(max_nb_regions_EW, trans_partitioner->nb_regions(j));
@@ -140,7 +141,7 @@ CASE("test_trans_distribution_matches_atlas") {
 
         EXPECT(t->n_regions_NS == trans_partitioner->nb_bands());
         EXPECT(t->n_regions_EW == max_nb_regions_EW);
-
+#endif
         EXPECT(distribution.nb_partitions() == idx_t(mpi::comm().size()));
         EXPECT(idx_t(distribution.size()) == g.size());
 
@@ -154,10 +155,12 @@ CASE("test_trans_distribution_matches_atlas") {
         EXPECT(t->ngptot == npts[mpi::comm().rank()]);
         EXPECT(t->ngptotmx == *std::max_element(npts.begin(), npts.end()));
 
+#if 0
         // array::LocalView<int,1> n_regions ( trans.n_regions() ) ;
         for (int j = 0; j < trans_partitioner->nb_bands(); ++j) {
             EXPECT(t->n_regions[j] == trans_partitioner->nb_regions(j));
         }
+#endif
     }
 }
 


### PR DESCRIPTION
This PR adds some changes to prepare for LAM support for spectral transforms.

- The checkerboard partitioner can now differentiate between splitting latitudes and longitude directions. Before it was either split none (e.g. regular), or split all. The setup of domain decomposition in ectrans only allows to split latitudes.
- Remove some member functions from the TransPartitioner that were assuming the equal-regions type partitioner is used in ectrans, rather than a checkerboard.