### PR TITLE
DelaunayMeshGenerator/ExtendNodesGlobal custom extension grid (defaul…

### DIFF
--- a/src/atlas/mesh/actions/ExtendNodesGlobal.cc
+++ b/src/atlas/mesh/actions/ExtendNodesGlobal.cc
@@ -24,14 +24,19 @@ namespace atlas {
 namespace mesh {
 namespace actions {
 
-ExtendNodesGlobal::ExtendNodesGlobal(const std::string& gridname): gridname_(gridname) {}
+const std::string ExtendNodesGlobal::DEFAULT_GRIDNAME = "O16";
+
+ExtendNodesGlobal::ExtendNodesGlobal(const std::string& gridname):
+    gridname_(gridname.empty() ? DEFAULT_GRIDNAME : gridname) {
+    ATLAS_ASSERT(!gridname_.empty());
+}
 
 void ExtendNodesGlobal::operator()(const Grid& grid, Mesh& mesh) const {
     if (grid.domain().global()) {
         return;  // don't add virtual points to global domains
     }
 
-    Grid O16("O16");
+    Grid extension_grid(gridname_);
 
     // virtual points
     std::vector<PointXY> extended_pts;
@@ -39,7 +44,7 @@ void ExtendNodesGlobal::operator()(const Grid& grid, Mesh& mesh) const {
 
     // loop over the point and keep the ones that *don't* fall in the domain
 
-    for (const PointLonLat& lonlat : O16.lonlat()) {
+    for (const PointLonLat& lonlat : extension_grid.lonlat()) {
         PointXY xy = grid.projection().xy(lonlat);
         if (not grid.domain().contains(xy)) {
             extended_pts.push_back(xy);
@@ -66,9 +71,9 @@ void ExtendNodesGlobal::operator()(const Grid& grid, Mesh& mesh) const {
     array::ArrayView<double, 2> xy     = array::make_view<double, 2>(nodes.xy());
     array::ArrayView<double, 2> lonlat = array::make_view<double, 2>(nodes.lonlat());
     array::ArrayView<gidx_t, 1> gidx   = array::make_view<gidx_t, 1>(nodes.global_index());
-    array::ArrayView<int, 1>    ghost  = array::make_view<int, 1>(nodes.ghost());
-    array::ArrayView<int, 1>    partition = array::make_view<int, 1>(nodes.partition());
-    array::ArrayView<int, 1>    flags  = array::make_view<int, 1>(nodes.flags());
+    array::ArrayView<int, 1> ghost     = array::make_view<int, 1>(nodes.ghost());
+    array::ArrayView<int, 1> partition = array::make_view<int, 1>(nodes.partition());
+    array::ArrayView<int, 1> flags     = array::make_view<int, 1>(nodes.flags());
 
     for (idx_t i = 0; i < nb_extension_pts; ++i) {
         const idx_t n         = nb_real_pts + i;

--- a/src/atlas/mesh/actions/ExtendNodesGlobal.h
+++ b/src/atlas/mesh/actions/ExtendNodesGlobal.h
@@ -24,10 +24,11 @@ namespace actions {
 /// Adds virtual nodes to the mesh that aren't contained in the Grid Domain
 class ExtendNodesGlobal {
 public:
-    ExtendNodesGlobal(const std::string& gridname = "O16");
+    explicit ExtendNodesGlobal(const std::string& gridname = DEFAULT_GRIDNAME);
     void operator()(const Grid&, Mesh&) const;
 
 private:
+    static const std::string DEFAULT_GRIDNAME;
     std::string gridname_;
 };
 

--- a/src/atlas/meshgenerator/detail/DelaunayMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/DelaunayMeshGenerator.cc
@@ -18,6 +18,7 @@
 #include "atlas/grid/Distribution.h"
 #include "atlas/grid/Grid.h"
 #include "atlas/grid/Iterator.h"
+#include "atlas/mesh/ElementType.h"
 #include "atlas/mesh/HybridElements.h"
 #include "atlas/mesh/Mesh.h"
 #include "atlas/mesh/Nodes.h"
@@ -26,11 +27,11 @@
 #include "atlas/mesh/actions/ExtendNodesGlobal.h"
 #include "atlas/meshgenerator/detail/DelaunayMeshGenerator.h"
 #include "atlas/meshgenerator/detail/MeshGeneratorFactory.h"
+#include "atlas/parallel/mpi/mpi.h"
 #include "atlas/projection/Projection.h"
 #include "atlas/runtime/Log.h"
+#include "atlas/util/Config.h"
 #include "atlas/util/CoordinateEnums.h"
-#include "atlas/parallel/mpi/mpi.h"
-#include "atlas/mesh/ElementType.h"
 
 using atlas::Mesh;
 
@@ -39,13 +40,12 @@ namespace meshgenerator {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-DelaunayMeshGenerator::DelaunayMeshGenerator() = default;
-
 DelaunayMeshGenerator::DelaunayMeshGenerator(const eckit::Parametrisation& p) {
     p.get("mpi_comm",mpi_comm_=mpi::comm().name());
     p.get("part",part_=mpi::comm(mpi_comm_).rank());
     p.get("reshuffle",reshuffle_=true);
     p.get("remove_duplicate_points",remove_duplicate_points_=true);
+    p.get("extension_grid", extension_grid_);
 }
 
 DelaunayMeshGenerator::~DelaunayMeshGenerator() = default;
@@ -92,11 +92,12 @@ void DelaunayMeshGenerator::generate(const Grid& grid, const grid::Distribution&
 
             ++jnode;
         }
+
         mesh::actions::BuildXYZField()(mesh);
-        mesh::actions::ExtendNodesGlobal()(grid,mesh);  ///< does nothing if global domain
+        mesh::actions::ExtendNodesGlobal{extension_grid_}(grid, mesh);  ///< does nothing if global domain
         mesh::actions::BuildConvexHull3D()(mesh);
-        
-        auto cells_gidx = array::make_view<gidx_t,1>( mesh.cells().global_index() );
+
+        auto cells_gidx = array::make_view<gidx_t, 1>(mesh.cells().global_index());
         for (idx_t jelem=0; jelem<mesh.cells().size(); ++jelem) {
             cells_gidx(jelem) = jelem + 1;
         }

--- a/src/atlas/meshgenerator/detail/DelaunayMeshGenerator.h
+++ b/src/atlas/meshgenerator/detail/DelaunayMeshGenerator.h
@@ -25,8 +25,7 @@ namespace meshgenerator {
 
 class DelaunayMeshGenerator : public MeshGenerator::Implementation {
 public:
-    DelaunayMeshGenerator();
-    DelaunayMeshGenerator(const eckit::Parametrisation& p);
+    DelaunayMeshGenerator(const eckit::Parametrisation& = util::NoConfig());
 
     virtual ~DelaunayMeshGenerator() override;
 
@@ -43,6 +42,7 @@ private:  // methods
     int part_;
     bool remove_duplicate_points_;
     bool reshuffle_;
+    std::string extension_grid_;
 };
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Ability to configure what is the extension/background grid (by name) to use one a Delaunay mesh generation, in case the grid of interest is not global. The default is "O16" (maintaining the same behaviour).

The grid name is passed at mesh generation construction via option "extension_grid", based on implementation class "ExtendNodesGlobal".


### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-337
<!-- STATIC-ANALYSIS_END -->