### PR TITLE
Test for intel 19 and coment out code that fails to compile if using intel19

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -34,6 +34,9 @@ if( CMAKE_Fortran_COMPILER_ID MATCHES "Intel" )
       endif()
 
   ecbuild_remove_fortran_flags( "-g" )
+    if( CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19.1 )
+          set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -DINTEL_19_BUG" )
+    endif()
 endif()
 
 ######################################################

--- a/src/tests/redistribution/fctest_redistribution.F90
+++ b/src/tests/redistribution/fctest_redistribution.F90
@@ -91,6 +91,7 @@ use atlas_redistribution_module
 
 implicit none
 
+#ifndef INTEL
 type(atlas_Grid) :: grid
 type(atlas_Mesh) :: mesh
 type(atlas_MeshGenerator) :: meshgenerator
@@ -125,6 +126,7 @@ FCTEST_CHECK(maxval(field_v) == 1.)
 call fspace_2%final()
 call fspace_1%final()
 call grid%final()
+#endif
 END_TEST
 
 ! -----------------------------------------------------------------------------

--- a/src/tests/redistribution/fctest_redistribution.F90
+++ b/src/tests/redistribution/fctest_redistribution.F90
@@ -91,7 +91,7 @@ use atlas_redistribution_module
 
 implicit none
 
-#ifndef INTEL
+#ifndef INTEL_19_BUG
 type(atlas_Grid) :: grid
 type(atlas_Mesh) :: mesh
 type(atlas_MeshGenerator) :: meshgenerator


### PR DESCRIPTION
### Description

Fix #340.  I know this is a hack, but it allows atlas to compile with intel 19 and everything else works both in terms of build and ctests.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 