### PR TITLE
Add Field::syncHost and Field::syncDevice

### DIFF
--- a/src/atlas/array/Array.h
+++ b/src/atlas/array/Array.h
@@ -129,6 +129,10 @@ public:
 
     void syncHostDevice() const { data_store_->syncHostDevice(); }
 
+    void syncHost() const { data_store_->syncHost(); }
+
+    void syncDevice() const { data_store_->syncDevice(); }
+
     bool hostNeedsUpdate() const { return data_store_->hostNeedsUpdate(); }
 
     bool deviceNeedsUpdate() const { return data_store_->deviceNeedsUpdate(); }

--- a/src/atlas/array/ArrayDataStore.h
+++ b/src/atlas/array/ArrayDataStore.h
@@ -50,6 +50,8 @@ public:
     virtual void updateHost() const                 = 0;
     virtual bool valid() const                      = 0;
     virtual void syncHostDevice() const             = 0;
+    virtual void syncHost() const                   = 0;
+    virtual void syncDevice() const                 = 0;
     virtual void allocateDevice() const             = 0;
     virtual void deallocateDevice() const           = 0;
     virtual bool deviceAllocated() const            = 0;

--- a/src/atlas/array/native/NativeDataStore.h
+++ b/src/atlas/array/native/NativeDataStore.h
@@ -158,6 +158,24 @@ public:
         }
     }
 
+    void syncHost() const override {
+        if (not host_updated_) {
+            ATLAS_ASSERT(device_updated_,"Unexpected state when calling syncHost() because (deviceNeedsUpdate() and hostNeedsUpdate())");
+            updateHost();
+        }
+    }
+
+    void syncDevice() const override {
+        if (not device_updated_) {
+            ATLAS_ASSERT(host_updated_,"Unexpected state when calling syncDevice() because (deviceNeedsUpdate() and hostNeedsUpdate())");
+            if (not host_updated_) {
+                throw_AssertionFailed("Unexpected state when calling syncDevice() because (deviceNeedsUpdate() and hostNeedsUpdate())",
+                Here());
+            }
+            updateDevice();
+        }
+    }
+
     bool deviceAllocated() const override { return device_allocated_; }
 
     void allocateDevice() const override {
@@ -396,6 +414,20 @@ public:
         }
         else if (not host_updated_) {
             updateHost();
+        }
+    }
+
+    void syncHost() const override {
+        if (not host_updated_) {
+            ATLAS_ASSERT(device_updated_,"Unexpected state when calling syncHost() because (deviceNeedsUpdate() and hostNeedsUpdate())");
+            updateHost();
+        }
+    }
+
+    void syncDevice() const override {
+        if (not device_updated_) {
+            ATLAS_ASSERT(host_updated_,"Unexpected state when calling syncDevice() because (deviceNeedsUpdate() and hostNeedsUpdate())");
+            updateDevice();
         }
     }
 

