### PR TITLE
Add more GPU tracing capabilities for device allocations and host-device data transfers

### DIFF
--- a/pluto/src/pluto/trace.cc
+++ b/pluto/src/pluto/trace.cc
@@ -73,7 +73,7 @@ std::string format_bytes(std::size_t bytes) {
 }
 
 namespace log {
-void allocate(std::string_view label, void* ptr, std::size_t bytes, std::size_t alignment, std::string_view resource_name, memory_tracker* memory_tracker) {
+void allocate(std::string_view label, const void* ptr, std::size_t bytes, std::size_t alignment, std::string_view resource_name, memory_tracker* memory_tracker) {
     out << "PLUTO_TRACE " << resource_name << "::allocate(";
     if (not label.empty()) {
         out << "label="<<label<<", ";
@@ -84,7 +84,7 @@ void allocate(std::string_view label, void* ptr, std::size_t bytes, std::size_t 
     }
     out << '\n';
 }
-void allocate_async(std::string_view label, void* ptr, std::size_t bytes, std::size_t alignment, void* stream, std::string_view resource_name, memory_tracker* memory_tracker) {
+void allocate_async(std::string_view label, const void* ptr, std::size_t bytes, std::size_t alignment, const void* stream, std::string_view resource_name, memory_tracker* memory_tracker) {
     out << "PLUTO_TRACE " << resource_name << "::allocate_async(";
     if (not label.empty()) {
         out << "label="<<label<<", ";
@@ -96,7 +96,7 @@ void allocate_async(std::string_view label, void* ptr, std::size_t bytes, std::s
     out << '\n';
 }
 
-void deallocate(std::string_view label, void* ptr, std::size_t bytes, std::size_t alignment, std::string_view resource_name, memory_tracker*) {
+void deallocate(std::string_view label, const void* ptr, std::size_t bytes, std::size_t alignment, std::string_view resource_name, memory_tracker*) {
     out << "PLUTO_TRACE " << resource_name << "::deallocate(";
     if (not label.empty()) {
         out << "label="<<label<<", ";
@@ -104,12 +104,30 @@ void deallocate(std::string_view label, void* ptr, std::size_t bytes, std::size_
     out << "ptr="<<ptr<<", bytes="<<format_bytes(bytes)<<", alignment="<<alignment<<")";
     out << '\n';
 }
-void deallocate_async(std::string_view label, void* ptr, std::size_t bytes, std::size_t alignment, void* stream, std::string_view resource_name, memory_tracker*) {
+void deallocate_async(std::string_view label, const void* ptr, std::size_t bytes, std::size_t alignment, const void* stream, std::string_view resource_name, memory_tracker*) {
     out << "PLUTO_TRACE " << resource_name << "::deallocate_async(";
     if (not label.empty()) {
         out << "label="<<label<<", ";
     }
     out << "ptr="<<ptr<<", bytes="<<format_bytes(bytes)<<", alignment="<<alignment<<", stream="<<stream<<")";
+    out << '\n';
+}
+
+void copy_host_to_device(std::string_view label, const void* dptr, const void* hptr, std::size_t bytes) {
+    out << "PLUTO_TRACE copy_host_to_device(";
+    if (not label.empty()) {
+        out << "label="<<label<<", ";
+    }
+    out << "device_ptr="<<dptr<<", host_ptr="<<hptr<<", bytes="<<format_bytes(bytes)<<")";
+    out << '\n';
+}
+
+void copy_device_to_host(std::string_view label, const void* hptr, const void* dptr, std::size_t bytes) {
+    out << "PLUTO_TRACE copy_device_to_host(";
+    if (not label.empty()) {
+        out << "label="<<label<<", ";
+    }
+    out << "host_ptr="<<hptr<<", device_ptr="<<dptr<<", bytes="<<format_bytes(bytes)<<")";
     out << '\n';
 }
 }

--- a/pluto/src/pluto/trace.h
+++ b/pluto/src/pluto/trace.h
@@ -69,10 +69,12 @@ inline void set_options(const Options& opts) {
 std::string format_bytes(std::size_t bytes);
 
 namespace log {
-void allocate(std::string_view label, void* ptr, std::size_t bytes, std::size_t alignment, std::string_view resource_name, memory_tracker* memory_tracker);
-void deallocate(std::string_view label, void* ptr, std::size_t bytes, std::size_t alignment, std::string_view resource_name, memory_tracker* memory_tracker);
-void allocate_async(std::string_view label, void* ptr, std::size_t bytes, std::size_t alignment, void* stream, std::string_view resource_name, memory_tracker* memory_tracker);
-void deallocate_async(std::string_view label, void* ptr, std::size_t bytes, std::size_t alignment, void* stream, std::string_view resource_name, memory_tracker* memory_tracker);
+void allocate(std::string_view label, const void* ptr, std::size_t bytes, std::size_t alignment, std::string_view resource_name, memory_tracker* memory_tracker);
+void deallocate(std::string_view label, const void* ptr, std::size_t bytes, std::size_t alignment, std::string_view resource_name, memory_tracker* memory_tracker);
+void allocate_async(std::string_view label, const void* ptr, std::size_t bytes, std::size_t alignment, const void* stream, std::string_view resource_name, memory_tracker* memory_tracker);
+void deallocate_async(std::string_view label, const void* ptr, std::size_t bytes, std::size_t alignment, const void* stream, std::string_view resource_name, memory_tracker* memory_tracker);
+void copy_host_to_device(std::string_view label, const void* dptr, const void* hptr, std::size_t bytes);
+void copy_device_to_host(std::string_view label, const void* hptr, const void* dptr, std::size_t bytes);
 }
 
 }  // namespace pluto::trace

--- a/src/atlas/linalg/sparse/MakeSparseMatrixStorageEckit.h
+++ b/src/atlas/linalg/sparse/MakeSparseMatrixStorageEckit.h
@@ -39,9 +39,21 @@ inline SparseMatrixStorage make_sparse_matrix_storage(eckit::linalg::SparseMatri
     std::size_t rows = m.rows();
     std::size_t cols = m.cols();
     std::size_t nnz  = m.nonZeros();
-    auto* outer = array::Array::wrap(const_cast<Index*>(m.outer()), array::make_shape(rows+1));
-    auto* inner = array::Array::wrap(const_cast<Index*>(m.inner()), array::make_shape(nnz));
-    auto* value = array::Array::wrap(const_cast<Value*>(m.data()),  array::make_shape(nnz));
+    array::Array* outer;
+    array::Array* inner;
+    array::Array* value;
+    {
+        array::label label{"sparse_matrix.outer"};
+        outer = array::Array::wrap(const_cast<Index*>(m.outer()), array::make_shape(rows+1));
+    }
+    {
+        array::label label{"sparse_matrix.inner"};
+        inner = array::Array::wrap(const_cast<Index*>(m.inner()), array::make_shape(nnz));
+    }
+    {
+        array::label label{"sparse_matrix.value"};
+        value = array::Array::wrap(const_cast<Value*>(m.data()),  array::make_shape(nnz));
+    }
 
     // We now move the eckit::linalg::SparseMatrix into a generic storage so
     //   the wrapped array data does not go out of scope
@@ -63,9 +75,22 @@ SparseMatrixStorage make_sparse_matrix_storage(eckit::linalg::SparseMatrix&& m) 
     std::size_t rows = m.rows();
     std::size_t cols = m.cols();
     std::size_t nnz  = m.nonZeros();
-    auto* outer = array::Array::create<index_type>(rows+1);
-    auto* inner = array::Array::create<index_type>(nnz);
-    auto* value = array::Array::create<value_type>(nnz);
+
+    array::Array* outer;
+    array::Array* inner;
+    array::Array* value;
+    {
+        array::label label{"sparse_matrix.outer"};
+        outer = array::Array::create<index_type>(rows+1);
+    }
+    {
+        array::label label{"sparse_matrix.inner"};
+        inner = array::Array::create<index_type>(nnz);
+    }
+    {
+        array::label label{"sparse_matrix.value"};
+        value = array::Array::create<value_type>(nnz);
+    }
 
     host_copy_eckit<index_type>(m.outer(), *outer);
     host_copy_eckit<index_type>(m.inner(), *inner);
@@ -87,9 +112,22 @@ inline SparseMatrixStorage make_sparse_matrix_storage(const eckit::linalg::Spars
     std::size_t rows = m.rows();
     std::size_t cols = m.cols();
     std::size_t nnz  = m.nonZeros();
-    auto* outer = array::Array::create<Index>(rows+1);
-    auto* inner = array::Array::create<Index>(nnz);
-    auto* value = array::Array::create<Value>(nnz);
+
+    array::Array* outer;
+    array::Array* inner;
+    array::Array* value;
+    {
+        array::label label{"sparse_matrix.outer"};
+        outer = array::Array::create<Index>(rows+1);
+    }
+    {
+        array::label label{"sparse_matrix.inner"};
+        inner = array::Array::create<Index>(nnz);
+    }
+    {
+        array::label label{"sparse_matrix.value"};
+        value = array::Array::create<Value>(nnz);
+    }
 
     host_copy_eckit<Index>(m.outer(), *outer);
     host_copy_eckit<Index>(m.inner(), *inner);
@@ -109,9 +147,22 @@ SparseMatrixStorage make_sparse_matrix_storage(const eckit::linalg::SparseMatrix
     std::size_t rows = m.rows();
     std::size_t cols = m.cols();
     std::size_t nnz  = m.nonZeros();
-    auto* outer = array::Array::create<index_type>(rows+1);
-    auto* inner = array::Array::create<index_type>(nnz);
-    auto* value = array::Array::create<value_type>(nnz);
+
+    array::Array* outer;
+    array::Array* inner;
+    array::Array* value;
+    {
+        array::label label{"sparse_matrix.outer"};
+        outer = array::Array::create<index_type>(rows+1);
+    }
+    {
+        array::label label{"sparse_matrix.inner"};
+        inner = array::Array::create<index_type>(nnz);
+    }
+    {
+        array::label label{"sparse_matrix.value"};
+        value = array::Array::create<value_type>(nnz);
+    }
     host_copy_eckit<index_type>(m.outer(), *outer);
     host_copy_eckit<index_type>(m.inner(), *inner);
     host_copy_eckit<value_type>(m.data(),  *value);

--- a/src/atlas/linalg/sparse/MakeSparseMatrixStorageEigen.h
+++ b/src/atlas/linalg/sparse/MakeSparseMatrixStorageEigen.h
@@ -48,9 +48,21 @@ SparseMatrixStorage make_sparse_matrix_storage(Eigen::SparseMatrix<Value, Eigen:
     std::size_t rows = m.rows();
     std::size_t cols = m.cols();
     std::size_t nnz  = m.nonZeros();
-    auto* outer = atlas::array::Array::wrap(const_cast<Index*>(m.outerIndexPtr()), atlas::array::make_shape(rows+1));
-    auto* inner = atlas::array::Array::wrap(const_cast<Index*>(m.innerIndexPtr()), atlas::array::make_shape(nnz));
-    auto* value = atlas::array::Array::wrap(const_cast<Value*>(m.valuePtr()),      atlas::array::make_shape(nnz));
+    array::Array* outer;
+    array::Array* inner;
+    array::Array* value;
+    {
+        array::label label{"sparse_matrix.outer"};
+        outer = atlas::array::Array::wrap(const_cast<Index*>(m.outerIndexPtr()), atlas::array::make_shape(rows+1));
+    }
+    {
+        array::label label{"sparse_matrix.inner"};
+        inner = atlas::array::Array::wrap(const_cast<Index*>(m.innerIndexPtr()), atlas::array::make_shape(nnz));
+    }
+    {
+        array::label label{"sparse_matrix.value"};
+        value = atlas::array::Array::wrap(const_cast<Value*>(m.valuePtr()),      atlas::array::make_shape(nnz));
+    }
 
     using EigenMatrix = Eigen::SparseMatrix<Value, Eigen::RowMajor, Index>;
     auto m_ptr = std::make_shared<EigenMatrix>();
@@ -75,9 +87,21 @@ SparseMatrixStorage make_sparse_matrix_storage(Eigen::SparseMatrix<Value, Eigen:
     std::size_t rows = m.rows();
     std::size_t cols = m.cols();
     std::size_t nnz  = m.nonZeros();
-    auto* outer = atlas::array::Array::create<index_type>(rows+1);
-    auto* inner = atlas::array::Array::create<index_type>(nnz);
-    auto* value = atlas::array::Array::create<value_type>(nnz);
+    array::Array* outer;
+    array::Array* inner;
+    array::Array* value;
+    {
+        array::label label{"sparse_matrix.outer"};
+        outer = atlas::array::Array::create<index_type>(rows+1);
+    }
+    {
+        array::label label{"sparse_matrix.inner"};
+        inner = atlas::array::Array::create<index_type>(nnz);
+    }
+    {
+        array::label label{"sparse_matrix.value"};
+        value = atlas::array::Array::create<value_type>(nnz);
+    }
 
     host_copy_eigen<index_type>(m.outerIndexPtr(), *outer);
     host_copy_eigen<index_type>(m.innerIndexPtr(), *inner);
@@ -97,9 +121,21 @@ SparseMatrixStorage make_sparse_matrix_storage(const Eigen::SparseMatrix<Value, 
     std::size_t rows = m.rows();
     std::size_t cols = m.cols();
     std::size_t nnz  = m.nonZeros();
-    auto* outer = atlas::array::Array::create<Index>(rows+1);
-    auto* inner = atlas::array::Array::create<Index>(nnz);
-    auto* value = atlas::array::Array::create<Value>(nnz);
+    array::Array* outer;
+    array::Array* inner;
+    array::Array* value;
+    {
+        array::label label{"sparse_matrix.outer"};
+        outer = atlas::array::Array::create<Index>(rows+1);
+    }
+    {
+        array::label label{"sparse_matrix.inner"};
+        inner = atlas::array::Array::create<Index>(nnz);
+    }
+    {
+        array::label label{"sparse_matrix.value"};
+        value = atlas::array::Array::create<Value>(nnz);
+    }
 
     host_copy_eigen<Index>(m.outerIndexPtr(), *outer);
     host_copy_eigen<Index>(m.innerIndexPtr(), *inner);
@@ -120,9 +156,21 @@ SparseMatrixStorage make_sparse_matrix_storage(const Eigen::SparseMatrix<Value, 
     std::size_t rows = m.rows();
     std::size_t cols = m.cols();
     std::size_t nnz  = m.nonZeros();
-    auto* outer = atlas::array::Array::create<index_type>(rows+1);
-    auto* inner = atlas::array::Array::create<index_type>(nnz);
-    auto* value = atlas::array::Array::create<value_type>(nnz);
+    array::Array* outer;
+    array::Array* inner;
+    array::Array* value;
+    {
+        array::label label{"sparse_matrix.outer"};
+        outer = atlas::array::Array::create<index_type>(rows+1);
+    }
+    {
+        array::label label{"sparse_matrix.inner"};
+        inner = atlas::array::Array::create<index_type>(nnz);
+    }
+    {
+        array::label label{"sparse_matrix.value"};
+        value = atlas::array::Array::create<value_type>(nnz);
+    }
     host_copy_eigen<index_type>(m.outerIndexPtr(), *outer);
     host_copy_eigen<index_type>(m.innerIndexPtr(), *inner);
     host_copy_eigen<value_type>(m.valuePtr(),      *value);

--- a/src/atlas/linalg/sparse/SparseMatrixStorage.cc
+++ b/src/atlas/linalg/sparse/SparseMatrixStorage.cc
@@ -32,9 +32,18 @@ SparseMatrixStorage::SparseMatrixStorage(const SparseMatrixStorage& other) {
     nnz_   = other.nnz_;
     rows_  = other.rows_;
     cols_  = other.cols_;
-    outer_.reset(atlas::array::Array::create(other.outer_->datatype(), atlas::array::make_shape(other.outer_->size())));
-    inner_.reset(atlas::array::Array::create(other.inner_->datatype(), atlas::array::make_shape(other.inner_->size())));
-    value_.reset(atlas::array::Array::create(other.value_->datatype(), atlas::array::make_shape(other.value_->size())));
+    {
+        array::label label{"sparse_matrix.outer"};
+        outer_.reset(atlas::array::Array::create(other.outer_->datatype(), atlas::array::make_shape(other.outer_->size())));
+    }
+    {
+        array::label label{"sparse_matrix.inner"};
+        inner_.reset(atlas::array::Array::create(other.inner_->datatype(), atlas::array::make_shape(other.inner_->size())));
+    }
+    {
+        array::label label{"sparse_matrix.value"};
+        value_.reset(atlas::array::Array::create(other.value_->datatype(), atlas::array::make_shape(other.value_->size())));
+    }
     outer_->copy(*other.outer_);
     inner_->copy(*other.inner_);
     value_->copy(*other.value_);
@@ -61,9 +70,18 @@ SparseMatrixStorage& SparseMatrixStorage::operator=(const SparseMatrixStorage& o
     nnz_   = other.nnz_;
     rows_  = other.rows_;
     cols_  = other.cols_;
-    outer_.reset(atlas::array::Array::create(other.outer_->datatype(), atlas::array::make_shape(other.outer_->size())));
-    inner_.reset(atlas::array::Array::create(other.inner_->datatype(), atlas::array::make_shape(other.inner_->size())));
-    value_.reset(atlas::array::Array::create(other.value_->datatype(), atlas::array::make_shape(other.value_->size())));
+    {
+        array::label label{"sparse_matrix.outer"};
+        outer_.reset(atlas::array::Array::create(other.outer_->datatype(), atlas::array::make_shape(other.outer_->size())));
+    }
+    {
+        array::label label{"sparse_matrix.inner"};
+        inner_.reset(atlas::array::Array::create(other.inner_->datatype(), atlas::array::make_shape(other.inner_->size())));
+    }
+    {
+        array::label label{"sparse_matrix.value"};
+        value_.reset(atlas::array::Array::create(other.value_->datatype(), atlas::array::make_shape(other.value_->size())));
+    }
     outer_->copy(*other.outer_);
     inner_->copy(*other.inner_);
     value_->copy(*other.value_);


### PR DESCRIPTION
- Adds PLUTO_TRACE output for pointers being copied between host/device.
- Adds ATLAS_TRACE output for Atlas arrays and fields for device allocations, device deallocations, update_device, update_host

To enable the ATLAS_TRACE output here, use the environment variable ATLAS_TRACE_MEMORY=ON