### PR TITLE
Replace use of deprecated Library::lookup

### DIFF
--- a/atlas_io/tests/TestEnvironment.h
+++ b/atlas_io/tests/TestEnvironment.h
@@ -23,6 +23,7 @@
 #include "eckit/eckit.h"
 #include "eckit/log/PrefixTarget.h"
 #include "eckit/runtime/Main.h"
+#include "eckit/system/LibraryManager.h"
 #include "eckit/testing/Test.h"
 #include "eckit/types/Types.h"
 
@@ -226,8 +227,8 @@ namespace {
 }
 
 [[maybe_unused]] void debug_addTarget(eckit::LogTarget* target) {
-    for (std::string libname : eckit::system::Library::list()) {
-        const eckit::system::Library& lib = eckit::system::Library::lookup(libname);
+    for (std::string libname : eckit::system::LibraryManager::list()) {
+        const eckit::system::Library& lib = eckit::system::LibraryManager::lookup(libname);
         if (lib.debug()) {
             lib.debugChannel().addTarget(new eckit::PrefixTarget(debug_prefix(libname), target));
         }
@@ -237,8 +238,8 @@ namespace {
 }
 
 [[maybe_unused]] void debug_setTarget(eckit::LogTarget* target) {
-    for (std::string libname : eckit::system::Library::list()) {
-        const eckit::system::Library& lib = eckit::system::Library::lookup(libname);
+    for (std::string libname : eckit::system::LibraryManager::list()) {
+        const eckit::system::Library& lib = eckit::system::LibraryManager::lookup(libname);
         if (lib.debug()) {
             lib.debugChannel().setTarget(new eckit::PrefixTarget(debug_prefix(libname), target));
         }
@@ -248,8 +249,8 @@ namespace {
 }
 
 [[maybe_unused]] void debug_reset() {
-    for (std::string libname : eckit::system::Library::list()) {
-        const eckit::system::Library& lib = eckit::system::Library::lookup(libname);
+    for (std::string libname : eckit::system::LibraryManager::list()) {
+        const eckit::system::Library& lib = eckit::system::LibraryManager::lookup(libname);
         if (lib.debug()) {
             lib.debugChannel().reset();
         }

--- a/src/atlas/library/Library.cc
+++ b/src/atlas/library/Library.cc
@@ -553,11 +553,11 @@ void Library::Information::print(std::ostream& out) const {
 
     out << "    \n  Dependencies: \n";
     out << "    ecbuild version (" << ECBUILD_VERSION << ")" << '\n';
-    if (Library::exists("eckit")) {
-        out << "    " << str(Library::lookup("eckit")) << '\n';
+    if (eckit::system::LibraryManager::exists("eckit")) {
+        out << "    " << str(eckit::system::LibraryManager::lookup("eckit")) << '\n';
     }
-    if (Library::exists("fckit")) {
-        out << "    " << str(Library::lookup("fckit")) << '\n';
+    if (eckit::system::LibraryManager::exists("fckit")) {
+        out << "    " << str(eckit::system::LibraryManager::lookup("fckit")) << '\n';
     }
 
 #if ATLAS_HAVE_TRANS

--- a/src/atlas/runtime/AtlasTool.cc
+++ b/src/atlas/runtime/AtlasTool.cc
@@ -20,6 +20,8 @@
 #include "atlas/library/config.h"
 #include "atlas/runtime/AtlasTool.h"
 
+#include "eckit/system/LibraryManager.h"
+
 namespace atlas {
 static void usage(const std::string& name) {
     Log::info() << "dummy usage" << std::endl;
@@ -45,8 +47,8 @@ static std::string debug_prefix(const std::string& libname) {
 }
 
 void debug_addTarget(eckit::LogTarget* target) {
-    for (std::string libname : eckit::system::Library::list()) {
-        const eckit::system::Library& lib = eckit::system::Library::lookup(libname);
+    for (std::string libname : eckit::system::LibraryManager::list()) {
+        const eckit::system::Library& lib = eckit::system::LibraryManager::lookup(libname);
         if (lib.debug()) {
             lib.debugChannel().addTarget(new eckit::PrefixTarget(debug_prefix(libname), target));
         }
@@ -57,8 +59,8 @@ void debug_addTarget(eckit::LogTarget* target) {
 }
 
 void debug_setTarget(eckit::LogTarget* target) {
-    for (std::string libname : eckit::system::Library::list()) {
-        const eckit::system::Library& lib = eckit::system::Library::lookup(libname);
+    for (std::string libname : eckit::system::LibraryManager::list()) {
+        const eckit::system::Library& lib = eckit::system::LibraryManager::lookup(libname);
         if (lib.debug()) {
             lib.debugChannel().setTarget(new eckit::PrefixTarget(debug_prefix(libname), target));
         }
@@ -69,8 +71,8 @@ void debug_setTarget(eckit::LogTarget* target) {
 }
 
 void debug_reset() {
-    for (std::string libname : eckit::system::Library::list()) {
-        const eckit::system::Library& lib = eckit::system::Library::lookup(libname);
+    for (std::string libname : eckit::system::LibraryManager::list()) {
+        const eckit::system::Library& lib = eckit::system::LibraryManager::lookup(libname);
         if (lib.debug()) {
             lib.debugChannel().reset();
         }

--- a/src/tests/AtlasTestEnvironment.h
+++ b/src/tests/AtlasTestEnvironment.h
@@ -25,6 +25,7 @@
 #include "eckit/log/PrefixTarget.h"
 #include "eckit/mpi/Comm.h"
 #include "eckit/runtime/Main.h"
+#include "eckit/system/LibraryManager.h"
 #include "eckit/testing/Test.h"
 #include "eckit/types/Types.h"
 
@@ -336,8 +337,8 @@ static std::string debug_prefix(const std::string& libname) {
 }
 
 void debug_addTarget(eckit::LogTarget* target) {
-    for (std::string libname : eckit::system::Library::list()) {
-        const eckit::system::Library& lib = eckit::system::Library::lookup(libname);
+    for (std::string libname : eckit::system::LibraryManager::list()) {
+        const eckit::system::Library& lib = eckit::system::LibraryManager::lookup(libname);
         if (lib.debug()) {
             lib.debugChannel().addTarget(new eckit::PrefixTarget(debug_prefix(libname), target));
         }
@@ -347,8 +348,8 @@ void debug_addTarget(eckit::LogTarget* target) {
 }
 
 void debug_setTarget(eckit::LogTarget* target) {
-    for (std::string libname : eckit::system::Library::list()) {
-        const eckit::system::Library& lib = eckit::system::Library::lookup(libname);
+    for (std::string libname : eckit::system::LibraryManager::list()) {
+        const eckit::system::Library& lib = eckit::system::LibraryManager::lookup(libname);
         if (lib.debug()) {
             lib.debugChannel().setTarget(new eckit::PrefixTarget(debug_prefix(libname), target));
         }
@@ -358,8 +359,8 @@ void debug_setTarget(eckit::LogTarget* target) {
 }
 
 void debug_reset() {
-    for (std::string libname : eckit::system::Library::list()) {
-        const eckit::system::Library& lib = eckit::system::Library::lookup(libname);
+    for (std::string libname : eckit::system::LibraryManager::list()) {
+        const eckit::system::Library& lib = eckit::system::LibraryManager::lookup(libname);
         if (lib.debug()) {
             lib.debugChannel().reset();
         }


### PR DESCRIPTION
### Description

Replace use of deprecated Library::lookup, to allow building after removing deprecated functionality from upstream eckit.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-342
<!-- STATIC-ANALYSIS_END -->