### PR TITLE
Fixes and workaround failing atlas_fctest_functionspace when fckit is compiled with -Mnotarget_temps with NVHPC

### DIFF
--- a/src/atlas_f/field/atlas_Field_module.fypp
+++ b/src/atlas_f/field/atlas_Field_module.fypp
@@ -431,69 +431,121 @@ end function
 function atlas_Field__wrap_name_${dtype}$_r${rank}$(name,data) result(field)
   use atlas_field_c_binding
   use fckit_array_module, only : array_strides, array_view1d
-  use, intrinsic :: iso_c_binding, only : c_int, c_long, c_float, c_double
-  use fckit_c_interop_module, only : c_str
+  use, intrinsic :: iso_c_binding, only : c_int, c_long, c_float, c_double, c_loc, c_int32_t, c_sizeof
+  use fckit_c_interop_module, only : c_str, c_ptr_to_loc
   type(atlas_Field) :: field
   character(len=*), intent(in) :: name
   ${ftype}$, intent(in), target :: data(${dim[rank]}$)
+  ${ftype}$, pointer :: data_ptr(${dim[rank]}$)
+  ${ftype}$ :: elem_value
   integer(c_int) :: shapef(${rank}$)
   integer(c_int) :: stridesf(${rank}$)
 #:if ftype != "logical"
   ${ftype}$, pointer :: data1d(:)
-  data1d => array_view1d(data)
+  ! For some reason, with nvhpc/22.11 we need create a pointer to pass to array_view1d
+  ! This is not reproducible all the time.
+  ! Test atlas_fctest_functionspace started failing when fckit was compiled with -Mnotarget_temps (nvidia/22.11)
+  data_ptr => data
+  data1d => array_view1d(data_ptr)
 #:else
+  ! Case for logical only
   integer(c_int), pointer :: data1d(:)
-  data1d => array_view1d( data, int(0,c_int) )
-#:endif
-  shapef = shape(data)
-  stridesf = array_strides(data)
-  field = atlas_Field__cptr( &
-    atlas__Field__wrap_${ctype}$_specf( c_str(name), data1d, size(shapef), shapef, stridesf ) )
-  call field%return()
-end function
-function atlas_Field__wrap_${dtype}$_r${rank}$(data) result(field)
-  use, intrinsic :: iso_c_binding, only : c_int, c_long, c_float, c_double, c_loc, c_int32_t
-  use :: fckit_c_interop_module
-  use atlas_field_c_binding
-  use fckit_array_module, only : array_strides, array_view1d
-  type(atlas_Field) :: field
-  ${ftype}$, intent(in), target :: data(${dim[rank]}$)
-  integer(c_int) :: shapef(${rank}$)
-  integer(c_int) :: stridesf(${rank}$)
-#:if ftype != "logical"
-    ${ftype}$, pointer :: data1d(:)
-    data1d => array_view1d(data)
-#:else
-    integer(c_int), pointer :: data1d(:)
-    data1d => array_view1d( data, int(0,c_int) )
+  data_ptr => data
+  data1d => array_view1d( data_ptr, int(0,c_int) )
 #:endif
   shapef = shape(data)
   if( size(data)>0 ) then
   !!! See issue https://github.com/ecmwf/atlas/pull/213 : problem with array_strides(data) with NAG compiler.
 #:if rank == 4
