### PR TITLE
Update MeshBuilder API

### DIFF
--- a/src/atlas/mesh/MeshBuilder.cc
+++ b/src/atlas/mesh/MeshBuilder.cc
@@ -25,18 +25,18 @@
 namespace atlas {
 
 namespace detail {
-atlas::UnstructuredGrid assemble_unstructured_grid(size_t nb_nodes, const double lons[], const double lats[],
-                                                   const int ghosts[], const eckit::mpi::Comm& comm) {
+atlas::UnstructuredGrid assemble_unstructured_grid(size_t nb_nodes, const double lon[], const double lat[],
+                                                   const int ghost[], const eckit::mpi::Comm& comm) {
 
     // First serialize owned lons and lats into single vector
-    const size_t nb_owned_nodes = std::count(ghosts, ghosts + nb_nodes, 0);
-    std::vector<double> owned_lonlats(2 * nb_owned_nodes);
+    const size_t nb_owned_nodes = std::count(ghost, ghost + nb_nodes, 0);
+    std::vector<double> owned_lonlat(2 * nb_owned_nodes);
     int counter = 0;
     for (size_t n = 0; n < nb_nodes; ++n) {
-        if (ghosts[n] == 0) {
-            owned_lonlats[counter] = lons[n];
+        if (ghost[n] == 0) {
+            owned_lonlat[counter] = lon[n];
             counter++;
-            owned_lonlats[counter] = lats[n];
+            owned_lonlat[counter] = lat[n];
             counter++;
         }
     }
@@ -46,14 +46,14 @@ atlas::UnstructuredGrid assemble_unstructured_grid(size_t nb_nodes, const double
     size_t nb_nodes_global = 0;
     comm.allReduce(nb_owned_nodes, nb_nodes_global, eckit::mpi::sum());
 
-    std::vector<double> global_lonlats(2 * nb_nodes_global);
+    std::vector<double> global_lonlat(2 * nb_nodes_global);
     eckit::mpi::Buffer<double> buffer(comm.size());
-    comm.allGatherv(owned_lonlats.begin(), owned_lonlats.end(), buffer);
-    global_lonlats = std::move(buffer.buffer);
+    comm.allGatherv(owned_lonlat.begin(), owned_lonlat.end(), buffer);
+    global_lonlat = std::move(buffer.buffer);
 
     std::vector<atlas::PointXY> points(nb_nodes_global);
     for (size_t n = 0; n < nb_nodes_global; ++n) {
-        points[n] = atlas::PointXY({global_lonlats[2*n], global_lonlats[2*n + 1]});
+        points[n] = atlas::PointXY({global_lonlat[2*n], global_lonlat[2*n + 1]});
     }
 
     return atlas::UnstructuredGrid(new std::vector<atlas::PointXY>(points.begin(), points.end()));
@@ -64,21 +64,23 @@ atlas::UnstructuredGrid assemble_unstructured_grid(size_t nb_nodes, const double
 // consistently with each other.
 //
 // This check makes a few assumptions
-// - the global_indices passed to the MeshBuilder are a 1-based contiguous index
+// - the global_index passed to the MeshBuilder are a global_index_base-based contiguous index
 // - the Grid is one of StructuredGrid or UnstructedGrid. This restriction is because a
 //   CubedSphereGrid doesn't present a simple interface for the coordinates at the N'th point.
 // - the Mesh grid points are the grid nodes, and not the grid cell-centers (e.g., HEALPix or CubedSphere meshes)
-void validate_grid_vs_mesh(const atlas::Grid& grid, size_t nb_nodes, const double lons[], const double lats[],
-                           const int ghosts[], const gidx_t global_indices[], const eckit::mpi::Comm& comm) {
-    // Check assumption that global_indices look like a 1-based contiguous index
-    const size_t nb_owned_nodes = std::count(ghosts, ghosts + nb_nodes, 0);
+void validate_grid_vs_mesh(const eckit::mpi::Comm& comm, const atlas::Grid& grid,
+                           size_t nb_nodes, const double lon[], const double lat[], size_t lonstride, size_t latstride,
+                           const int ghost[], const gidx_t global_index[], gidx_t global_index_base) {
+    // Check assumption that global_index look like a global_index_based contiguous index
+    const size_t nb_owned_nodes = std::count(ghost, ghost + nb_nodes, 0);
     size_t nb_nodes_global = 0;
     comm.allReduce(nb_owned_nodes, nb_nodes_global, eckit::mpi::sum());
     for (size_t n = 0; n < nb_nodes; ++n) {
-        if (ghosts[n] == 0) {
-            // Check global_indices is consistent with a 1-based contiguous index over nodes
-            ATLAS_ASSERT(global_indices[n] >= 1);
-            ATLAS_ASSERT(global_indices[n] <= nb_nodes_global);
+        if (ghost[n] == 0) {
+            // Check global_index is consistent with a global_index_base contiguous index over nodes
+            auto g = global_index[n] - global_index_base;
+            ATLAS_ASSERT(g >= 0);
+            ATLAS_ASSERT(g < nb_nodes_global);
         }
     }
 
@@ -91,9 +93,9 @@ void validate_grid_vs_mesh(const atlas::Grid& grid, size_t nb_nodes, const doubl
     if (grid.type() == "unstructured") {
         const atlas::UnstructuredGrid ugrid(grid);
         for (size_t n = 0; n < nb_nodes; ++n) {
-            if (ghosts[n] == 0) {
-                ugrid.lonlat(global_indices[n] - 1, lonlat);
-                if (!equal_within_roundoff(lonlat[0], lons[n]) || !equal_within_roundoff(lonlat[1], lats[n])) {
+            if (ghost[n] == 0) {
+                ugrid.lonlat(global_index[n] - global_index_base, lonlat);
+                if (!equal_within_roundoff(lonlat[0], lon[n]) || !equal_within_roundoff(lonlat[1], lat[n])) {
                     throw_Exception("In MeshBuilder: UnstructuredGrid from config does not match mesh coordinates", Here());
                 }
             }
@@ -101,20 +103,20 @@ void validate_grid_vs_mesh(const atlas::Grid& grid, size_t nb_nodes, const doubl
     } else if (grid.type() == "structured") {
         const atlas::StructuredGrid sgrid(grid);
         for (size_t n = 0; n < nb_nodes; ++n) {
-            if (ghosts[n] == 0) {
+            if (ghost[n] == 0) {
                 idx_t i, j;
-                sgrid.index2ij(global_indices[n] - 1, i, j);
+                sgrid.index2ij(global_index[n] - global_index_base, i, j);
                 sgrid.lonlat(i, j, lonlat);
-                if (!equal_within_roundoff(lonlat[0], lons[n]) || !equal_within_roundoff(lonlat[1], lats[n])) {
+                if (!equal_within_roundoff(lonlat[0], lon[n]) || !equal_within_roundoff(lonlat[1], lat[n])) {
                     throw_Exception("In MeshBuilder: StructuredGrid from config does not match mesh coordinates", Here());
                 }
             }
         }
     } else {
         for (size_t n = 0; n < nb_nodes; ++n) {
-            if (ghosts[n] == 0) {
-                auto point = *(grid.lonlat().begin() + static_cast<size_t>(global_indices[n] - 1));
-                if (!equal_within_roundoff(point.lon(), lons[n]) || !equal_within_roundoff(point.lat(), lats[n])) {
+            if (ghost[n] == 0) {
+                auto point = *(grid.lonlat().begin() + static_cast<size_t>(global_index[n] - global_index_base));
+                if (!equal_within_roundoff(point.lon(), lon[n]) || !equal_within_roundoff(point.lat(), lat[n])) {
                     throw_Exception("In MeshBuilder: Grid from config does not match mesh coordinates", Here());
                 }
             }
@@ -127,67 +129,98 @@ namespace mesh {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-Mesh MeshBuilder::operator()(const std::vector<double>& lons, const std::vector<double>& lats,
-                             const std::vector<int>& ghosts, const std::vector<gidx_t>& global_indices,
-                             const std::vector<idx_t>& remote_indices, const idx_t remote_index_base,
-                             const std::vector<int>& partitions,
-                             const std::vector<std::array<gidx_t, 3>>& tri_boundary_nodes,
-                             const std::vector<gidx_t>& tri_global_indices,
-                             const std::vector<std::array<gidx_t, 4>>& quad_boundary_nodes,
-                             const std::vector<gidx_t>& quad_global_indices,
+Mesh MeshBuilder::operator()(const std::vector<double>& lon, const std::vector<double>& lat,
+                             const std::vector<int>& ghost, const std::vector<gidx_t>& global_index,
+                             const std::vector<idx_t>& remote_index, const idx_t remote_index_base,
+                             const std::vector<int>& partition,
+                             const std::vector<std::array<gidx_t, 3>>& triag_nodes_global,
+                             const std::vector<gidx_t>& triag_global_index,
+                             const std::vector<std::array<gidx_t, 4>>& quad_nodes_global,
+                             const std::vector<gidx_t>& quad_global_index,
                              const eckit::Configuration& config) const {
-    const size_t nb_nodes = global_indices.size();
-    const size_t nb_tris  = tri_global_indices.size();
-    const size_t nb_quads = quad_global_indices.size();
+    constexpr gidx_t global_index_base = 1;
 
-    ATLAS_ASSERT(nb_nodes == lons.size());
-    ATLAS_ASSERT(nb_nodes == lats.size());
-    ATLAS_ASSERT(nb_nodes == ghosts.size());
-    ATLAS_ASSERT(nb_nodes == remote_indices.size());
-    ATLAS_ASSERT(nb_nodes == partitions.size());
-    ATLAS_ASSERT(nb_tris == tri_boundary_nodes.size());
-    ATLAS_ASSERT(nb_quads == quad_boundary_nodes.size());
-
-    return operator()(nb_nodes, lons.data(), lats.data(), ghosts.data(), global_indices.data(), remote_indices.data(),
-                      remote_index_base, partitions.data(), nb_tris,
-                      reinterpret_cast<const gidx_t*>(tri_boundary_nodes.data()), tri_global_indices.data(), nb_quads,
-                      reinterpret_cast<const gidx_t*>(quad_boundary_nodes.data()), quad_global_indices.data(),
-                      config);
+    return operator()(
+        span<const gidx_t>{global_index.data(),global_index.size()},
+        span<const double>{lon.data(), lon.size()},  span<const double>{lat.data(), lat.size()},
+        span<const double>{lon.data(), lon.size()},  span<const double>{lat.data(), lat.size()},
+        span<const int>{ghost.data(), ghost.size()}, span<const int>{partition.data(), partition.size()},
+        span<const idx_t>{remote_index.data(), remote_index.size()}, remote_index_base,
+        span<const gidx_t>{triag_global_index.data(), triag_global_index.size()},
+        mdspan<const gidx_t,extents<size_t,dynamic_extent,3>>{reinterpret_cast<const gidx_t*>(triag_nodes_global.data()),triag_nodes_global.size()},
+        span<const gidx_t>{quad_global_index.data(), quad_global_index.size()},
+        mdspan<const gidx_t,extents<size_t,dynamic_extent,4>>{reinterpret_cast<const gidx_t*>(quad_nodes_global.data()),quad_nodes_global.size()},
+        global_index_base,
+        config);
 }
 
-Mesh MeshBuilder::operator()(size_t nb_nodes, const double lons[], const double lats[], const int ghosts[],
-                             const gidx_t global_indices[], const idx_t remote_indices[], const idx_t remote_index_base,
-                             const int partitions[], size_t nb_tris, const gidx_t tri_boundary_nodes[],
-                             const gidx_t tri_global_indices[], size_t nb_quads, const gidx_t quad_boundary_nodes[],
-                             const gidx_t quad_global_indices[],
+Mesh MeshBuilder::operator()(size_t nb_nodes, const double lon[], const double lat[], const int ghost[],
+                             const gidx_t global_index[], const idx_t remote_index[], const idx_t remote_index_base,
+                             const int partition[], size_t nb_triags, const gidx_t triag_nodes_global[],
+                             const gidx_t triag_global_index[], size_t nb_quads, const gidx_t quad_nodes_global[],
+                             const gidx_t quad_global_index[],
                              const eckit::Configuration& config) const {
+    constexpr gidx_t global_index_base = 1;
     return this->operator()(
-        nb_nodes, global_indices,
-        lons, lats, 1, 1,
-        lons, lats, 1, 1,
-        ghosts, partitions, remote_indices, remote_index_base,
-        nb_tris, tri_global_indices, tri_boundary_nodes,
-        nb_quads, quad_global_indices, quad_boundary_nodes,
+        nb_nodes, global_index,
+        lon, lat,
+        ghost, partition, remote_index, remote_index_base,
+        nb_triags, triag_global_index, triag_nodes_global,
+        nb_quads, quad_global_index, quad_nodes_global,
+        global_index_base,
         config
     );
 }
 
-Mesh MeshBuilder::operator()(size_t nb_nodes, const gidx_t global_indices[],
+Mesh MeshBuilder::operator()(
+    size_t nb_nodes, const gidx_t global_index[],
+    const double lon[], const double lat[],
+    const int ghost[], const int partition[], const idx_t remote_index[], const idx_t remote_index_base,
+    size_t nb_triags, const gidx_t triag_nodes_global[], const gidx_t triag_global_index[],
+    size_t nb_quads,  const gidx_t quad_nodes_global[],  const gidx_t quad_global_index[],
+    gidx_t global_index_base,
+    const eckit::Configuration& config) const {
+    return this->operator()(
+        nb_nodes, global_index,
+        lon, lat, 1, 1,
+        lon, lat, 1, 1,
+        ghost, partition, remote_index, remote_index_base,
+        nb_triags, triag_global_index, triag_nodes_global,
+        nb_quads, quad_global_index, quad_nodes_global,
+        global_index_base,
+        config
+    );
+}
+
+
+Mesh MeshBuilder::operator()(size_t nb_nodes, const gidx_t global_index[],
                              const double x[], const double y[], size_t xstride, size_t ystride,
                              const double lon[], const double lat[], size_t lonstride, size_t latstride,
-                             const int ghosts[], const int partitions[], const idx_t remote_index[], const idx_t remote_index_base,
+                             const int ghost[], const int partitions[], const idx_t remote_index[], const idx_t remote_index_base,
                              size_t nb_triags, const gidx_t triag_global_index[], const gidx_t triag_nodes_global[],
                              size_t nb_quads,  const gidx_t quad_global_index[],  const gidx_t quad_nodes_global[],
                              const eckit::Configuration& config) const {
-    auto* lons = lon;
-    auto* lats = lat;
-    auto* remote_indices = remote_index;
-    auto nb_tris = nb_triags;
-    auto* tri_boundary_nodes = triag_nodes_global;
-    auto* tri_global_indices = triag_global_index;
-    auto* quad_boundary_nodes = quad_nodes_global;
-    auto* quad_global_indices = quad_global_index;
+    constexpr gidx_t global_index_base = 1;
+    return this->operator()(
+        nb_nodes, global_index,
+        x, y, xstride, ystride,
+        lon, lat, lonstride, latstride,
+        ghost, partitions, remote_index, remote_index_base,
+        nb_triags, triag_global_index, triag_nodes_global,
+        nb_quads, quad_global_index, quad_nodes_global,
+        global_index_base,
+        config);
+}
 
+
+Mesh MeshBuilder::operator()(size_t nb_nodes, const gidx_t global_index[],
+                             const double x[], const double y[], size_t xstride, size_t ystride,
+                             const double lon[], const double lat[], size_t lonstride, size_t latstride,
+                             const int ghost[], const int partitions[], const idx_t remote_index[], const idx_t remote_index_base,
+                             size_t nb_triags, const gidx_t triag_global_index[], const gidx_t triag_nodes_global[],
+                             size_t nb_quads,  const gidx_t quad_global_index[],  const gidx_t quad_nodes_global[],
+                             gidx_t global_index_base,
+                             const eckit::Configuration& config) const {
     // Get MPI comm from config name or fall back to atlas default comm
     auto mpi_comm_name = [](const auto& config) {
         return config.getString("mpi_comm", atlas::mpi::comm().name());
@@ -203,13 +236,13 @@ Mesh MeshBuilder::operator()(size_t nb_nodes, const gidx_t global_indices[],
         if (config.has("grid.type") && (config.getString("grid.type") == "unstructured")
             && !config.has("grid.xy")) {
             // Assemble the unstructured grid by gathering input lons,lats across ranks
-            grid = ::atlas::detail::assemble_unstructured_grid(nb_nodes, lons, lats, ghosts, comm);
+            grid = ::atlas::detail::assemble_unstructured_grid(nb_nodes, lon, lat, ghost, comm);
         } else {
             // Build grid directly from config
             grid = atlas::Grid(config.getSubConfiguration("grid"));
             const bool validate = config.getBool("validate", false);
             if (validate) {
-                ::atlas::detail::validate_grid_vs_mesh(grid, nb_nodes, lons, lats, ghosts, global_indices, comm);
+                ::atlas::detail::validate_grid_vs_mesh(comm, grid, nb_nodes, lon, lat, lonstride, latstride, ghost, global_index, global_index_base);
             }
         }
         mesh.setGrid(grid);
@@ -220,20 +253,20 @@ Mesh MeshBuilder::operator()(size_t nb_nodes, const gidx_t global_indices[],
     mesh.nodes().resize(nb_nodes);
     auto xy        = array::make_view<double, 2>(mesh.nodes().xy());
     auto lonlat    = array::make_view<double, 2>(mesh.nodes().lonlat());
-    auto ghost     = array::make_view<int, 1>(mesh.nodes().ghost());
+    auto ghostv    = array::make_view<int, 1>(mesh.nodes().ghost());
     auto gidx      = array::make_view<gidx_t, 1>(mesh.nodes().global_index());
     auto ridx      = array::make_indexview<idx_t, 1>(mesh.nodes().remote_index());
     auto partition = array::make_view<int, 1>(mesh.nodes().partition());
     auto halo      = array::make_view<int, 1>(mesh.nodes().halo());
 
     for (size_t i = 0; i < nb_nodes; ++i) {
-        xy(i, size_t(XX))      = x[i];
-        xy(i, size_t(YY))      = y[i];
-        lonlat(i, size_t(LON)) = lons[i];
-        lonlat(i, size_t(LAT)) = lats[i];
-        ghost(i)               = ghosts[i];
-        gidx(i)                = global_indices[i];
-        ridx(i)                = remote_indices[i] - remote_index_base;
+        xy(i, size_t(XX))      = x[i*xstride];
+        xy(i, size_t(YY))      = y[i*ystride];
+        lonlat(i, size_t(LON)) = lon[i*lonstride];
+        lonlat(i, size_t(LAT)) = lat[i*latstride];
+        ghostv(i)              = ghost[i];
+        gidx(i)                = global_index[i] - global_index_base + 1; // Make 1-based!
+        ridx(i)                = remote_index[i] - remote_index_base;
         partition(i)           = partitions[i];
     }
     halo.assign(0);
@@ -241,17 +274,17 @@ Mesh MeshBuilder::operator()(size_t nb_nodes, const gidx_t global_indices[],
     // Populate cell/element data
 
     // First, count how many cells of each type are on this processor
-    // Then optimize away the element type if globally nb_tris or nb_quads is zero
-    size_t sum_nb_tris = 0;
-    comm.allReduce(nb_tris, sum_nb_tris, eckit::mpi::sum());
-    const bool add_tris = (sum_nb_tris > 0);
+    // Then optimize away the element type if globally nb_triags or nb_quads is zero
+    size_t sum_nb_triags = 0;
+    comm.allReduce(nb_triags, sum_nb_triags, eckit::mpi::sum());
+    const bool add_triags = (sum_nb_triags > 0);
 
     size_t sum_nb_quads = 0;
     comm.allReduce(nb_quads, sum_nb_quads, eckit::mpi::sum());
     const bool add_quads = (sum_nb_quads > 0);
 
-    if (add_tris) {
-        mesh.cells().add(mesh::ElementType::create("Triangle"), nb_tris);
+    if (add_triags) {
+        mesh.cells().add(mesh::ElementType::create("Triangle"), nb_triags);
     }
     if (add_quads) {
         mesh.cells().add(mesh::ElementType::create("Quadrilateral"), nb_quads);
@@ -261,22 +294,21 @@ Mesh MeshBuilder::operator()(size_t nb_nodes, const gidx_t global_indices[],
     auto cells_part = array::make_view<int, 1>(mesh.cells().partition());
     auto cells_gidx = array::make_view<gidx_t, 1>(mesh.cells().global_index());
 
-    // Find position of idx inside global_indices
-    const auto position_of = [&nb_nodes, &global_indices](const gidx_t idx) {
-        const auto& it = std::find(global_indices, global_indices + nb_nodes, idx);
-        ATLAS_ASSERT(it != global_indices + nb_nodes);
-        return std::distance(global_indices, it);
-    };
+    std::unordered_map<gidx_t,idx_t> global_to_local_index;
+    global_to_local_index.reserve(nb_nodes);
+    for (gidx_t j=0; j<nb_nodes; ++j) {
+        global_to_local_index.insert({global_index[j],j});
+    }
 
     size_t idx = 0;
-    if (add_tris) {
+    if (add_triags) {
         idx_t buffer[3];
-        for (size_t tri = 0; tri < nb_tris; ++tri) {
+        for (size_t tri = 0; tri < nb_triags; ++tri) {
             for (size_t i = 0; i < 3; ++i) {
-                buffer[i] = position_of(tri_boundary_nodes[3 * tri + i]);
+                buffer[i] = global_to_local_index.at(triag_nodes_global[3 * tri + i]);
             }
             node_connectivity.set(idx, buffer);
-            cells_gidx(idx) = tri_global_indices[tri];
+            cells_gidx(idx) = triag_global_index[tri] - global_index_base + 1; // make 1-based
             idx++;
         }
     }
@@ -284,25 +316,75 @@ Mesh MeshBuilder::operator()(size_t nb_nodes, const gidx_t global_indices[],
         idx_t buffer[4];
         for (size_t quad = 0; quad < nb_quads; ++quad) {
             for (size_t i = 0; i < 4; ++i) {
-                buffer[i] = position_of(quad_boundary_nodes[4 * quad + i]);
+                buffer[i] = global_to_local_index.at(quad_nodes_global[4 * quad + i]);
             }
             node_connectivity.set(idx, buffer);
-            cells_gidx(idx) = quad_global_indices[quad];
+            cells_gidx(idx) = quad_global_index[quad] - global_index_base + 1; // make 1-based
             idx++;
         }
     }
 
-    ATLAS_ASSERT(idx == nb_tris + nb_quads);
+    ATLAS_ASSERT(idx == nb_triags + nb_quads);
 
     cells_part.assign(comm.rank());
 
     return mesh;
 }
 
+Mesh MeshBuilder::operator()(
+    span<const gidx_t> global_index,
+    strided_span<const double> x,   strided_span<const double> y,
+    strided_span<const double> lon, strided_span<const double> lat,
+    span<const int> ghost, span<const int> partition,
+    span<const idx_t> remote_index, const idx_t remote_index_base,
+    span<const gidx_t> triag_global_index, mdspan<const gidx_t, extents<size_t,dynamic_extent,3>> triag_nodes_global,
+    span<const gidx_t> quad_global_index,  mdspan<const gidx_t, extents<size_t,dynamic_extent,4>> quad_nodes_global,
+    const gidx_t global_index_base,
+    const eckit::Configuration& config) const {
+
+    const size_t nb_nodes  = global_index.size();
+    const size_t nb_triags = triag_global_index.size();
+    const size_t nb_quads  = quad_global_index.size();
+
+    ATLAS_ASSERT(nb_nodes  == lon.size());
+    ATLAS_ASSERT(nb_nodes  == lat.size());
+    ATLAS_ASSERT(nb_nodes  == ghost.size());
+    ATLAS_ASSERT(nb_nodes  == remote_index.size());
+    ATLAS_ASSERT(nb_nodes  == partition.size());
+    ATLAS_ASSERT(nb_triags == triag_nodes_global.extent(0));
+    ATLAS_ASSERT(nb_quads  == quad_nodes_global.extent(0));
+
+    return operator()(
+        nb_nodes, global_index.data_handle(),
+        x.data_handle(),   y.data_handle(),   x.stride(0),   y.stride(0),
+        lon.data_handle(), lat.data_handle(), lon.stride(0), lat.stride(0),
+        ghost.data_handle(), partition.data_handle(), remote_index.data_handle(), remote_index_base,
+        nb_triags, triag_global_index.data_handle(), triag_nodes_global.data_handle(),
+        nb_quads,  quad_global_index.data_handle(),  quad_nodes_global.data_handle(),
+        global_index_base,
+        config);
+}
+
 //----------------------------------------------------------------------------------------------------------------------
 
 Mesh TriangularMeshBuilder::operator()(size_t nb_nodes,  const gidx_t nodes_global_index[], const double x[], const double y[], const double lon[], const double lat[],
                                        size_t nb_triags, const gidx_t triangle_global_index[], const gidx_t triangle_nodes_global_index[]) const {
+    constexpr gidx_t global_index_base = 1;
+    constexpr size_t stride_1 = 1;
+    return this->operator()(
+        nb_nodes, nodes_global_index, x, y, stride_1, stride_1, lon, lat, stride_1, stride_1,
+        nb_triags, triangle_global_index, triangle_nodes_global_index,
+        global_index_base
+    );
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+Mesh TriangularMeshBuilder::operator()(size_t nb_nodes,  const gidx_t nodes_global_index[],
+                                       const double x[], const double y[], size_t xstride, size_t ystride,
+                                       const double lon[], const double lat[], size_t lonstride, size_t latstride,
+                                       size_t nb_triags, const gidx_t triangle_global_index[], const gidx_t triangle_nodes_global_index[],
+                                       gidx_t global_index_base) const {
     std::vector<int> ghost(nb_nodes,0);
     std::vector<int> partition(nb_nodes,0);
     std::vector<idx_t> remote_index(nb_nodes);
@@ -310,15 +392,16 @@ Mesh TriangularMeshBuilder::operator()(size_t nb_nodes,  const gidx_t nodes_glob
     std::iota(remote_index.begin(), remote_index.end(), remote_index_base);
 
     size_t nb_quads = 0;
-    std::vector<gidx_t> quad_nodes_global_index;
-    std::vector<gidx_t> quad_global_index;
+    gidx_t quad_global_index[] = {};
+    gidx_t quad_nodes_global_index[] = {};
 
     return meshbuilder_(
         nb_nodes, nodes_global_index,
-        x, y, 1, 1, lon, lat, 1, 1,
+        x, y, xstride, ystride, lon, lat, lonstride, latstride,
         ghost.data(), partition.data(), remote_index.data(), remote_index_base,
         nb_triags, triangle_global_index, triangle_nodes_global_index,
-        nb_quads, quad_global_index.data(), quad_nodes_global_index.data());
+        nb_quads, quad_global_index, quad_nodes_global_index,
+        global_index_base);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/atlas/mesh/detail/MeshBuilderIntf.cc
+++ b/src/atlas/mesh/detail/MeshBuilderIntf.cc
@@ -10,6 +10,7 @@
 
 #include "atlas/mesh/detail/MeshBuilderIntf.h"
 #include "atlas/runtime/Exception.h"
+#include "atlas/runtime/Log.h"
 
 namespace atlas {
 namespace mesh {
@@ -27,15 +28,21 @@ void atlas__TriangularMeshBuilder__delete(TriangularMeshBuilder* This) {
 }
 
 Mesh::Implementation* atlas__TriangularMeshBuilder__operator(TriangularMeshBuilder* This,
-        size_t nb_nodes, const gidx_t node_global_index[], const double x[], const double y[], const double lon[], const double lat[],
-        size_t nb_triags, const gidx_t triangle_global_index[], const gidx_t triangle_nodes_global_index[]) {
+        size_t nb_nodes, const gidx_t node_global_index[],
+        const double x[], const double y[], size_t xstride, size_t ystride,
+        const double lon[], const double lat[], size_t lonstride, size_t latstride,
+        size_t nb_triags, const gidx_t triangle_global_index[], const gidx_t triangle_nodes_global_index[],
+        gidx_t global_index_base) {
 
     ATLAS_ASSERT(This != nullptr, "Cannot access uninitialisd atlas_TriangularMeshBuilder");
 
     Mesh::Implementation* m;
     {
-        Mesh mesh = This->operator()(nb_nodes, node_global_index, x, y, lon, lat,
-                                     nb_triags, triangle_global_index, triangle_nodes_global_index);
+        Mesh mesh = This->operator()(nb_nodes, node_global_index,
+                                     x, y, xstride, ystride,
+                                     lon, lat, lonstride, latstride,
+                                     nb_triags, triangle_global_index, triangle_nodes_global_index,
+                                     global_index_base);
         mesh.get()->attach();
         m = mesh.get();
     }

--- a/src/atlas/mesh/detail/MeshBuilderIntf.h
+++ b/src/atlas/mesh/detail/MeshBuilderIntf.h
@@ -23,8 +23,11 @@ TriangularMeshBuilder* atlas__TriangularMeshBuilder__new();
 void atlas__TriangularMeshBuilder__delete(TriangularMeshBuilder* This);
 
 Mesh::Implementation* atlas__TriangularMeshBuilder__operator(TriangularMeshBuilder* This,
-  size_t nb_nodes, const gidx_t node_global_index[], const double x[], const double y[], const double lon[], const double lat[],
-  size_t nb_triags, const gidx_t triangle_global_index[], const gidx_t triangle_nodes_global_index[]);
+  size_t nb_nodes, const gidx_t node_global_index[],
+  const double x[], const double y[], size_t xstride, size_t ystride,
+  const double lon[], const double lat[], size_t lonstride, size_t latstride,
+  size_t nb_triags, const gidx_t triangle_global_index[], const gidx_t triangle_nodes_global_index[],
+  gidx_t global_index_base);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/atlas_f/mesh/atlas_MeshBuilder_module.F90
+++ b/src/atlas_f/mesh/atlas_MeshBuilder_module.F90
@@ -69,33 +69,47 @@ end function
 
 
 !    Mesh operator()(size_t nb_nodes,  const gidx_t node_global_index[], const double x[], const double y[], const double lon[], const double lat[],
-!                    size_t nb_triags, const gidx_t triangle_global_index[], const gidx_t triangle_nodes_global_index[]) const;
+!                    size_t nb_triags, const gidx_t triangle_global_index[], const gidx_t triangle_nodes_global_index[],
+!                    gidx_t global_index_base) const;
 
 function atlas_TriangularMeshBuilder__build(this, &
     nb_nodes, node_global_index, x, y, lon, lat, &
-    nb_triags, triag_global_index, triag_nodes) result(mesh)
+    nb_triags, triag_global_index, triag_nodes, &
+    global_index_base) result(mesh)
   use, intrinsic :: iso_c_binding, only: c_double, c_size_t
   use atlas_MeshBuilder_c_binding
   use atlas_Mesh_module, only: atlas_Mesh
   use atlas_kinds_module, only : ATLAS_KIND_GIDX
-  use fckit_array_module, only : array_strides, array_view1d
-
+  use fckit_array_module, only : array_stride, array_view1d
   type(atlas_Mesh) :: mesh
   class(atlas_TriangularMeshBuilder), intent(in) :: this
   integer, intent(in) :: nb_nodes
-  integer(ATLAS_KIND_GIDX), intent(in) :: node_global_index(:)
-  real(c_double), contiguous, intent(in) :: x(:), y(:), lon(:), lat(:)
+  integer(ATLAS_KIND_GIDX), intent(in) :: node_global_index(nb_nodes)
+  real(c_double), intent(in), target :: x(:), y(:), lon(:), lat(:)
   integer, intent(in) :: nb_triags
-  integer(ATLAS_KIND_GIDX), intent(in) :: triag_global_index(nb_triags)
+  integer(ATLAS_KIND_GIDX), intent(in), target :: triag_global_index(nb_triags)
   integer(ATLAS_KIND_GIDX), intent(in), target :: triag_nodes(3,nb_triags)
-
-  integer(ATLAS_KIND_GIDX), pointer :: triag_nodes_1d(:)
-  triag_nodes_1d => array_view1d( triag_nodes, int(0,ATLAS_KIND_GIDX) )
-
+  integer(ATLAS_KIND_GIDX), optional, intent(in) :: global_index_base
+  integer(ATLAS_KIND_GIDX) :: global_index_base_
+  real(c_double), pointer :: view1d_x(:), view1d_y(:), view1d_lon(:), view1d_lat(:)
+  integer(ATLAS_KIND_GIDX), pointer :: view1d_triag_global_index(:), view1d_triag_nodes(:)
+  global_index_base_ = 1
+  if (present(global_index_base)) then
+    global_index_base_ = global_index_base
+  endif
+  view1d_x => array_view1d(x)
+  view1d_y => array_view1d(y)
+  view1d_lon => array_view1d(lon)
+  view1d_lat => array_view1d(lat)
+  view1d_triag_global_index => array_view1d(triag_global_index)
+  view1d_triag_nodes => array_view1d(triag_nodes)
   call mesh%reset_c_ptr() ! Somehow needed with PGI/16.7 and build-type "bit"
   mesh = atlas_Mesh( atlas__TriangularMeshBuilder__operator(this%CPTR_PGIBUG_A, &
-       & int(nb_nodes,c_size_t), node_global_index, x, y, lon, lat, &
-       & int(nb_triags,c_size_t), triag_global_index, triag_nodes_1d) )
+       & int(nb_nodes,c_size_t), node_global_index, &
+       & view1d_x,   view1d_y,   int(array_stride(x,1),c_size_t),   int(array_stride(y,1),c_size_t),   &
+       & view1d_lon, view1d_lat, int(array_stride(lon,1),c_size_t), int(array_stride(lat,1),c_size_t), &
+       & int(nb_triags,c_size_t), view1d_triag_global_index, view1d_triag_nodes, &
+       & global_index_base_ ))
   call mesh%return()
 end function
 

--- a/src/tests/mesh/test_mesh_builder.cc
+++ b/src/tests/mesh/test_mesh_builder.cc
@@ -31,6 +31,17 @@ namespace test {
 
 //-----------------------------------------------------------------------------
 
+template <typename T>
+mdspan<T,dims<1>> make_mdspan(std::vector<T>& v) {
+    return mdspan<T,dims<1>>{v.data(), v.size()};
+}
+template <typename T, size_t N>
+mdspan<T,extents<size_t,dynamic_extent,N>> make_mdspan(std::vector<std::array<T,N>>& v) {
+    return mdspan<T,extents<size_t,dynamic_extent,N>>{reinterpret_cast<T*>(v.data()), v.size()};
+}
+
+//-----------------------------------------------------------------------------
+
 CASE("test_tiny_mesh") {
     // small regional grid whose cell-centers are connected as (global nodes and cells):
     //
@@ -38,16 +49,17 @@ CASE("test_tiny_mesh") {
     //   |  3  \ 1 /2|
     //   2 ----- 3 - 4
     //
+    constexpr size_t nb_nodes = 6;
     std::vector<double> lons{{0.0, 0.0, 10.0, 15.0, 5.0, 15.0}};
     std::vector<double> lats{{5.0, 0.0, 0.0, 0.0, 5.0, 5.0}};
 
-    std::vector<int> ghosts(6, 0);  // all points owned
-    std::vector<gidx_t> global_indices(6);
+    std::vector<int> ghosts(nb_nodes, 0);  // all points owned
+    std::vector<gidx_t> global_indices(nb_nodes);
     std::iota(global_indices.begin(), global_indices.end(), 1);  // 1-based numbering
     const idx_t remote_index_base = 0;                           // 0-based numbering
-    std::vector<idx_t> remote_indices(6);
+    std::vector<idx_t> remote_indices(nb_nodes);
     std::iota(remote_indices.begin(), remote_indices.end(), remote_index_base);
-    std::vector<int> partitions(6, 0);  // all points on proc 0
+    std::vector<int> partitions(nb_nodes, 0);  // all points on proc 0
 
     // triangles
     std::vector<std::array<gidx_t, 3>> tri_boundary_nodes = {{{3, 6, 5}}, {{3, 4, 6}}};
@@ -57,9 +69,19 @@ CASE("test_tiny_mesh") {
     std::vector<std::array<gidx_t, 4>> quad_boundary_nodes = {{{1, 2, 3, 5}}};
     std::vector<gidx_t> quad_global_indices                = {3};
 
+    gidx_t global_index_base = 1;
     const MeshBuilder mesh_builder{};
-    const Mesh mesh = mesh_builder(lons, lats, ghosts, global_indices, remote_indices, remote_index_base, partitions,
-                                   tri_boundary_nodes, tri_global_indices, quad_boundary_nodes, quad_global_indices);
+
+    // const Mesh mesh = mesh_builder(lons, lats, ghosts, global_indices, remote_indices, remote_index_base, partitions,
+    //                                tri_boundary_nodes, tri_global_indices, quad_boundary_nodes, quad_global_indices);
+    const Mesh mesh = mesh_builder(
+        make_mdspan(global_indices),
+        make_mdspan(lons), make_mdspan(lats),
+        make_mdspan(lons), make_mdspan(lats),
+        make_mdspan(ghosts), make_mdspan(partitions), make_mdspan(remote_indices), remote_index_base,
+        make_mdspan(tri_global_indices), make_mdspan(tri_boundary_nodes),
+        make_mdspan(quad_global_indices), make_mdspan(quad_boundary_nodes),
+        global_index_base);
 
     helper::check_mesh_nodes_and_cells(mesh, lons, lats, ghosts, global_indices, remote_indices, remote_index_base,
                                        partitions, tri_boundary_nodes, tri_global_indices, quad_boundary_nodes,
@@ -85,9 +107,10 @@ CASE("test_cs_c2_mesh_serial") {
                                 59.6388,  59.6388,  59.6388,  59.6388,    // +z
                                 -59.6388, -59.6388, -59.6388, -59.6388};  // -z
 
+    gidx_t global_index_base = 1;
     std::vector<int> ghosts(24, 0);
     std::vector<gidx_t> global_indices(24);
-    std::iota(global_indices.begin(), global_indices.end(), 1);
+    std::iota(global_indices.begin(), global_indices.end(), global_index_base);
     const idx_t remote_index_base = 1;  // test with 1-based numbering
     std::vector<idx_t> remote_indices(24);
     std::iota(remote_indices.begin(), remote_indices.end(), remote_index_base);
@@ -104,7 +127,7 @@ CASE("test_cs_c2_mesh_serial") {
                                                              {{24, 11, 6}},
                                                              {{22, 15, 9}}};
     std::vector<gidx_t> tri_global_indices(8);
-    std::iota(tri_global_indices.begin(), tri_global_indices.end(), 1);
+    std::iota(tri_global_indices.begin(), tri_global_indices.end(), global_index_base);
 
     // quads
     std::vector<std::array<gidx_t, 4>> quad_boundary_nodes = {// faces
@@ -128,13 +151,19 @@ CASE("test_cs_c2_mesh_serial") {
                                                               {{22, 21, 13, 15}},
                                                               {{21, 23, 2, 1}}};
     std::vector<gidx_t> quad_global_indices(18);
-    std::iota(quad_global_indices.begin(), quad_global_indices.end(), 9);  // nb_tris + 1
+    std::iota(quad_global_indices.begin(), quad_global_indices.end(), global_index_base + tri_global_indices.size());
 
     const MeshBuilder mesh_builder{};
 
     SECTION("Build Mesh without a Grid") {
-        const Mesh mesh = mesh_builder(lons, lats, ghosts, global_indices, remote_indices, remote_index_base, partitions,
-                                       tri_boundary_nodes, tri_global_indices, quad_boundary_nodes, quad_global_indices);
+        const Mesh mesh = mesh_builder(
+            make_mdspan(global_indices),
+            make_mdspan(lons), make_mdspan(lats),
+            make_mdspan(lons), make_mdspan(lats),
+            make_mdspan(ghosts), make_mdspan(partitions), make_mdspan(remote_indices), remote_index_base,
+            make_mdspan(tri_global_indices), make_mdspan(tri_boundary_nodes),
+            make_mdspan(quad_global_indices), make_mdspan(quad_boundary_nodes),
+            global_index_base);
 
         helper::check_mesh_nodes_and_cells(mesh, lons, lats, ghosts, global_indices, remote_indices, remote_index_base,
                                            partitions, tri_boundary_nodes, tri_global_indices, quad_boundary_nodes,
@@ -160,9 +189,15 @@ CASE("test_cs_c2_mesh_serial") {
         config.set("grid.xy", lonlats);
         config.set("validate", true);
 
-        const Mesh mesh = mesh_builder(lons, lats, ghosts, global_indices, remote_indices, remote_index_base, partitions,
-                                       tri_boundary_nodes, tri_global_indices, quad_boundary_nodes, quad_global_indices,
-                                       config);
+        const Mesh mesh = mesh_builder(
+            make_mdspan(global_indices),
+            make_mdspan(lons), make_mdspan(lats),
+            make_mdspan(lons), make_mdspan(lats),
+            make_mdspan(ghosts), make_mdspan(partitions), make_mdspan(remote_indices), remote_index_base,
+            make_mdspan(tri_global_indices), make_mdspan(tri_boundary_nodes),
+            make_mdspan(quad_global_indices), make_mdspan(quad_boundary_nodes),
+            global_index_base,
+            config);
 
         helper::check_mesh_nodes_and_cells(mesh, lons, lats, ghosts, global_indices, remote_indices, remote_index_base,
                                            partitions, tri_boundary_nodes, tri_global_indices, quad_boundary_nodes,
@@ -176,9 +211,17 @@ CASE("test_cs_c2_mesh_serial") {
         util::Config config{};
         config.set("grid.type", "unstructured");
 
-        const Mesh mesh = mesh_builder(lons, lats, ghosts, global_indices, remote_indices, remote_index_base, partitions,
-                                       tri_boundary_nodes, tri_global_indices, quad_boundary_nodes, quad_global_indices,
-                                       config);
+        const Mesh mesh = mesh_builder(
+            make_mdspan(global_indices),
+            make_mdspan(lons), make_mdspan(lats),
+            make_mdspan(lons), make_mdspan(lats),
+            make_mdspan(ghosts), make_mdspan(partitions), make_mdspan(remote_indices), remote_index_base,
+            make_mdspan(tri_global_indices), make_mdspan(tri_boundary_nodes),
+            make_mdspan(quad_global_indices), make_mdspan(quad_boundary_nodes),
+            global_index_base,
+            config);
+
+
 
         helper::check_mesh_nodes_and_cells(mesh, lons, lats, ghosts, global_indices, remote_indices, remote_index_base,
                                            partitions, tri_boundary_nodes, tri_global_indices, quad_boundary_nodes,
@@ -192,9 +235,15 @@ CASE("test_cs_c2_mesh_serial") {
         util::Config config{};
         config.set("grid.name", "CS-LFR-2");
 
-        const Mesh mesh = mesh_builder(lons, lats, ghosts, global_indices, remote_indices, remote_index_base, partitions,
-                                       tri_boundary_nodes, tri_global_indices, quad_boundary_nodes, quad_global_indices,
-                                       config);
+        const Mesh mesh = mesh_builder(
+            make_mdspan(global_indices),
+            make_mdspan(lons), make_mdspan(lats),
+            make_mdspan(lons), make_mdspan(lats),
+            make_mdspan(ghosts), make_mdspan(partitions), make_mdspan(remote_indices), remote_index_base,
+            make_mdspan(tri_global_indices), make_mdspan(tri_boundary_nodes),
+            make_mdspan(quad_global_indices), make_mdspan(quad_boundary_nodes),
+            global_index_base,
+            config);
 
         helper::check_mesh_nodes_and_cells(mesh, lons, lats, ghosts, global_indices, remote_indices, remote_index_base,
                                            partitions, tri_boundary_nodes, tri_global_indices, quad_boundary_nodes,

--- a/src/tests/mesh/test_mesh_builder_parallel.cc
+++ b/src/tests/mesh/test_mesh_builder_parallel.cc
@@ -31,9 +31,22 @@ namespace test {
 
 //-----------------------------------------------------------------------------
 
+template <typename T>
+mdspan<T,dims<1>> make_mdspan(std::vector<T>& v) {
+    return mdspan<T,dims<1>>{v.data(), v.size()};
+}
+template <typename T, size_t N>
+mdspan<T,extents<size_t,dynamic_extent,N>> make_mdspan(std::vector<std::array<T,N>>& v) {
+    return mdspan<T,extents<size_t,dynamic_extent,N>>{reinterpret_cast<T*>(v.data()), v.size()};
+}
+
+//-----------------------------------------------------------------------------
+
 CASE("test_cs_c2_mesh_parallel") {
     ATLAS_ASSERT(mpi::comm().size() == 6);
     const int rank = mpi::comm().rank();
+
+    constexpr gidx_t global_index_base = 1;
 
     // Coordinates of the C2 LFRic cubed-sphere grid: grid("CS-LFR-2");
     const std::vector<double> global_lons = {337.5, 22.5,  337.5, 22.5,   // +x
@@ -154,8 +167,15 @@ CASE("test_cs_c2_mesh_parallel") {
     const MeshBuilder mesh_builder{};
 
     SECTION("Build Mesh without a Grid") {
-        const Mesh mesh = mesh_builder(lons, lats, ghosts, global_indices, remote_indices, remote_index_base, partitions,
-                                       tri_boundary_nodes, tri_global_indices, quad_boundary_nodes, quad_global_indices);
+        const Mesh mesh = mesh_builder(
+            make_mdspan(global_indices),
+            make_mdspan(lons), make_mdspan(lats), make_mdspan(lons), make_mdspan(lats),
+            make_mdspan(ghosts), make_mdspan(partitions), make_mdspan(remote_indices), remote_index_base,
+            make_mdspan(tri_global_indices), make_mdspan(tri_boundary_nodes),
+            make_mdspan(quad_global_indices), make_mdspan(quad_boundary_nodes),
+            global_index_base);
+        // const Mesh mesh = mesh_builder(lons, lats, ghosts, global_indices, remote_indices, remote_index_base, partitions,
+        //                                tri_boundary_nodes, tri_global_indices, quad_boundary_nodes, quad_global_indices);
 
         helper::check_mesh_nodes_and_cells(mesh, lons, lats, ghosts, global_indices, remote_indices, remote_index_base,
                                            partitions, tri_boundary_nodes, tri_global_indices, quad_boundary_nodes,
@@ -190,9 +210,17 @@ CASE("test_cs_c2_mesh_parallel") {
         config.set("grid.xy", global_lonlats);
         config.set("validate", true);
 
-        const Mesh mesh = mesh_builder(lons, lats, ghosts, global_indices, remote_indices, remote_index_base, partitions,
-                                       tri_boundary_nodes, tri_global_indices, quad_boundary_nodes, quad_global_indices,
-                                       config);
+        // const Mesh mesh = mesh_builder(lons, lats, ghosts, global_indices, remote_indices, remote_index_base, partitions,
+        //                                tri_boundary_nodes, tri_global_indices, quad_boundary_nodes, quad_global_indices,
+        //                                config);
+        const Mesh mesh = mesh_builder(
+            make_mdspan(global_indices),
+            make_mdspan(lons), make_mdspan(lats), make_mdspan(lons), make_mdspan(lats),
+            make_mdspan(ghosts), make_mdspan(partitions), make_mdspan(remote_indices), remote_index_base,
+            make_mdspan(tri_global_indices), make_mdspan(tri_boundary_nodes),
+            make_mdspan(quad_global_indices), make_mdspan(quad_boundary_nodes),
+            global_index_base,
+            config);
 
         helper::check_mesh_nodes_and_cells(mesh, lons, lats, ghosts, global_indices, remote_indices, remote_index_base,
                                            partitions, tri_boundary_nodes, tri_global_indices, quad_boundary_nodes,
@@ -205,9 +233,17 @@ CASE("test_cs_c2_mesh_parallel") {
         util::Config config{};
         config.set("grid.type", "unstructured");
 
-        const Mesh mesh = mesh_builder(lons, lats, ghosts, global_indices, remote_indices, remote_index_base, partitions,
-                                       tri_boundary_nodes, tri_global_indices, quad_boundary_nodes, quad_global_indices,
-                                       config);
+        // const Mesh mesh = mesh_builder(lons, lats, ghosts, global_indices, remote_indices, remote_index_base, partitions,
+        //                                tri_boundary_nodes, tri_global_indices, quad_boundary_nodes, quad_global_indices,
+        //                                config);
+        const Mesh mesh = mesh_builder(
+            make_mdspan(global_indices),
+            make_mdspan(lons), make_mdspan(lats), make_mdspan(lons), make_mdspan(lats),
+            make_mdspan(ghosts), make_mdspan(partitions), make_mdspan(remote_indices), remote_index_base,
+            make_mdspan(tri_global_indices), make_mdspan(tri_boundary_nodes),
+            make_mdspan(quad_global_indices), make_mdspan(quad_boundary_nodes),
+            global_index_base,
+            config);
 
         helper::check_mesh_nodes_and_cells(mesh, lons, lats, ghosts, global_indices, remote_indices, remote_index_base,
                                            partitions, tri_boundary_nodes, tri_global_indices, quad_boundary_nodes,

--- a/src/tests/mesh/test_mesh_triangular_mesh_builder.cc
+++ b/src/tests/mesh/test_mesh_triangular_mesh_builder.cc
@@ -38,6 +38,7 @@ CASE("test_tiny_mesh") {
     //   | 3 / 4 | 1 /2 |
     //   2 ----- 3 ---- 4
     //
+    gidx_t global_index_base = 1;
     size_t nb_nodes = 6;
     std::vector<double> lon{{0.0, 0.0, 10.0, 15.0, 5.0, 15.0}};
     std::vector<double> lat{{5.0, 0.0, 0.0, 0.0, 5.0, 5.0}};
@@ -48,7 +49,7 @@ CASE("test_tiny_mesh") {
         y[j] = lat[j] / 10.;
     }
     std::vector<gidx_t> global_index(6);
-    std::iota(global_index.begin(), global_index.end(), 1);  // 1-based numbering
+    std::iota(global_index.begin(), global_index.end(), global_index_base);
 
     // triangles
     size_t nb_triags = 4;
@@ -56,8 +57,11 @@ CASE("test_tiny_mesh") {
     std::vector<gidx_t> triag_global_index                = {1, 2, 3, 4};
 
     const TriangularMeshBuilder mesh_builder{};
-    const Mesh mesh = mesh_builder(nb_nodes, global_index.data(), x.data(), y.data(), lon.data(), lat.data(),
-                                   nb_triags, triag_global_index.data(), triag_nodes_global.data()->data());
+    constexpr size_t stride_1 = 1;
+    const Mesh mesh = mesh_builder(nb_nodes, global_index.data(),
+                                   x.data(), y.data(), stride_1, stride_1, lon.data(), lat.data(), stride_1, stride_1,
+                                   nb_triags, triag_global_index.data(), triag_nodes_global.data()->data(),
+                                   global_index_base);
 
     output::Gmsh gmsh("out.msh", util::Config("coordinates", "xy"));
     gmsh.write(mesh);


### PR DESCRIPTION
Updates to the MeshBuilder and TriangularMeshBuilder API

- Changes to allow to use arbitrary indexing base for global_index (e.g. 0-based or 1-based) to define nodes, elements and connectivities.

- API that uses mdspan

- Fixes to allow strided node-coordinates

- Allow Fortran array slices for (strided) coordinates in TriangularMeshBuilder

@fmahebert this may be affecting you. Previous APIs are still working but are deprecated, with a compiler warning.
Just adding a `global_index_base` argument should remove the warning.
 

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-305
<!-- STATIC-ANALYSIS_END -->