--- a/src/atlas/field/Field.cc
+++ b/src/atlas/field/Field.cc
@@ -242,6 +242,12 @@ void Field::updateDevice() const {
 void Field::syncHostDevice() const {
     get()->syncHostDevice();
 }
+void Field::syncHost() const {
+    get()->syncHost();
+}
+void Field::syncDevice() const {
+    get()->syncDevice();
+}
 bool Field::hostNeedsUpdate() const {
     return get()->hostNeedsUpdate();
 }
@@ -251,8 +257,14 @@ bool Field::deviceNeedsUpdate() const {
 void Field::setHostNeedsUpdate(bool v) const {
     return get()->setHostNeedsUpdate(v);
 }
+void Field::setHostNeedsUpdate() const {
+    return get()->setHostNeedsUpdate(true);
+}
 void Field::setDeviceNeedsUpdate(bool v) const {
     return get()->setDeviceNeedsUpdate(v);
+}
+void Field::setDeviceNeedsUpdate() const {
+    return get()->setDeviceNeedsUpdate(true);
 }
 bool Field::deviceAllocated() const {
     return get()->deviceAllocated();

--- a/src/atlas/field/Field.h
+++ b/src/atlas/field/Field.h
@@ -190,11 +190,15 @@ public:
     // -- Methods related to host-device synchronisation
     void updateHost() const;
     void updateDevice() const;
+    void syncHost() const;
+    void syncDevice() const;
     void syncHostDevice() const;
     bool hostNeedsUpdate() const;
     bool deviceNeedsUpdate() const;
     void setHostNeedsUpdate(bool) const;
     void setDeviceNeedsUpdate(bool) const;
+    void setHostNeedsUpdate() const;
+    void setDeviceNeedsUpdate() const;
     bool deviceAllocated() const;
     void allocateDevice();
     void deallocateDevice();

--- a/src/atlas/field/FieldSet.cc
+++ b/src/atlas/field/FieldSet.cc
@@ -239,6 +239,138 @@ void FieldSetImpl::deallocateDevice(std::initializer_list<int> findices) const {
     }
 }
 
+void FieldSetImpl::setDeviceNeedsUpdate(bool value) const {
+    for (auto field: *this) {
+        field.setDeviceNeedsUpdate(value);
+    }
+}
+
+void FieldSetImpl::setDeviceNeedsUpdate(bool value, std::initializer_list<std::string> fnames) const {
+    ATLAS_ASSERT(fnames.size() > 0);
+    for (int i = 0; i < fnames.size(); ++i) {
+        auto field = this->field(fnames.begin()[i]);
+        field.setDeviceNeedsUpdate(true);
+    }
+}
+
+void FieldSetImpl::setDeviceNeedsUpdate(bool value, std::initializer_list<int> findices) const {
+    ATLAS_ASSERT(findices.size() > 0);
+    for (int i = 0; i < findices.size(); ++i) {
+        auto field = this->field(findices.begin()[i]);
+        field.setDeviceNeedsUpdate(value);
+    }
+}
+
+void FieldSetImpl::setDeviceNeedsUpdate() const {
+    for (auto field: *this) {
+        field.setDeviceNeedsUpdate();
+    }
+}
+
+void FieldSetImpl::setDeviceNeedsUpdate(std::initializer_list<std::string> fnames) const {
+    ATLAS_ASSERT(fnames.size() > 0);
+    for (int i = 0; i < fnames.size(); ++i) {
+        auto field = this->field(fnames.begin()[i]);
+        field.setDeviceNeedsUpdate();
+    }
+}
+
+void FieldSetImpl::setDeviceNeedsUpdate(std::initializer_list<int> findices) const {
+    ATLAS_ASSERT(findices.size() > 0);
+    for (int i = 0; i < findices.size(); ++i) {
+        auto field = this->field(findices.begin()[i]);
+        field.setDeviceNeedsUpdate();
+    }
+}
+
+void FieldSetImpl::setHostNeedsUpdate(bool value) const {
+    for (auto field: *this) {
+        field.setHostNeedsUpdate(value);
+    }
+}
+
+void FieldSetImpl::setHostNeedsUpdate(bool value, std::initializer_list<std::string> fnames) const {
+    ATLAS_ASSERT(fnames.size() > 0);
+    for (int i = 0; i < fnames.size(); ++i) {
+        auto field = this->field(fnames.begin()[i]);
+        field.setHostNeedsUpdate(value);
+    }
+}
+
+void FieldSetImpl::setHostNeedsUpdate(bool value, std::initializer_list<int> findices) const {
+    ATLAS_ASSERT(findices.size() > 0);
+    for (int i = 0; i < findices.size(); ++i) {
+        auto field = this->field(findices.begin()[i]);
+        field.setHostNeedsUpdate(value);
+    }
+}
+
+void FieldSetImpl::setHostNeedsUpdate() const {
+    for (auto field: *this) {
+        field.setHostNeedsUpdate();
+    }
+}
+
+void FieldSetImpl::setHostNeedsUpdate(std::initializer_list<std::string> fnames) const {
+    ATLAS_ASSERT(fnames.size() > 0);
+    for (int i = 0; i < fnames.size(); ++i) {
+        auto field = this->field(fnames.begin()[i]);
+        field.setHostNeedsUpdate();
+    }
+}
+
+void FieldSetImpl::setHostNeedsUpdate(std::initializer_list<int> findices) const {
+    ATLAS_ASSERT(findices.size() > 0);
+    for (int i = 0; i < findices.size(); ++i) {
+        auto field = this->field(findices.begin()[i]);
+        field.setHostNeedsUpdate();
+    }
+}
+
+void FieldSetImpl::syncHost() const {
+    for (auto field: *this) {
+        field.syncHost();
+    }
+}
+
+void FieldSetImpl::syncHost(std::initializer_list<std::string> fnames) const {
+    ATLAS_ASSERT(fnames.size() > 0);
+    for (int i = 0; i < fnames.size(); ++i) {
+        auto field = this->field(fnames.begin()[i]);
+        field.syncHost();
+    }
+}
+
+void FieldSetImpl::syncHost(std::initializer_list<int> findices) const {
+    ATLAS_ASSERT(findices.size() > 0);
+    for (int i = 0; i < findices.size(); ++i) {
+        auto field = this->field(findices.begin()[i]);
+        field.syncHost();
+    }
+}
+
+void FieldSetImpl::syncDevice() const {
+    for (auto field: *this) {
+        field.syncDevice();
+    }
+}
+
+void FieldSetImpl::syncDevice(std::initializer_list<std::string> fnames) const {
+    ATLAS_ASSERT(fnames.size() > 0);
+    for (int i = 0; i < fnames.size(); ++i) {
+        auto field = this->field(fnames.begin()[i]);
+        field.syncDevice();
+    }
+}
+
+void FieldSetImpl::syncDevice(std::initializer_list<int> findices) const {
+    ATLAS_ASSERT(findices.size() > 0);
+    for (int i = 0; i < findices.size(); ++i) {
+        auto field = this->field(findices.begin()[i]);
+        field.syncDevice();
+    }
+}
+
 //-----------------------------------------------------------------------------
 // C wrapper interfaces to C++ routines
 extern "C" {

--- a/src/atlas/field/FieldSet.h
+++ b/src/atlas/field/FieldSet.h
@@ -149,6 +149,24 @@ public:  // methods
     void deallocateDevice() const;
     void deallocateDevice(std::initializer_list<std::string> names) const;
     void deallocateDevice(std::initializer_list<int> indices) const;
+    void setDeviceNeedsUpdate(bool) const;
+    void setDeviceNeedsUpdate(bool, std::initializer_list<std::string> names) const;
+    void setDeviceNeedsUpdate(bool, std::initializer_list<int> indices) const;
+    void setHostNeedsUpdate(bool) const;
+    void setHostNeedsUpdate(bool, std::initializer_list<std::string> names) const;
+    void setHostNeedsUpdate(bool, std::initializer_list<int> indices) const;
+    void setDeviceNeedsUpdate() const;
+    void setDeviceNeedsUpdate(std::initializer_list<std::string> names) const;
+    void setDeviceNeedsUpdate(std::initializer_list<int> indices) const;
+    void setHostNeedsUpdate() const;
+    void setHostNeedsUpdate(std::initializer_list<std::string> names) const;
+    void setHostNeedsUpdate(std::initializer_list<int> indices) const;
+    void syncHost() const;
+    void syncHost(std::initializer_list<std::string> names) const;
+    void syncHost(std::initializer_list<int> indices) const;
+    void syncDevice() const;
+    void syncDevice(std::initializer_list<std::string> names) const;
+    void syncDevice(std::initializer_list<int> indices) const;
 
 
 
@@ -290,6 +308,18 @@ public:  // methods
     void deallocateDevice() const { get()->deallocateDevice(); }
     void deallocateDevice(std::initializer_list<std::string> names) const { get()->deallocateDevice(names); }
     void deallocateDevice(std::initializer_list<int> indices) const { get()->deallocateDevice(indices); }
+    void setDeviceNeedsUpdate(bool value) const { get()->setDeviceNeedsUpdate(value); }
+    void setDeviceNeedsUpdate(bool value, std::initializer_list<std::string> names) const { get()->setDeviceNeedsUpdate(value, names); }
+    void setDeviceNeedsUpdate(bool value, std::initializer_list<int> indices) const { get()->setDeviceNeedsUpdate(value, indices); }
+    void setHostNeedsUpdate(bool value) const { get()->setHostNeedsUpdate(value); }
+    void setHostNeedsUpdate(bool value, std::initializer_list<std::string> names) const { get()->setHostNeedsUpdate(value, names); }
+    void setHostNeedsUpdate(bool value, std::initializer_list<int> indices) const { get()->setHostNeedsUpdate(value, indices); }
+    void syncHost() const { get()->syncHost(); }
+    void syncHost(std::initializer_list<std::string> names) const { get()->syncHost(names); }
+    void syncHost(std::initializer_list<int> indices) const { get()->syncHost(indices); }
+    void syncDevice() const { get()->syncDevice(); }
+    void syncDevice(std::initializer_list<std::string> names) const { get()->syncDevice(names); }
+    void syncDevice(std::initializer_list<int> indices) const { get()->syncDevice(indices); }
 
     // Deprecated API
     DEPRECATED("use 'has' instead") bool has_field(const std::string& name) const { return get()->has(name); }

--- a/src/atlas/field/detail/FieldImpl.h
+++ b/src/atlas/field/detail/FieldImpl.h
@@ -207,6 +207,8 @@ public:  // Destructor
     void updateHost() const { array_->updateHost(); }
     void updateDevice() const { array_->updateDevice(); }
     void syncHostDevice() const { array_->syncHostDevice(); }
+    void syncHost() const { array_->syncHost(); }
+    void syncDevice() const { array_->syncDevice(); }
     bool deviceAllocated() const { return array_->deviceAllocated(); }
     void allocateDevice() const { array_->allocateDevice(); }
     void deallocateDevice() const { array_->deallocateDevice(); }

--- a/src/atlas/field/detail/FieldInterface.cc
+++ b/src/atlas/field/detail/FieldInterface.cc
@@ -275,6 +275,16 @@ void atlas__Field__update_host(FieldImpl* This) {
     This->updateHost();
 }
 
+void atlas__Field__sync_device(FieldImpl* This) {
+    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Field");
+    This->syncDevice();
+}
+
+void atlas__Field__sync_host(FieldImpl* This) {
+    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Field");
+    This->syncHost();
+}
+
 void atlas__Field__sync_host_device(FieldImpl* This) {
     ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Field");
     This->syncHostDevice();

--- a/src/atlas/field/detail/FieldInterface.h
+++ b/src/atlas/field/detail/FieldInterface.h
@@ -72,6 +72,8 @@ void atlas__Field__set_host_needs_update(const FieldImpl* This, int value);
 void atlas__Field__set_device_needs_update(const FieldImpl* This, int value);
 void atlas__Field__update_device(FieldImpl* This);
 void atlas__Field__update_host(FieldImpl* This);
+void atlas__Field__sync_device(FieldImpl* This);
+void atlas__Field__sync_host(FieldImpl* This);
 void atlas__Field__sync_host_device(FieldImpl* This);
 void atlas__Field__allocate_device(FieldImpl* This);
 void atlas__Field__deallocate_device(FieldImpl* This);

--- a/src/atlas/linalg/sparse/SparseMatrixStorage.cc
+++ b/src/atlas/linalg/sparse/SparseMatrixStorage.cc
@@ -71,31 +71,43 @@ SparseMatrixStorage& SparseMatrixStorage::operator=(const SparseMatrixStorage& o
 }
 
 
-void SparseMatrixStorage::updateDevice() const { 
+void SparseMatrixStorage::updateDevice() const {
     outer_->updateDevice();
     inner_->updateDevice();
     value_->updateDevice();
 }
 
-void SparseMatrixStorage::updateHost() const { 
+void SparseMatrixStorage::updateHost() const {
     outer_->updateHost();
     inner_->updateHost();
     value_->updateHost();
 }
 
-bool SparseMatrixStorage::hostNeedsUpdate() const { 
+void SparseMatrixStorage::syncDevice() const {
+    outer_->syncDevice();
+    inner_->syncDevice();
+    value_->syncDevice();
+}
+
+void SparseMatrixStorage::syncHost() const {
+    outer_->syncHost();
+    inner_->syncHost();
+    value_->syncHost();
+}
+
+bool SparseMatrixStorage::hostNeedsUpdate() const {
     return outer_->hostNeedsUpdate() ||
-            inner_->hostNeedsUpdate() ||
-            value_->hostNeedsUpdate();
+           inner_->hostNeedsUpdate() ||
+           value_->hostNeedsUpdate();
 }
 
-bool SparseMatrixStorage::deviceNeedsUpdate() const { 
+bool SparseMatrixStorage::deviceNeedsUpdate() const {
     return outer_->deviceNeedsUpdate() ||
-            inner_->deviceNeedsUpdate() ||
-            value_->deviceNeedsUpdate();
+           inner_->deviceNeedsUpdate() ||
+           value_->deviceNeedsUpdate();
 }
 
-void SparseMatrixStorage::setHostNeedsUpdate(bool v) const { 
+void SparseMatrixStorage::setHostNeedsUpdate(bool v) const {
     outer_->setHostNeedsUpdate(v);
     inner_->setHostNeedsUpdate(v);
     value_->setHostNeedsUpdate(v);
@@ -109,8 +121,8 @@ void SparseMatrixStorage::setDeviceNeedsUpdate(bool v) const {
 
 bool SparseMatrixStorage::deviceAllocated() const {
     return outer_->deviceAllocated() &&
-            inner_->deviceAllocated() &&
-            value_->deviceAllocated();
+           inner_->deviceAllocated() &&
+           value_->deviceAllocated();
 }
 
 void SparseMatrixStorage::allocateDevice() const {
@@ -119,7 +131,7 @@ void SparseMatrixStorage::allocateDevice() const {
     value_->allocateDevice();
 }
 
-void SparseMatrixStorage::deallocateDevice() const { 
+void SparseMatrixStorage::deallocateDevice() const {
     outer_->deallocateDevice();
     inner_->deallocateDevice();
     value_->deallocateDevice();

--- a/src/atlas/linalg/sparse/SparseMatrixStorage.h
+++ b/src/atlas/linalg/sparse/SparseMatrixStorage.h
@@ -109,15 +109,19 @@ public:
 
     bool deviceNeedsUpdate() const;
 
-    void setHostNeedsUpdate(bool v) const;
+    void setHostNeedsUpdate(bool) const;
 
-    void setDeviceNeedsUpdate(bool v) const;
+    void setDeviceNeedsUpdate(bool) const;
 
     bool deviceAllocated() const;
 
     void allocateDevice() const;
 
     void deallocateDevice() const;
+
+    void syncHost() const;
+
+    void syncDevice() const;
 
     static SparseMatrixStorage make(
         std::size_t rows,

--- a/src/atlas_f/field/atlas_FieldSet_module.fypp
+++ b/src/atlas_f/field/atlas_FieldSet_module.fypp
@@ -105,6 +105,12 @@ contains
   procedure, public :: sync_host_device_idx
   procedure, public :: sync_host_device_name
   generic :: sync_host_device => sync_host_device_idx, sync_host_device_name
+  procedure, public :: sync_host_idx
+  procedure, public :: sync_host_name
+  generic :: sync_host => sync_host_idx, sync_host_name
+  procedure, public :: sync_device_idx
+  procedure, public :: sync_device_name
+  generic :: sync_device => sync_device_idx, sync_device_name
   procedure, public :: allocate_device_idx
   procedure, public :: allocate_device_name
   generic :: allocate_device => allocate_device_idx, allocate_device_name
@@ -553,6 +559,84 @@ subroutine sync_host_device_name(this, field_names)
   do i = 1, size(field_names)
     field = this%field(field_names(i))
     call atlas__Field__sync_host_device(field%CPTR_PGIBUG_A)
+  end do
+end subroutine
+
+!-------------------------------------------------------------------------------
+
+subroutine sync_host_idx(this, field_indices)
+  use, intrinsic :: iso_c_binding, only : c_int
+  use atlas_field_c_binding
+  use atlas_Field_module, only: atlas_Field
+  class(atlas_FieldSet), intent(inout) :: this
+  integer, intent(in), optional :: field_indices(:)
+  type(atlas_Field) :: field
+  integer(c_int) :: i
+  if (present(field_indices)) then
+    do i = 1, size(field_indices)
+      field = this%field(field_indices(i))
+      call atlas__Field__sync_host(field%CPTR_PGIBUG_A)
+    end do
+  else
+    do i = 1, this%size()
+      field = this%field(i)
+      call atlas__Field__sync_host(field%CPTR_PGIBUG_A)
+    end do
+  end if
+end subroutine
+
+!-------------------------------------------------------------------------------
+
+subroutine sync_host_name(this, field_names)
+  use, intrinsic :: iso_c_binding, only : c_int
+  use atlas_field_c_binding
+  use atlas_Field_module, only: atlas_Field
+  class(atlas_FieldSet), intent(inout) :: this
+  character(*), intent(in) :: field_names(:)
+  type(atlas_Field) :: field
+  integer(c_int) :: i
+  do i = 1, size(field_names)
+    field = this%field(field_names(i))
+    call atlas__Field__sync_host(field%CPTR_PGIBUG_A)
+  end do
+end subroutine
+
+!-------------------------------------------------------------------------------
+
+subroutine sync_device_idx(this, field_indices)
+  use, intrinsic :: iso_c_binding, only : c_int
+  use atlas_field_c_binding
+  use atlas_Field_module, only: atlas_Field
+  class(atlas_FieldSet), intent(inout) :: this
+  integer, intent(in), optional :: field_indices(:)
+  type(atlas_Field) :: field
+  integer(c_int) :: i
+  if (present(field_indices)) then
+    do i = 1, size(field_indices)
+      field = this%field(field_indices(i))
+      call atlas__Field__sync_device(field%CPTR_PGIBUG_A)
+    end do
+  else
+    do i = 1, this%size()
+      field = this%field(i)
+      call atlas__Field__sync_device(field%CPTR_PGIBUG_A)
+    end do
+  end if
+end subroutine
+
+!-------------------------------------------------------------------------------
+
+subroutine sync_device_name(this, field_names)
+  use, intrinsic :: iso_c_binding, only : c_int
+  use atlas_field_c_binding
+  use atlas_Field_module, only: atlas_Field
+  class(atlas_FieldSet), intent(inout) :: this
+  character(*), intent(in) :: field_names(:)
+  type(atlas_Field) :: field
+  integer(c_int) :: i
+  do i = 1, size(field_names)
+    field = this%field(field_names(i))
+    call atlas__Field__sync_device(field%CPTR_PGIBUG_A)
   end do
 end subroutine
 

--- a/src/atlas_f/field/atlas_Field_module.fypp
+++ b/src/atlas_f/field/atlas_Field_module.fypp
@@ -109,6 +109,8 @@ contains
   procedure, public :: update_device
   procedure, public :: update_host
   procedure, public :: sync_host_device
+  procedure, public :: sync_host
+  procedure, public :: sync_device
 
   procedure, private :: dummy
 
@@ -777,6 +779,21 @@ subroutine sync_host_device(this)
   use atlas_field_c_binding
   class(atlas_Field), intent(inout) :: this
   call atlas__Field__sync_host_device(this%CPTR_PGIBUG_A)
+end subroutine
+
+!-------------------------------------------------------------------------------
+
+subroutine sync_host(this)
+  use atlas_field_c_binding
+  class(atlas_Field), intent(inout) :: this
+  call atlas__Field__sync_host(this%CPTR_PGIBUG_A)
+end subroutine
+
+!-------------------------------------------------------------------------------
+subroutine sync_device(this)
+  use atlas_field_c_binding
+  class(atlas_Field), intent(inout) :: this
+  call atlas__Field__sync_device(this%CPTR_PGIBUG_A)
 end subroutine
 
 !-------------------------------------------------------------------------------

--- a/src/tests/field/fctest_fieldset_gpu.F90
+++ b/src/tests/field/fctest_fieldset_gpu.F90
@@ -252,5 +252,123 @@ END_TEST
 
 ! -----------------------------------------------------------------------------
 
+TEST( test_fieldset_cummulative_gpu_calls_subset_field_with_sync_host_sync_device)
+implicit none
+type(atlas_FieldSet) :: fset
+type(atlas_Field) :: field
+real(4), pointer :: fview(:,:)
+print *, "fieldset_cummulative_gpu_calls subset fields"
+
+fset = atlas_FieldSet()
+call fset%add(atlas_Field(name="f1", kind=atlas_real(4), shape=[1,2]))
+call fset%add(atlas_Field(name="f2", kind=atlas_real(4), shape=[2,2]))
+call fset%add(atlas_Field(name="f3", kind=atlas_real(4), shape=[2,1]))
+
+print *, "... by idx"
+field = fset%field(2)
+call field%data(fview)
+fview(:,:) = 1.
+fview(2,1) = 2.
+
+call fset%set_host_needs_update((/2, 3/), .false.)
+call fset%allocate_device((/ 2, 3 /)) ! device allocate only for field 2 and 3
+call fset%sync_device((/ 2, 3 /)) ! device-memcpy for field 2 and 3
+
+!$acc kernels present(fview)
+fview(2,1) = 5.
+!$acc end kernels
+
+call fset%set_host_needs_update((/ 2 /))
+
+FCTEST_CHECK_EQUAL( fview(2,1), 2. )
+call fset%sync_host()
+FCTEST_CHECK_EQUAL( fview(2,1), 5. )
+call fset%deallocate_device()
+
+print *, "... by name"
+field = fset%field("f3")
+call field%data(fview)
+fview(:,:) = 3.
+fview(2,1) = 4.
+
+call fset%allocate_device((/ "f2", "f3" /))
+call fset%sync_device((/ "f2", "f3" /))
+
+!$acc kernels present(fview)
+fview(2,1) = 7.
+!$acc end kernels
+
+call fset%set_host_needs_update((/ "f3" /))
+
+FCTEST_CHECK_EQUAL( fview(2,1), 4. )
+call fset%sync_host()
+FCTEST_CHECK_EQUAL( fview(2,1), 7. )
+
+call fset%final()
+END_TEST
+
+! -----------------------------------------------------------------------------
+
+TEST( test_fieldset_cummulative_gpu_calls_with_sync_host_sync_device)
+implicit none
+type(atlas_FieldSet) :: fset
+type(atlas_Field) :: field
+real(4), pointer :: fview(:,:)
+
+print *, "test_fieldset_cummulative_gpu_calls_with_sync_host_device"
+fset = atlas_FieldSet()
+call fset%add(atlas_Field(name="f1", kind=atlas_real(4), shape=[1,2]))
+call fset%add(atlas_Field(name="f2", kind=atlas_real(4), shape=[2,2]))
+call fset%add(atlas_Field(name="f3", kind=atlas_real(4), shape=[2,1]))
+
+print *, "... by idx"
+field = fset%field(2)
+call field%data(fview)
+fview(:,:) = 1.
+fview(2,1) = 2.
+
+call fset%set_host_needs_update(.false.)
+call fset%allocate_device((/ 2, 3 /)) ! device allocate only for field 2 and 3
+call fset%set_device_needs_update((/ 2 /))
+call fset%sync_device((/ 2 /)) ! device-memcpy for field 2 and 3
+
+!$acc kernels present(fview)
+fview(2,1) = 5.
+!$acc end kernels
+
+call fset%set_host_needs_update((/ 2 /))
+
+FCTEST_CHECK_EQUAL( fview(2,1), 2. )
+call fset%sync_host()
+FCTEST_CHECK_EQUAL( fview(2,1), 5. )
+
+call fset%deallocate_device()
+
+print *, "... by name"
+field = fset%field("f2")
+call field%data(fview)
+fview(:,:) = 3.
+fview(2,1) = 4.
+
+call fset%set_host_needs_update(.false.)
+call fset%allocate_device((/ "f2", "f3" /)) ! device allocate only for field 2 and 3
+call fset%set_device_needs_update((/ "f2" /)) ! set fields for sync_host_device
+call fset%sync_device((/ "f2" /)) ! device-memcpy for field 'f2'
+
+!$acc kernels present(fview)
+fview(2,1) = 7.
+!$acc end kernels
+
+call fset%set_host_needs_update((/ "f2" /))
+
+FCTEST_CHECK_EQUAL( fview(2,1), 4. )
+call fset%sync_host()
+FCTEST_CHECK_EQUAL( fview(2,1), 7. )
+
+call fset%final()
+END_TEST
+
+! -----------------------------------------------------------------------------
+
 END_TESTSUITE
 


### PR DESCRIPTION
Add `Field::syncHost` and `Field::syncDevice` functions.

- `field.syncHost()` is equivalent to `if (field.hostNeedsUpdate()) { field.updateHost(); }`
- `field.syncDevice()` is equivalent to `if (field.deviceNeedsUpdate()) { field.updateDevice(); }`

This also applies to `atlas::Array` and `atlas::FieldSet`
Fortran interfaces are also created for FieldSet and Field.

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-311
<!-- STATIC-ANALYSIS_END -->