### PR TITLE
Fix empty adjoint matrix for SphericalVector for scalar fields

### DIFF
--- a/src/atlas/interpolation/method/Method.cc
+++ b/src/atlas/interpolation/method/Method.cc
@@ -428,16 +428,22 @@ Method::Method(const Method::Config& config) {
     config.get("adjoint", adjoint_);
 }
 
+void Method::computeMatrixAdjoint() {
+    ATLAS_ASSERT(matrix_);
+    if (not matrix_->empty()) {
+        eckit::linalg::SparseMatrix matrix_copy = make_eckit_sparse_matrix(*matrix_); // Makes a copy!
+        matrix_copy.transpose(); // transpose the copy in place
+        matrix_transpose_ = linalg::make_sparse_matrix_storage(std::move(matrix_copy)); // Move the copy into storage
+    }
+}
+
 void Method::setup(const FunctionSpace& source, const FunctionSpace& target) {
     ATLAS_TRACE("atlas::interpolation::method::Method::setup(FunctionSpace, FunctionSpace)");
     this->do_setup(source, target);
 
-    if (adjoint_ && target.size() > 0 && matrixAllocated()) {
-        if (not matrix_->empty()) {
-            eckit::linalg::SparseMatrix matrix_copy = make_eckit_sparse_matrix(*matrix_); // Makes a copy!
-            matrix_copy.transpose(); // transpose the copy in place
-            matrix_transpose_ = linalg::make_sparse_matrix_storage(std::move(matrix_copy)); // Move the copy into storage
-        }
+    if (target.size() > 0 && adjoint_) {
+        ATLAS_ASSERT(matrix_, "Cannot compute adjoint for matrix-free interpolation methods");
+        ATLAS_ASSERT(not matrix_transpose_.empty());
     }
 }
 

--- a/src/atlas/interpolation/method/Method.h
+++ b/src/atlas/interpolation/method/Method.h
@@ -105,6 +105,7 @@ protected:
     friend class interpolation::MatrixCache;
 
 protected:
+    void computeMatrixAdjoint();
 
     void setMatrix(Matrix&& m, const std::string& uid = "") {
         if (not matrix_shared_) {
@@ -114,6 +115,9 @@ protected:
         matrix_cache_ = interpolation::MatrixCache(matrix_shared_, uid);
         matrix_       = &matrix_cache_.matrix();
 
+        if (adjoint_) {
+            computeMatrixAdjoint();
+        }
     }
 
     void setMatrix(interpolation::MatrixCache matrix_cache) {

--- a/src/atlas/interpolation/method/sphericalvector/SphericalVector.cc
+++ b/src/atlas/interpolation/method/sphericalvector/SphericalVector.cc
@@ -68,16 +68,26 @@ void SphericalVector::do_setup(const FunctionSpace& source,
     return;
   }
 
-  setMatrix(Interpolation(interpolationScheme_, source_, target_));
+  {
+    Interpolation underlying_interpolator;
+    ATLAS_TRACE_SCOPE("Create underlying interpolator")
+    underlying_interpolator = Interpolation(interpolationScheme_, source_, target_);
+    auto underlying_interpolator_cache = MatrixCache(underlying_interpolator);
+    ATLAS_ASSERT(underlying_interpolator_cache);
+    ATLAS_TRACE_SCOPE("copy matrix") {
+      Matrix underlying_matrix = underlying_interpolator_cache.matrix();
+      setMatrix(std::move(underlying_matrix));
+    }
+  }
 
   // Get matrix data.
-  const auto m = atlas::linalg::make_non_owning_eckit_sparse_matrix(matrix());
+  const auto m = atlas::linalg::make_host_view<double>(matrix());
   const auto nRows = static_cast<Index>(m.rows());
   const auto nCols = static_cast<Index>(m.cols());
-  const auto nNonZeros = static_cast<std::size_t>(m.nonZeros());
+  const auto nNonZeros = static_cast<std::size_t>(m.nnz());
   const auto* outerIndices = m.outer();
   const auto* innerIndices = m.inner();
-  const auto* baseWeights  = m.data();
+  const auto* baseWeights  = m.value();
 
   // Note: need to store copy of weights as Eigen3 sorts compressed rows by j
   // whereas eckit does not.

--- a/src/tests/interpolation/test_interpolation_spherical_vector.cc
+++ b/src/tests/interpolation/test_interpolation_spherical_vector.cc
@@ -116,6 +116,8 @@ struct FunctionSpaceFixtures {
 struct FieldSpecFixtures {
   static const Config& get(const std::string& fixture) {
     static const auto fieldSpecs = std::map<std::string_view, Config>{
+        {"scalar", option::name("test field") | option::variables(1) |
+                        option::type("scalar")},
         {"2vector", option::name("test field") | option::variables(2) |
                         option::type("vector")},
         {"3vector", option::name("test field") | option::variables(3) |
@@ -308,6 +310,17 @@ void testInterpolation(const Config& config) {
   }
 }
 
+CASE("cubed sphere CS-LFR-48 scalar interpolation (3d-field, scalar)") {
+  const auto config =
+      Config("source_fixture", "cubedsphere_mesh")
+          .set("target_fixture", "gaussian_mesh")
+          .set("field_spec_fixture", "scalar")
+          .set("interp_fixture", "cubedsphere_bilinear_spherical")
+          .set("file_id", "spherical_vector_cs2")
+          .set("tol", 0.00018);
+
+  testInterpolation<Rank3dField>((config));
+}
 
 CASE("cubed sphere CS-LFR-48 vector interpolation (3d-field, 2-vector)") {
   const auto config =


### PR DESCRIPTION
This PR fixes issue #309  where an empty adjoint matrix occurs for handling scalar fields with the SphericalVector interpolation method.

@l90lpa please verify this is OK.