### PR TITLE
Improve HaloExchange on_device, checking state flags

### DIFF
--- a/cmake/features/CUDA.cmake
+++ b/cmake/features/CUDA.cmake
@@ -29,9 +29,22 @@ endif()
 set( HAVE_CUDA ${atlas_HAVE_CUDA} )
 set( HAVE_HIP  ${atlas_HAVE_HIP} )
 set( HAVE_GPU  ${atlas_HAVE_GPU} )
-
 if( HAVE_GPU )
   ecbuild_info("GPU support enabled")
 else()
   ecbuild_info("GPU support not enabled")
+endif()
+
+if( HAVE_GPU )
+  set( GPU_AWARE_MPI_default ON )
+else()
+  set( GPU_AWARE_MPI_default OFF )
+endif()
+ecbuild_add_option( FEATURE GPU_AWARE_MPI
+                    DESCRIPTION "MPI supports GPU to GPU transfers"
+                    DEFAULT ${GPU_AWARE_MPI_default} )
+if( HAVE_GPU_AWARE_MPI )
+  ecbuild_info("GPU aware MPI support enabled")
+else()
+  ecbuild_info("GPU aware MPI support not enabled")
 endif()

--- a/src/atlas/functionspace/detail/StructuredColumns.cc
+++ b/src/atlas/functionspace/detail/StructuredColumns.cc
@@ -808,22 +808,22 @@ struct FixupHaloForVectors<3> {
 
 
 template <int RANK>
-void dispatch_haloExchange(Field& field, const parallel::HaloExchange& halo_exchange, const StructuredColumns& fs) {
+void dispatch_haloExchange(Field& field, bool on_device, const parallel::HaloExchange& halo_exchange, const StructuredColumns& fs) {
     FixupHaloForVectors<RANK> fixup_halos(fs);
     if (field.datatype() == array::DataType::kind<int>()) {
-        halo_exchange.template execute<int, RANK>(field.array(), false);
+        halo_exchange.template execute<int, RANK>(field.array(), on_device);
         fixup_halos.template apply<int>(field);
     }
     else if (field.datatype() == array::DataType::kind<long>()) {
-        halo_exchange.template execute<long, RANK>(field.array(), false);
+        halo_exchange.template execute<long, RANK>(field.array(), on_device);
         fixup_halos.template apply<long>(field);
     }
     else if (field.datatype() == array::DataType::kind<float>()) {
-        halo_exchange.template execute<float, RANK>(field.array(), false);
+        halo_exchange.template execute<float, RANK>(field.array(), on_device);
         fixup_halos.template apply<float>(field);
     }
     else if (field.datatype() == array::DataType::kind<double>()) {
-        halo_exchange.template execute<double, RANK>(field.array(), false);
+        halo_exchange.template execute<double, RANK>(field.array(), on_device);
         fixup_halos.template apply<double>(field);
     }
     else {
@@ -834,24 +834,24 @@ void dispatch_haloExchange(Field& field, const parallel::HaloExchange& halo_exch
 
 
 template <int RANK>
-void dispatch_adjointHaloExchange(Field& field, const parallel::HaloExchange& halo_exchange,
+void dispatch_adjointHaloExchange(Field& field, bool on_device, const parallel::HaloExchange& halo_exchange,
                                   const StructuredColumns& fs) {
     FixupHaloForVectors<RANK> fixup_halos(fs);
     if (field.datatype() == array::DataType::kind<int>()) {
         fixup_halos.template apply<int>(field);
-        halo_exchange.template execute_adjoint<int, RANK>(field.array(), false);
+        halo_exchange.template execute_adjoint<int, RANK>(field.array(), on_device);
     }
     else if (field.datatype() == array::DataType::kind<long>()) {
         fixup_halos.template apply<long>(field);
-        halo_exchange.template execute_adjoint<long, RANK>(field.array(), false);
+        halo_exchange.template execute_adjoint<long, RANK>(field.array(), on_device);
     }
     else if (field.datatype() == array::DataType::kind<float>()) {
         fixup_halos.template apply<float>(field);
-        halo_exchange.template execute_adjoint<float, RANK>(field.array(), false);
+        halo_exchange.template execute_adjoint<float, RANK>(field.array(), on_device);
     }
     else if (field.datatype() == array::DataType::kind<double>()) {
         fixup_halos.template apply<double>(field);
-        halo_exchange.template execute_adjoint<double, RANK>(field.array(), false);
+        halo_exchange.template execute_adjoint<double, RANK>(field.array(), on_device);
     }
     else {
         throw_Exception("datatype not supported", Here());
@@ -860,21 +860,21 @@ void dispatch_adjointHaloExchange(Field& field, const parallel::HaloExchange& ha
 }
 }  // namespace
 
-void StructuredColumns::haloExchange(const FieldSet& fieldset, bool) const {
+void StructuredColumns::haloExchange(const FieldSet& fieldset, bool on_device) const {
     for (idx_t f = 0; f < fieldset.size(); ++f) {
         Field& field = const_cast<FieldSet&>(fieldset)[f];
         switch (field.rank()) {
             case 1:
-                dispatch_haloExchange<1>(field, halo_exchange(), *this);
+                dispatch_haloExchange<1>(field, on_device, halo_exchange(), *this);
                 break;
             case 2:
-                dispatch_haloExchange<2>(field, halo_exchange(), *this);
+                dispatch_haloExchange<2>(field, on_device, halo_exchange(), *this);
                 break;
             case 3:
-                dispatch_haloExchange<3>(field, halo_exchange(), *this);
+                dispatch_haloExchange<3>(field, on_device, halo_exchange(), *this);
                 break;
             case 4:
-                dispatch_haloExchange<4>(field, halo_exchange(), *this);
+                dispatch_haloExchange<4>(field, on_device, halo_exchange(), *this);
                 break;
             default:
                 throw_Exception("Rank not supported", Here());
@@ -882,21 +882,21 @@ void StructuredColumns::haloExchange(const FieldSet& fieldset, bool) const {
     }
 }
 
-void StructuredColumns::adjointHaloExchange(const FieldSet& fieldset, bool) const {
+void StructuredColumns::adjointHaloExchange(const FieldSet& fieldset, bool on_device) const {
     for (idx_t f = 0; f < fieldset.size(); ++f) {
         Field& field = const_cast<FieldSet&>(fieldset)[f];
         switch (field.rank()) {
             case 1:
-                dispatch_adjointHaloExchange<1>(field, halo_exchange(), *this);
+                dispatch_adjointHaloExchange<1>(field, on_device, halo_exchange(), *this);
                 break;
             case 2:
-                dispatch_adjointHaloExchange<2>(field, halo_exchange(), *this);
+                dispatch_adjointHaloExchange<2>(field, on_device, halo_exchange(), *this);
                 break;
             case 3:
-                dispatch_adjointHaloExchange<3>(field, halo_exchange(), *this);
+                dispatch_adjointHaloExchange<3>(field, on_device, halo_exchange(), *this);
                 break;
             case 4:
-                dispatch_adjointHaloExchange<4>(field, halo_exchange(), *this);
+                dispatch_adjointHaloExchange<4>(field, on_device, halo_exchange(), *this);
                 break;
             default:
                 throw_Exception("Rank not supported", Here());
@@ -904,16 +904,16 @@ void StructuredColumns::adjointHaloExchange(const FieldSet& fieldset, bool) cons
     }
 }
 
-void StructuredColumns::haloExchange(const Field& field, bool) const {
+void StructuredColumns::haloExchange(const Field& field, bool on_device) const {
     FieldSet fieldset;
     fieldset.add(field);
-    haloExchange(fieldset);
+    haloExchange(fieldset, on_device);
 }
 
-void StructuredColumns::adjointHaloExchange(const Field& field, bool) const {
+void StructuredColumns::adjointHaloExchange(const Field& field, bool on_device) const {
     FieldSet fieldset;
     fieldset.add(field);
-    adjointHaloExchange(fieldset);
+    adjointHaloExchange(fieldset, on_device);
 }
 
 size_t StructuredColumns::footprint() const {

--- a/src/atlas/library/defines.h.in
+++ b/src/atlas/library/defines.h.in
@@ -18,6 +18,7 @@
 #define ATLAS_OMP_TASK_SUPPORTED             @ATLAS_OMP_TASK_SUPPORTED@
 #define ATLAS_OMP_TASK_UNTIED_SUPPORTED      @ATLAS_OMP_TASK_UNTIED_SUPPORTED@
 #define ATLAS_HAVE_GPU                       @atlas_HAVE_GPU@
+#define ATLAS_HAVE_GPU_AWARE_MPI             @atlas_HAVE_GPU_AWARE_MPI@
 #define ATLAS_HAVE_ACC                       @atlas_HAVE_ACC@
 #define ATLAS_HAVE_QHULL                     @atlas_HAVE_QHULL@
 #define ATLAS_HAVE_CGAL                      @atlas_HAVE_CGAL@


### PR DESCRIPTION
The on_device halo exchanges are now checking that the fields are marked as up-to-date on device.
When GPU_AWARE_MPI feature is disabled, then halo exchanges always happen on host with data copied to host and back to device.

For HaloExchange::execute_adjoint,  on_device is not implemented, and the route via the host is always used.

Also fix for StructuredColumsn::haloExchange which was not respecting the on_device flag.