### PR TITLE
Improvement in spherical-polygon intersection

### DIFF
--- a/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
+++ b/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
@@ -240,6 +240,7 @@ ConservativeSphericalPolygonInterpolation::ConservativeSphericalPolygonInterpola
     config.get("tgt_cell_data", tgt_cell_data_ = true);
 
 
+    config.get("statistics.intersection", statistics_timings_ = false);
     config.get("statistics.intersection", statistics_intersection_ = false);
     config.get("statistics.conservation", statistics_conservation_ = false);
 
@@ -1080,16 +1081,16 @@ void ConservativeSphericalPolygonInterpolation::intersect_polygons(const CSPolyg
                 continue;
             }
             double src_cover_area   = 0.;
-            stopwatch_kdtree_search.start();
+            if (statistics_timings_) { stopwatch_kdtree_search.start(); }
             auto tgt_cells = kdt_search.closestPointsWithinRadius(s_csp.centroid(), s_csp.radius() + max_tgtcell_rad);
-            stopwatch_kdtree_search.stop();
+            if (statistics_timings_) { stopwatch_kdtree_search.stop(); }
             for (idx_t ttcell = 0; ttcell < tgt_cells.size(); ++ttcell) {
                 auto tcell        = tgt_cells[ttcell].payload();
                 const auto& t_csp = std::get<0>(tgt_csp[tcell]);
-                stopwatch_polygon_intersections.start();
+                if (statistics_timings_) { stopwatch_polygon_intersections.start(); }
                 ConvexSphericalPolygon csp_i = s_csp.intersect(t_csp, nullptr, pointsSameEPS);
                 double csp_i_area            = csp_i.area();
-                stopwatch_polygon_intersections.stop();
+                if (statistics_timings_) { stopwatch_polygon_intersections.stop(); }
                 if (validate_) {
                     int pout;
                     // TODO: this can be removed soon

--- a/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
+++ b/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
@@ -240,9 +240,13 @@ ConservativeSphericalPolygonInterpolation::ConservativeSphericalPolygonInterpola
     config.get("tgt_cell_data", tgt_cell_data_ = true);
 
 
-    config.get("statistics.intersection", statistics_timings_ = false);
+    config.get("statistics.timings", statistics_timings_ = false);
     config.get("statistics.intersection", statistics_intersection_ = false);
     config.get("statistics.conservation", statistics_conservation_ = false);
+    if (statistics_conservation_ && ! statistics_timings_) {
+        Log::info() << "statistics.conservation requested -> enabling statistics.timings";
+        statistics_timings_ = true;
+    }
 
     sharable_data_ = std::make_shared<Data>();
     cache_         = Cache(sharable_data_);
@@ -1826,12 +1830,14 @@ void ConservativeSphericalPolygonInterpolation::do_execute(const Field& src_fiel
     }
 
     auto& timings = data_->timings;
+    if (statistics_timings_) {
+        metadata.set("timings.target_kdtree_search", timings.target_kdtree_search);
+        metadata.set("timings.polygon_intersections", timings.polygon_intersections);
+    }
     metadata.set("timings.source_polygons_assembly", timings.source_polygons_assembly);
     metadata.set("timings.target_polygons_assembly", timings.target_polygons_assembly);
     metadata.set("timings.target_kdtree_assembly", timings.target_kdtree_assembly);
-    metadata.set("timings.target_kdtree_search", timings.target_kdtree_search);
     metadata.set("timings.source_polygons_filter", timings.source_polygons_filter);
-    metadata.set("timings.polygon_intersections", timings.polygon_intersections);
     metadata.set("timings.matrix_assembly", timings.matrix_assembly);
     metadata.set("timings.interpolation", stopwatch.elapsed());
 

--- a/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
+++ b/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.cc
@@ -137,7 +137,6 @@ void dump_polygons_to_json( const ConvexSphericalPolygon& t_csp,
 }
 
 constexpr double unit_sphere_area() {
-    // 4*pi*r^2  with r=1
     return 4. * M_PI;
 }
 
@@ -145,6 +144,7 @@ template <typename T>
 size_t memory_of(const std::vector<T>& vector) {
     return sizeof(T) * vector.capacity();
 }
+
 template <typename T>
 size_t memory_of(const std::vector<std::vector<T>>& vector_of_vector) {
     size_t mem = 0;

--- a/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.h
+++ b/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.h
@@ -197,6 +197,7 @@ private:
     int normalise_intersections_;
     int order_;
     bool matrix_free_;
+    bool statistics_timings_;
     bool statistics_intersection_;
     bool statistics_conservation_;
 

--- a/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.h
+++ b/src/atlas/interpolation/method/unstructured/ConservativeSphericalPolygonInterpolation.h
@@ -94,9 +94,9 @@ public:
             SRC_PLG = 0,  // index, number of source polygons
             TGT_PLG,      // index, number of target polygons
             INT_PLG,      // index, number of intersection polygons
-            UNCVR_SRC     // index, number of uncovered source polygons
+            UNCVR_SRC,    // index, number of uncovered source polygons
+            COUNTS_ENUM_SIZE
         };
-        std::array<int, 4> counts;
         enum Errors
         {
             SRC_SUBPLG_L1 = 0,  // index, \sum_{cell of mesh} {cell.area - \sum_{subpol of cell} subpol.area}
@@ -113,6 +113,7 @@ public:
             REMAP_LINF,  // index, like REMAP_L2 but in L_infinity norm
             ERRORS_ENUM_SIZE
         };
+        std::array<int, COUNTS_ENUM_SIZE> counts;
         std::array<double, ERRORS_ENUM_SIZE> errors;
 
         double tgt_area_sum;
@@ -137,8 +138,9 @@ public:
 
     using Method::do_setup;
     void do_setup(const FunctionSpace& src_fs, const FunctionSpace& tgt_fs) override;
-    void do_setup(const Grid& src_grid, const Grid& tgt_grid, const interpolation::Cache&) override;
     void do_setup(const FunctionSpace& source, const FunctionSpace& target, const interpolation::Cache&) override;
+    void do_setup(const Grid& src_grid, const Grid& tgt_grid, const interpolation::Cache&) override;
+
     void do_execute(const Field& src_field, Field& tgt_field, Metadata&) const override;
     void do_execute(const FieldSet& src_fields, FieldSet& tgt_fields, Metadata&) const override;
 

--- a/src/atlas/util/ConvexSphericalPolygon.cc
+++ b/src/atlas/util/ConvexSphericalPolygon.cc
@@ -71,6 +71,8 @@ PointLonLat xyz2lonlat(const PointXYZ& xyz) {
 
 //------------------------------------------------------------------------------------------------------
 
+bool ConvexSphericalPolygon::fpe_ = true;
+
 ConvexSphericalPolygon::ConvexSphericalPolygon(const PointLonLat points[], size_t size): size_{size} {
     ATLAS_ASSERT(size_ > 2, "Polygon must have at least 3 points");
     ATLAS_ASSERT(size_ < MAX_SIZE, "Number of polygon points exceeds compile time MAX_SIZE");
@@ -351,7 +353,7 @@ void ConvexSphericalPolygon::clip(const GreatCircleSegment& great_circle, Clippe
 // @param[out] intersecting polygon
 ConvexSphericalPolygon ConvexSphericalPolygon::intersect(const ConvexSphericalPolygon& plg, std::ostream* out, double pointsSameEPS) const {
 
-    bool fpe_disabled = atlas::library::disable_floating_point_exception(FE_INVALID);
+    bool fpe_disabled = fpe_ ? atlas::library::disable_floating_point_exception(FE_INVALID) : false;
     auto restore_fpe = [fpe_disabled] {
         if (fpe_disabled) {
             atlas::library::enable_floating_point_exception(FE_INVALID);

--- a/src/atlas/util/ConvexSphericalPolygon.cc
+++ b/src/atlas/util/ConvexSphericalPolygon.cc
@@ -67,39 +67,6 @@ PointLonLat xyz2lonlat(const PointXYZ& xyz) {
 }
 #endif
 
-#if 0
-// NOTE: StackVector is not used
-template <typename T, size_t MAX_SIZE>
-struct StackVector {
-private:
-    using Wrapped = std::array<T,MAX_SIZE>;
-
-public:
-    using reference = typename Wrapped::reference;
-    StackVector()   = default;
-    StackVector(size_t size): size_(size) {}
-#if ATLAS_VECTOR_BOUNDS_CHECKING
-    reference operator[](size_t i) {
-        if (i >= size_) {
-            throw_OutOfRange(i, size_);
-        }
-        return wrapped_[i];
-    }
-#else
-    reference operator[](size_t i) { return wrapped_[i]; }
-#endif
-    void push_back(const T& value) {
-        wrapped_[size_++] = value;
-        ATLAS_ASSERT(size_ < MAX_SIZE);
-    }
-    size_t size() const { return size_; }
-
-private:
-    size_t size_{0};
-    Wrapped wrapped_;
-};
-#endif
-
 }  // namespace
 
 //------------------------------------------------------------------------------------------------------

--- a/src/atlas/util/ConvexSphericalPolygon.cc
+++ b/src/atlas/util/ConvexSphericalPolygon.cc
@@ -40,6 +40,10 @@ double distance2(const PointXYZ& p1, const PointXYZ& p2) {
     return dx * dx + dy * dy + dz * dz;
 }
 
+bool approx_eq(const double& v1, const double& v2) {
+    return std::abs(v1 - v2) <= EPS;
+}
+
 bool approx_eq(const PointXYZ& v1, const PointXYZ& v2) {
     //return approx_eq( v1[0], v2[0], t ) && approx_eq( v1[1], v2[1], t ) && approx_eq( v1[2], v2[2], t );
     return distance2(v1, v2) <= EPS2;
@@ -380,12 +384,28 @@ ConvexSphericalPolygon ConvexSphericalPolygon::intersect(const ConvexSphericalPo
 
     ConvexSphericalPolygon intersection;
     const ConvexSphericalPolygon* intersector;
-
-    intersector = this;
-    intersection = plg;
-#if DEBUG_OUTPUT
     std::string intor_id = "P1";
     std::string inted_id = "P2";
+
+    bool this_intersector = (area() > plg.area());
+    if (approx_eq(area(), plg.area())) {
+        PointXYZ dc = centroid() - plg.centroid();
+        if (dc[0] > 0. or (dc[0] == 0. and (dc[1] > 0. or (dc[1] == 0. and dc[2] > 0.)))) {
+            this_intersector = true;
+        }
+    }
+    if (this_intersector) {
+        intersector = this;
+        intersection = plg;
+    }
+    else {
+        intor_id = "P2";
+        inted_id = "P1";
+        intersector = &plg;
+        intersection = *this;
+    }
+
+#if DEBUG_OUTPUT
     if (out) {
         *out << inted_id << " : ";
         print(*out);

--- a/src/atlas/util/ConvexSphericalPolygon.cc
+++ b/src/atlas/util/ConvexSphericalPolygon.cc
@@ -59,11 +59,13 @@ void xyz2lonlat(const PointXYZ& xyz, PointLonLat& lonlat) {
     eckit::geometry::Sphere::convertCartesianToSpherical(1., xyz, lonlat);
 }
 
+#if DEBUG_OUTPUT
 PointLonLat xyz2lonlat(const PointXYZ& xyz) {
     PointLonLat lonlat;
     eckit::geometry::Sphere::convertCartesianToSpherical(1., xyz, lonlat);
     return lonlat;
 }
+#endif
 
 #if 0
 // NOTE: StackVector is not used

--- a/src/atlas/util/ConvexSphericalPolygon.cc
+++ b/src/atlas/util/ConvexSphericalPolygon.cc
@@ -151,7 +151,7 @@ ConvexSphericalPolygon::ConvexSphericalPolygon(const PointXYZ points[], size_t s
     }
 }
 
-void ConvexSphericalPolygon::compute_centroid() const {
+void ConvexSphericalPolygon::compute_centroid_and_area() const {
     const auto triangles = triangulate();
 
     area_          = triangles.area();
@@ -469,7 +469,7 @@ double ConvexSphericalPolygon::compute_radius() const {
     double radius{0.};
     if (valid_) {
         if (not computed_centroid_) {
-            compute_centroid();
+            compute_centroid_and_area();
         }
         for (size_t i = 0; i < size_; ++i) {
             radius = std::max(radius, PointXYZ::distance(sph_coords_[i], centroid_));

--- a/src/atlas/util/ConvexSphericalPolygon.cc
+++ b/src/atlas/util/ConvexSphericalPolygon.cc
@@ -21,8 +21,6 @@
 #include "atlas/util/NormaliseLongitude.h"
 #include "atlas/library/FloatingPointExceptions.h"
 
-#define DEBUG_OUTPUT 0
-
 namespace atlas {
 namespace util {
 
@@ -44,11 +42,11 @@ inline double dot(const PointXYZ& p1, const PointXYZ& p2) {
     return p1[0] * p2[0] + p1[1] * p2[1] + p1[2] * p2[2];
 }
 
-bool approx_eq(const double& v1, const double& v2) {
+inline bool approx_eq(const double& v1, const double& v2) {
     return std::abs(v1 - v2) <= EPS;
 }
 
-bool approx_eq(const PointXYZ& v1, const PointXYZ& v2) {
+inline bool approx_eq(const PointXYZ& v1, const PointXYZ& v2) {
     //return approx_eq( v1[0], v2[0], t ) && approx_eq( v1[1], v2[1], t ) && approx_eq( v1[2], v2[2], t );
     return distance2(v1, v2) <= EPS2;
 }
@@ -284,6 +282,8 @@ void ConvexSphericalPolygon::clip(const GreatCircleSegment& great_circle, Clippe
     size_t clipped_sph_coords_size{0};
 #if DEBUG_OUTPUT
     int add_point_num = 0;
+#endif
+#ifndef NDEBUG
     ATLAS_ASSERT(valid_);
     ATLAS_ASSERT(not approx_eq(great_circle.first(), great_circle.second()));
 #endif

--- a/src/atlas/util/ConvexSphericalPolygon.cc
+++ b/src/atlas/util/ConvexSphericalPolygon.cc
@@ -285,7 +285,7 @@ void ConvexSphericalPolygon::clip(const GreatCircleSegment& great_circle, Clippe
 #if DEBUG_OUTPUT
     int add_point_num = 0;
 #endif
-#ifndef NDEBUG
+#if ATLAS_BUILD_TYPE_DEBUG
     ATLAS_ASSERT(valid_);
     ATLAS_ASSERT(not approx_eq(great_circle.first(), great_circle.second()));
 #endif

--- a/src/atlas/util/ConvexSphericalPolygon.h
+++ b/src/atlas/util/ConvexSphericalPolygon.h
@@ -130,6 +130,8 @@ public:
 
     int next(const int index) const { return (index == size_ - 1) ? 0 : index + 1; };
 
+    static void fpe(bool v) { fpe_ = v; }
+    static bool fpe() { return fpe_; }
 private:
     struct SubTriangle {
         PointXYZ centroid;
@@ -168,6 +170,8 @@ private:
     mutable bool computed_centroid_{false};
     mutable bool computed_radius_{false};
     mutable bool computed_area_{false};
+
+    static bool fpe_;
 };
 
 //------------------------------------------------------------------------------------------------------

--- a/src/atlas/util/ConvexSphericalPolygon.h
+++ b/src/atlas/util/ConvexSphericalPolygon.h
@@ -152,7 +152,8 @@ private:
 
     SubTriangles triangulate() const;
 
-    void clip(const GreatCircleSegment&, std::ostream* f = nullptr, double pointsSameEPS = std::numeric_limits<double>::epsilon());
+    template <class ClippedCoords>
+    void clip(const GreatCircleSegment&, ClippedCoords&, const double& pointsSameEPS = std::numeric_limits<double>::epsilon(), std::ostream* out = nullptr);
 
     // Set valid_ to true when polygon is convex
     void validate();

--- a/src/atlas/util/ConvexSphericalPolygon.h
+++ b/src/atlas/util/ConvexSphericalPolygon.h
@@ -43,7 +43,7 @@ public:
                    << (PointXYZ::dot(cross(), P) >= offset) << std::endl;
            }
 #endif
-            return (PointXYZ::dot(cross(), P) >= offset); // has to have = included
+            return (cross_[0] * P[0] + cross_[1] * P[1] + cross_[2] * P[2]) >= offset; // has to have = included
         }
 
         PointXYZ intersect(const GreatCircleSegment&, std::ostream* f = NULL, double pointsSameEPS = std::numeric_limits<double>::epsilon()) const;

--- a/src/atlas/util/ConvexSphericalPolygon.h
+++ b/src/atlas/util/ConvexSphericalPolygon.h
@@ -18,7 +18,7 @@
 #include "atlas/util/Polygon.h"
 #include "atlas/runtime/Log.h"
 
-#define DEBUG_OUTPUT 1
+#define DEBUG_OUTPUT 0
 
 namespace atlas {
 namespace util {

--- a/src/atlas/util/ConvexSphericalPolygon.h
+++ b/src/atlas/util/ConvexSphericalPolygon.h
@@ -88,14 +88,14 @@ public:
 
     double area() const {
         if (not computed_area_) {
-            compute_centroid();
+            compute_centroid_and_area();
         }
         return area_;
     }
 
     const PointXYZ& centroid() const {
         if (not computed_centroid_) {
-            compute_centroid();
+            compute_centroid_and_area();
         }
         return centroid_;
     }
@@ -146,7 +146,7 @@ private:
         size_t size_{0};
     };
 
-    void compute_centroid() const;
+    void compute_centroid_and_area() const;
 
     double compute_radius() const;
 

--- a/src/sandbox/interpolation/atlas-conservative-interpolation.cc
+++ b/src/sandbox/interpolation/atlas-conservative-interpolation.cc
@@ -81,6 +81,8 @@ public:
         add_option(new SimpleOption<bool>("matrix_free", "Do not store matrix for consecutive interpolations"));
 
         add_option(
+            new SimpleOption<bool>("statistics.timings", "Enable extra statistics on polygon intersections"));
+        add_option(
             new SimpleOption<bool>("statistics.intersection", "Enable extra statistics on polygon intersections"));
         add_option(new SimpleOption<bool>("statistics.accuracy",
                                           "Enable extra statistics, comparing result with initial condition"));

--- a/src/tests/interpolation/test_interpolation_conservative.cc
+++ b/src/tests/interpolation/test_interpolation_conservative.cc
@@ -216,7 +216,7 @@ CASE("test_interpolation_conservative") {
         src_cell_data = false;
         tgt_cell_data = true;
         do_remapping_test(Grid("O16"), Grid("H12"), func, remap_stat_1, remap_stat_2, src_cell_data, tgt_cell_data);
-        check(remap_stat_1, remap_stat_2, {1.0e-13, 1.0e-12, 7.0e-3, 4.0e-3, 1.0e-15, 1.0e-8});
+        check(remap_stat_1, remap_stat_2, {1.0e-13, 1.0e-12, 7.0e-3, 4.0e-3, 1.0e-15, 2.0e-8});
 
         src_cell_data = false;
         tgt_cell_data = false;

--- a/src/tests/interpolation/test_interpolation_conservative.cc
+++ b/src/tests/interpolation/test_interpolation_conservative.cc
@@ -216,7 +216,7 @@ CASE("test_interpolation_conservative") {
         src_cell_data = false;
         tgt_cell_data = true;
         do_remapping_test(Grid("O16"), Grid("H12"), func, remap_stat_1, remap_stat_2, src_cell_data, tgt_cell_data);
-        check(remap_stat_1, remap_stat_2, {1.0e-13, 1.0e-12, 7.0e-3, 4.0e-3, 1.0e-15, 2.0e-8});
+        check(remap_stat_1, remap_stat_2, {1.0e-13, 1.0e-12, 7.0e-3, 4.0e-3, 1.0e-15, 1.0e-8});
 
         src_cell_data = false;
         tgt_cell_data = false;


### PR DESCRIPTION
A 40% computational improvements in spherical polygon intersections.

Benchmark:
./atlas/src/sandbox/interpolation/atlas-conservative-interpolation --source.grid S964x432 --target.grid O128)

on Atos HPC/ECMWF with:
    build type      : Release
    timestamp     : 20250829113802
c++ compiler     : IntelLLVM 2025.0.4
         flags          :  -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -fno-finite-math-only -O3 -DNDEBUG

The old develop needs 13.56s in the intersect_polygon subroutine, whereas the new one only 7.78s.

(co-developed with Willem Deconinck <willem.deconinck@ecmwf.int>)
 

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-310
<!-- STATIC-ANALYSIS_END -->