-    stridesf(1) = &
-      int(c_ptr_to_loc(c_loc(data(2,1,1,1)))-c_ptr_to_loc(c_loc(data(1,1,1,1))),c_int32_t)/int(8,c_int32_t)
-    stridesf(2) = &
-      int(c_ptr_to_loc(c_loc(data(1,2,1,1)))-c_ptr_to_loc(c_loc(data(1,1,1,1))),c_int32_t)/int(8,c_int32_t)
-    stridesf(3) = &
-      int(c_ptr_to_loc(c_loc(data(1,1,2,1)))-c_ptr_to_loc(c_loc(data(1,1,1,1))),c_int32_t)/int(8,c_int32_t)
-    stridesf(4) = &
-      int(c_ptr_to_loc(c_loc(data(1,1,1,2)))-c_ptr_to_loc(c_loc(data(1,1,1,1))),c_int32_t)/int(8,c_int32_t)
+    stridesf = 1
+    if (ubound(data,1) > 1) stridesf(1) = &
+      int(c_ptr_to_loc(c_loc(data(2,1,1,1)))-c_ptr_to_loc(c_loc(data(1,1,1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+    if (ubound(data,2) > 1) stridesf(2) = &
+      int(c_ptr_to_loc(c_loc(data(1,2,1,1)))-c_ptr_to_loc(c_loc(data(1,1,1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+    if (ubound(data,3) > 1) stridesf(3) = &
+      int(c_ptr_to_loc(c_loc(data(1,1,2,1)))-c_ptr_to_loc(c_loc(data(1,1,1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+    if (ubound(data,4) > 1) stridesf(4) = &
+      int(c_ptr_to_loc(c_loc(data(1,1,1,2)))-c_ptr_to_loc(c_loc(data(1,1,1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
 #:elif rank == 3
-    stridesf(1) = &
-      int(c_ptr_to_loc(c_loc(data(2,1,1)))-c_ptr_to_loc(c_loc(data(1,1,1))),c_int32_t)/int(8,c_int32_t)
-    stridesf(2) = &
-      int(c_ptr_to_loc(c_loc(data(1,2,1)))-c_ptr_to_loc(c_loc(data(1,1,1))),c_int32_t)/int(8,c_int32_t)
-    stridesf(3) = &
-      int(c_ptr_to_loc(c_loc(data(1,1,2)))-c_ptr_to_loc(c_loc(data(1,1,1))),c_int32_t)/int(8,c_int32_t)
+    stridesf = 1
+    if (ubound(data,1) > 1) stridesf(1) = &
+      int(c_ptr_to_loc(c_loc(data(2,1,1)))-c_ptr_to_loc(c_loc(data(1,1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+    if (ubound(data,2) > 1) stridesf(2) = &
+      int(c_ptr_to_loc(c_loc(data(1,2,1)))-c_ptr_to_loc(c_loc(data(1,1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+    if (ubound(data,3) > 1) stridesf(3) = &
+      int(c_ptr_to_loc(c_loc(data(1,1,2)))-c_ptr_to_loc(c_loc(data(1,1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
 #:elif rank == 2
-    stridesf(1) = &
-      int(c_ptr_to_loc(c_loc(data(2,1)))-c_ptr_to_loc(c_loc(data(1,1))),c_int32_t)/int(8,c_int32_t)
-    stridesf(2) = &
-      int(c_ptr_to_loc(c_loc(data(1,2)))-c_ptr_to_loc(c_loc(data(1,1))),c_int32_t)/int(8,c_int32_t)
+    stridesf = 1
+    if (ubound(data,1) > 1) stridesf(1) = &
+      int(c_ptr_to_loc(c_loc(data(2,1)))-c_ptr_to_loc(c_loc(data(1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+    if (ubound(data,2) > 1) stridesf(2) = &
+      int(c_ptr_to_loc(c_loc(data(1,2)))-c_ptr_to_loc(c_loc(data(1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
 #:elif rank == 1
-    stridesf(1) = &
-      int(c_ptr_to_loc(c_loc(data(2)))-c_ptr_to_loc(c_loc(data(1))),c_int32_t)/int(8,c_int32_t)
+    stridesf = 1
+    if (ubound(data,1) > 1) stridesf(1) = &
+      int(c_ptr_to_loc(c_loc(data(2)))-c_ptr_to_loc(c_loc(data(1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+#:else
+    stridesf = array_strides(data)
+#:endif
+  else
+    stridesf = 0
+  endif
+
+  field = atlas_Field__cptr( &
+    atlas__Field__wrap_${ctype}$_specf( c_str(name), data1d, size(shapef), shapef, stridesf ) )
+  call field%return()
+end function
+function atlas_Field__wrap_${dtype}$_r${rank}$(data) result(field)
+  use, intrinsic :: iso_c_binding, only : c_int, c_long, c_float, c_double, c_loc, c_int32_t, c_sizeof
+  use :: fckit_c_interop_module, only : c_str, c_ptr_to_loc
+  use atlas_field_c_binding
+  use fckit_array_module, only : array_strides, array_view1d
+  type(atlas_Field) :: field
+  ${ftype}$, intent(in), target :: data(${dim[rank]}$)
+  ${ftype}$, pointer :: data_ptr(${dim[rank]}$)
+  ${ftype}$ :: elem_value
+  integer(c_int) :: shapef(${rank}$)
+  integer(c_int) :: stridesf(${rank}$)
+#:if ftype != "logical"
+    ${ftype}$, pointer :: data1d(:)
+    data_ptr => data
+    data1d => array_view1d(data_ptr)
+#:else
+    integer(c_int), pointer :: data1d(:)
+    data_ptr => data
+    data1d => array_view1d( data_ptr, int(0,c_int) )
+#:endif
+  shapef = shape(data)
+  if( size(data)>0 ) then
+  !!! See issue https://github.com/ecmwf/atlas/pull/213 : problem with array_strides(data) with NAG compiler.
+#:if rank == 4
+    stridesf = 1
+    if (ubound(data,1) > 1) stridesf(1) = &
+      int(c_ptr_to_loc(c_loc(data(2,1,1,1)))-c_ptr_to_loc(c_loc(data(1,1,1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+    if (ubound(data,2) > 1) stridesf(2) = &
+      int(c_ptr_to_loc(c_loc(data(1,2,1,1)))-c_ptr_to_loc(c_loc(data(1,1,1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+    if (ubound(data,3) > 1) stridesf(3) = &
+      int(c_ptr_to_loc(c_loc(data(1,1,2,1)))-c_ptr_to_loc(c_loc(data(1,1,1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+    if (ubound(data,4) > 1) stridesf(4) = &
+      int(c_ptr_to_loc(c_loc(data(1,1,1,2)))-c_ptr_to_loc(c_loc(data(1,1,1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+#:elif rank == 3
+    stridesf = 1
+    if (ubound(data,1) > 1) stridesf(1) = &
+      int(c_ptr_to_loc(c_loc(data(2,1,1)))-c_ptr_to_loc(c_loc(data(1,1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+    if (ubound(data,2) > 1) stridesf(2) = &
+      int(c_ptr_to_loc(c_loc(data(1,2,1)))-c_ptr_to_loc(c_loc(data(1,1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+    if (ubound(data,3) > 1) stridesf(3) = &
+      int(c_ptr_to_loc(c_loc(data(1,1,2)))-c_ptr_to_loc(c_loc(data(1,1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+#:elif rank == 2
+    stridesf = 1
+    if (ubound(data,1) > 1) stridesf(1) = &
+      int(c_ptr_to_loc(c_loc(data(2,1)))-c_ptr_to_loc(c_loc(data(1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+    if (ubound(data,2) > 1) stridesf(2) = &
+      int(c_ptr_to_loc(c_loc(data(1,2)))-c_ptr_to_loc(c_loc(data(1,1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
+#:elif rank == 1
+    stridesf = 1
+    if (ubound(data,1) > 1) stridesf(1) = &
+      int(c_ptr_to_loc(c_loc(data(2)))-c_ptr_to_loc(c_loc(data(1))),c_int32_t)/int(c_sizeof(elem_value),c_int32_t)
 #:else
     stridesf = array_strides(data)
 #:endif

--- a/src/tests/functionspace/fctest_functionspace.F90
+++ b/src/tests/functionspace/fctest_functionspace.F90
@@ -958,9 +958,9 @@ type(atlas_FieldSet) :: fset
 type(atlas_functionspace) :: fs_base
 type(atlas_trace) :: trace
 
-integer i, k
-integer rank
-real space
+integer(c_int) ::  i, k
+integer(c_int) :: rank
+real(c_double) :: space
 real(c_double), allocatable :: point_values(:,:)
 integer(c_int), dimension(4) :: ghost_values
 integer(c_int), dimension(4) :: partition_index
@@ -989,15 +989,15 @@ rank = fckit_mpi%rank()
 ! 0  45 | 315  90
 
 
-space = 360.0 /(2.0 * fckit_mpi%size())
+space = 360.0_c_double /(2.0_c_double * fckit_mpi%size())
 fset = atlas_FieldSet()
 
 allocate(point_values(2, 4))
 
-point_values = reshape((/space * (2 * rank), 0.0, &
-                         space * (2 * rank + 1), 0.0, &
-                         space * (2 * rank - 1), 0.0, &
-                         space * (2 * rank + 2), 0.0/), shape(point_values))
+point_values = reshape((/space * (2 * rank),      0.0_c_double, &
+                         space * (2 * rank + 1),  0.0_c_double, &
+                         space * (2 * rank - 1),  0.0_c_double, &
+                         space * (2 * rank + 2),  0.0_c_double/),  shape(point_values))
 
 if (point_values(1, 3) < 0.0) point_values(1, 3) = 360.0 + point_values(1, 3)
 if (point_values(1, 4) > 360.0 - tol) point_values(1, 4) = 0.0d0


### PR DESCRIPTION
For some reason, with nvhpc/22.11 we need to create a pointer to pass to array_view1d in atlas_Field_module when wrapping existing data. This seems not always be the case. E.g.  atlas_fctest_functionspace started failing when fckit was compiled with -Mnotarget_temps (nvidia/22.11). See comment in issue https://github.com/ecmwf/fckit/pull/74#issuecomment-3503594744

Also taken the liberty to be consistent and fix array stride computation bugs introduced with https://github.com/ecmwf/atlas/pull/213 . The bytes of an element was hardcoded to 8 but should be dependent on the data type.

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-332
<!-- STATIC-ANALYSIS_END -->