### PR TITLE
atlas::mpi improvements

### DIFF
--- a/src/atlas/mesh/Mesh.cc
+++ b/src/atlas/mesh/Mesh.cc
@@ -27,13 +27,13 @@ Mesh::Mesh(): Handle(new Implementation()) {}
 Mesh::Mesh(const Grid& grid, const eckit::Configuration& config):
     Handle([&]() {
         if (config.has("mpi_comm")) {
-            mpi::push(config.getString("mpi_comm"));
+            mpi::scope::push(config.getString("mpi_comm"));
         }
         auto cfg           = grid.meshgenerator() | util::Config(config);
         auto meshgenerator = MeshGenerator{grid.meshgenerator() | config};
         auto mesh          = meshgenerator.generate(grid, grid::Partitioner(grid.partitioner() | config));
         if (config.has("mpi_comm")) {
-            mpi::pop();
+            mpi::scope::pop();
         }
         mesh.get()->attach();
         return mesh.get();

--- a/src/atlas/meshgenerator/detail/HealpixMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/HealpixMeshGenerator.cc
@@ -490,10 +490,10 @@ void HealpixMeshGenerator::generate(const Grid& grid, Mesh& mesh) const {
     std::string partitioner_type = "equal_regions";
     options.get("partitioner", partitioner_type);
 
-    mpi::push(options.getString("mpi_comm"));
+    mpi::scope::push(options.getString("mpi_comm"));
     grid::Partitioner partitioner(partitioner_type, nb_parts);
     grid::Distribution distribution(partitioner.partition(grid));
-    mpi::pop();
+    mpi::scope::pop();
     generate(grid, distribution, mesh);
 }
 

--- a/src/atlas/meshgenerator/detail/RegularMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/RegularMeshGenerator.cc
@@ -135,10 +135,10 @@ void RegularMeshGenerator::generate(const Grid& grid, Mesh& mesh) const {
     // if ( nb_parts == 1 || eckit::mpi::size() == 1 ) partitioner_factory =
     // "equal_regions"; // Only one part --> Trans is slower
 
-    mpi::push(options.getString("mpi_comm"));
+    mpi::scope::push(options.getString("mpi_comm"));
     grid::Partitioner partitioner(partitioner_type, nb_parts);
     grid::Distribution distribution(partitioner.partition(grid));
-    mpi::pop();
+    mpi::scope::pop();
     generate(grid, distribution, mesh);
 }
 

--- a/src/atlas/meshgenerator/detail/StructuredMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/StructuredMeshGenerator.cc
@@ -209,10 +209,10 @@ void StructuredMeshGenerator::generate(const Grid& grid, Mesh& mesh) const {
     if (nb_parts == 1) {
         partitioner_type = "serial";
     }
-    mpi::push(options.getString("mpi_comm"));
+    mpi::scope::push(options.getString("mpi_comm"));
     grid::Partitioner partitioner(partitioner_type, nb_parts);
     grid::Distribution distribution(partitioner.partition(grid));
-    mpi::pop();
+    mpi::scope::pop();
     generate(grid, distribution, mesh);
 }
 

--- a/src/atlas/parallel/mpi/mpi.cc
+++ b/src/atlas/parallel/mpi/mpi.cc
@@ -9,11 +9,18 @@
  */
 
 #include "atlas/parallel/mpi/mpi.h"
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <stack>
+#include <vector>
+
 #include "atlas/runtime/Log.h"
 #include "atlas/runtime/Exception.h"
 
-namespace atlas {
-namespace mpi {
+namespace atlas::mpi {
 
 void finalize() {
     finalise();
@@ -23,50 +30,180 @@ void finalise() {
     eckit::mpi::finaliseAllComms();
 }
 
-void CommStack::push(std::string_view name) {
-    if (stack_.size() == size_) {
-        stack_.resize(2 * size_);
+namespace {
+const Comm& comm_world() {
+    static const Comm& world = atlas::mpi::comm("world");
+    return world;
+}
+const Comm& comm_self() {
+    static const Comm& self = atlas::mpi::comm("self");
+    return self;
+}
+int comm_world_int() {
+    static int world = comm_world().communicator();
+    return world;
+}
+int comm_self_int() {
+    static int self = comm_self().communicator();
+    return self;
+}
+
+std::string comm_name_from_communicator( int communicator ) {
+    return "int." + std::to_string(communicator);
+}
+
+std::optional<std::reference_wrapper<const Comm>> lookup_comm( int communicator ) {
+    // First check if the communicator corresponds to the well-known comm_world or comm_self, or the current default comm
+    // Then fall back to a more expensive lookup in the registered communicators, if any
+    if ( communicator == comm_world_int() ) {
+        return comm_world();
     }
-    stack_[size_++] = name;
-    eckit::mpi::setCommDefault(name.data());
+    else if ( communicator == comm_self_int() ) {
+        return comm_self();
+    }
+    else {
+        const auto& default_comm = comm();
+        if ( default_comm.communicator() == communicator ) {
+            return default_comm;
+        }
+        else {
+            for( std::string name : eckit::mpi::listComms() ) {
+                const auto& comm = atlas::mpi::comm(name);
+                if ( comm.communicator() == communicator ) {
+                    return comm;
+                }
+            }
+        }
+    }
+    return std::nullopt;
 }
 
-void CommStack::pop(std::string_view _name) {
-    ATLAS_ASSERT(_name == name());
-    pop();
+class CommScope {
+public:
+    CommScope() {
+        Log::debug() << "atlas::mpi::scope::push()" << std::endl;
+        previous_comm_name_ = mpi::comm().name();
+    }
+    CommScope(std::string_view name) {
+        Log::debug() << "atlas::mpi::scope::push(" << name << ")" << std::endl;
+        previous_comm_name_ = mpi::comm().name();
+        eckit::mpi::setCommDefault(name.data());
+    }
+    CommScope(const Comm& comm) {
+        Log::debug() << "atlas::mpi::scope::push(" << comm.name() << ")" << std::endl;
+        previous_comm_name_ = mpi::comm().name();
+        eckit::mpi::setCommDefault(comm.name().data());
+    }
+    CommScope(int communicator) {
+        previous_comm_name_ = mpi::comm().name();
+        auto comm_opt = lookup_comm(communicator);
+        if (comm_opt) {
+            Log::debug() << "atlas::mpi::scope::push(" << communicator << ") : found existing comm " << comm_opt->get().name() << std::endl;
+            eckit::mpi::setCommDefault(comm_opt->get().name().data());
+        }
+        else {
+            new_registered_comm_name_ = comm_name_from_communicator(communicator);
+            Log::debug() << "atlas::mpi::scope::push(" << communicator << ") : registered new comm " << new_registered_comm_name_ << std::endl;
+            register_comm(new_registered_comm_name_, communicator);
+            eckit::mpi::setCommDefault(new_registered_comm_name_.c_str());
+        }
+    }
+    ~CommScope() {
+        Log::debug() << "atlas::mpi::scope::pop() : restored to " << previous_comm_name_;
+        eckit::mpi::setCommDefault(previous_comm_name_.c_str());
+        if (not new_registered_comm_name_.empty()) {
+            Log::debug() << " and unregistered comm " << new_registered_comm_name_;
+            unregister_comm(new_registered_comm_name_);
+        }
+        Log::debug() << '\n';
+    }
+private:
+    std::string previous_comm_name_;
+    std::string new_registered_comm_name_;
+};
+
+class ScopeStack {
+    using value_type = std::unique_ptr<CommScope>;
+    using container_type = std::vector<value_type>;
+    using stack_type = std::stack<value_type, container_type>;
+public:
+    void push() {
+        stack_.push(std::make_unique<CommScope>());
+    }
+    void push(std::string_view name) {
+        stack_.push(std::make_unique<CommScope>(name));
+    }
+    void push(const Comm& comm) {
+        stack_.push(std::make_unique<CommScope>(comm));
+    }
+    void push(int communicator) {
+        stack_.push(std::make_unique<CommScope>(communicator));
+    }
+    void pop() {
+        if( !stack_.empty() ) {
+            stack_.pop();
+        }
+    }
+    static ScopeStack& instance() {
+        static ScopeStack instance;
+        return instance;
+    }
+
+private:
+    ScopeStack() {
+        container_type underlying;
+        underlying.reserve(64);
+        stack_ = stack_type(std::move(underlying));
+    }
+private:
+    stack_type stack_;
+};
 }
 
-void CommStack::pop() {
-    --size_;
-    eckit::mpi::setCommDefault(name().c_str());
+void scope::push() {
+    ScopeStack::instance().push();
 }
 
-const std::string& CommStack::name() const {
-    return stack_[size_-1];
+void scope::push(std::string_view name) {
+    ScopeStack::instance().push(name);
 }
 
-const mpi::Comm& CommStack::comm() const {
-    return mpi::comm(name());
+void scope::push(const Comm& comm) {
+    ScopeStack::instance().push(comm);
 }
 
-CommStack::CommStack(): stack_(64){
-        stack_[size_++] = mpi::comm().name();
-    };
-
-void push(std::string_view name) {
-    Log::debug() << "atlas::mpi::push("<<name<<")" << std::endl;
-    CommStack::instance().push(name);
+void scope::push(int communicator) {
+    ScopeStack::instance().push(communicator);
 }
 
-void pop(std::string_view name) {
-    Log::debug() << "atlas::mpi::pop("<<mpi::comm().name()<<")" << std::endl;
-    CommStack::instance().pop(name);
+void scope::pop() {
+    ScopeStack::instance().pop();
 }
 
-void pop() {
-    Log::debug() << "atlas::mpi::pop("<<mpi::comm().name()<<")" << std::endl;
-    CommStack::instance().pop();
+bool has_comm( std::string_view name ) {
+    return eckit::mpi::hasComm(name.data());
 }
 
-}  // namespace mpi
-}  // namespace atlas
+const Comm& comm(int communicator) {
+    auto comm_opt = lookup_comm( communicator );
+    if ( comm_opt ) {
+        return comm_opt->get();
+    }
+    throw_Exception("No MPI communicator found with integer value " + std::to_string(communicator), Here());
+}
+
+const Comm& register_comm(std::string_view name, int communicator) {
+    eckit::mpi::addComm(name.data(), communicator);
+    return comm(name);
+}
+
+void unregister_comm(std::string_view name) {
+#if ATLAS_ECKIT_VERSION_AT_LEAST(2, 0, 0)
+    eckit::mpi::unregisterComm(name.data());
+#else
+    Log::warning() << "atlas::mpi::unregister_comm is a no-op with eckit versions prior to 2.0.0" << std::endl;
+#endif
+}
+
+
+}  // namespace atlas::mpi

--- a/src/atlas/parallel/mpi/mpi.h
+++ b/src/atlas/parallel/mpi/mpi.h
@@ -15,8 +15,7 @@
 #include "eckit/mpi/Comm.h"
 #include "atlas/parallel/mpi/Statistics.h"
 
-namespace atlas {
-namespace mpi {
+namespace atlas::mpi {
 
 using Comm = eckit::mpi::Comm;
 
@@ -27,6 +26,13 @@ inline const Comm& comm() {
 inline const Comm& comm(std::string_view name) {
     return eckit::mpi::comm(name.data());
 }
+
+const Comm& comm(int communicator);
+
+bool has_comm(std::string_view name);
+
+const Comm& register_comm(std::string_view name, int communicator);
+void unregister_comm(std::string_view name);
 
 inline idx_t rank() {
     return static_cast<idx_t>(comm().rank());
@@ -39,45 +45,39 @@ inline int size() {
 void finalize();
 void finalise();
 
-class CommStack {
-public:
-    using const_iterator = std::vector<std::string>::const_iterator;
-
-public:
+namespace scope {
+    /// @brief Push a new scope for MPI communicators. The current default communicator is restored when the scope is destructed using pop()
+    void push();
+    /// @brief Push a new scope for MPI communicators. The given communicator is set as the default communicator for the duration of the scope. The previous default communicator is restored when the scope is destructed using pop()
     void push(std::string_view name);
+    /// @brief Push a new scope for MPI communicators. The given communicator is set as the default communicator for the duration of the scope. The previous default communicator is restored when the scope is destructed using pop()
+    void push(const Comm& comm);
+    /// @brief Push a new scope for MPI communicators. The given communicator is set as the default communicator for the duration of the scope. The previous default communicator is restored when the scope is destructed using pop()
+    /// If the given communicator is not already registered, it will be registered with a generated name "int.<communicator>" for the duration of the scope, and unregistered when the scope is destructed.
+    void push(int communicator);
+    /// @brief Pop the current MPI communicator scope, restoring the previous default communicator
     void pop();
-    void pop(std::string_view name); // verifies name matches compared to version above
-    const std::string& name() const;
-    const mpi::Comm& comm() const;
+}
 
-    const_iterator begin() const { return stack_.begin(); }
-    const_iterator end() const { return stack_.begin() + size_; }
-
-    size_t size() const { return size_; }
-
-    static CommStack& instance() {
-        static CommStack instance;
-        return instance;
-    }
-
-private:
-    CommStack();
-private:
-    std::vector<std::string> stack_;
-    size_t size_{0};
-};
-void push(std::string_view name);
-void pop(std::string_view name);
-void pop();
+/// @brief RAII helper class to manage MPI communicator scopes. The constructor pushes a new scope, and the destructor pops the scope, ensuring that the previous default communicator is restored even in case of exceptions.
 struct Scope {
-    Scope(std::string_view name) : name_(name) {
-        push(name_);
-    }
-    ~Scope() {
-        pop(name_);
-    }
-    std::string name_;
+    Scope() { scope::push(); }
+    Scope(std::string_view name) { scope::push(name); }
+    Scope(const Comm& comm) { scope::push(comm); };
+    /// @brief Constructor using integer value. If the given communicator is not already registered, it will be registered with a generated name "int.<communicator>" for the duration of the scope, and unregistered when the scope is destructed.
+    /// @param communicator The integer value of the MPI communicator to use for the scope
+    Scope(int communicator) { scope::push(communicator); }
+
+    Scope(const Scope&) = delete;
+    Scope(Scope&&) = delete;
+    Scope& operator=(const Scope&) = delete;
+    Scope& operator=(Scope&&) = delete;
+    ~Scope() { scope::pop(); }
 };
 
-}  // namespace mpi
-}  // namespace atlas
+[[deprecated("Use atlas::mpi::scope::push instead")]] inline void push() { scope::push(); }
+[[deprecated("Use atlas::mpi::scope::pop instead")]]  inline void pop() { scope::pop(); }
+[[deprecated("Use atlas::mpi::scope::push instead")]] inline void push(std::string_view name) { scope::push(name); }
+[[deprecated("Use atlas::mpi::scope::pop instead")]]  inline void pop(std::string_view /*name*/) { scope::pop(); }
+
+}  // namespace atlas::mpi

--- a/src/tests/parallel/CMakeLists.txt
+++ b/src/tests/parallel/CMakeLists.txt
@@ -72,3 +72,10 @@ ecbuild_add_test( TARGET atlas_test_omp_copy
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )
 
+ecbuild_add_test( TARGET atlas_test_mpi_scope
+  MPI        1
+  CONDITION  eckit_HAVE_MPI
+  SOURCES    test_mpi_scope.cc
+  LIBS       atlas
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)

--- a/src/tests/parallel/test_mpi_scope.cc
+++ b/src/tests/parallel/test_mpi_scope.cc
@@ -1,0 +1,103 @@
+#include "atlas/parallel/mpi/mpi.h"
+#include "eckit/mpi/Comm.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+namespace atlas::test {
+
+CASE("test_mpi_scope") {
+    mpi::comm().split(mpi::comm().rank(), "comm1");
+    mpi::comm().split(mpi::comm().rank(), "comm2");
+
+    eckit::mpi::setCommDefault("comm1");
+    EXPECT_EQ( mpi::comm().name(), "comm1" );
+    {
+        // Use manual push/pop style scope management
+        mpi::scope::push("self");
+        EXPECT_EQ( mpi::comm().name(), "self" );
+        mpi::scope::pop();
+    }
+    EXPECT_EQ( mpi::comm().name(), "comm1" );
+
+    eckit::mpi::setCommDefault("comm2");
+    EXPECT_EQ( mpi::comm().name(), "comm2" );
+    {
+        // Use RAII style scope management using atlas::mpi::Scope
+        mpi::Scope scope("self");
+        EXPECT_EQ( mpi::comm().name(), "self" );
+    }
+    EXPECT_EQ( mpi::comm().name(), "comm2" );
+
+
+    eckit::mpi::setCommDefault("comm1");
+    EXPECT_EQ( mpi::comm().name(), "comm1" );
+    {
+        // Use RAII style scope management using atlas::mpi::Scope, now without explicitly specifying the comm name
+        // We can edit at will manually the default comm within the scope, and it will be restored to "comm1" at the end of the scope
+        mpi::Scope scope;
+        EXPECT_EQ( mpi::comm().name(), "comm1" );
+        eckit::mpi::setCommDefault("self");
+        EXPECT_EQ( mpi::comm().name(), "self" );
+    }
+    EXPECT_EQ( mpi::comm().name(), "comm1" );
+
+    {
+        // Use RAII style scope management using atlas::mpi::Scope with Comm argument
+        mpi::Scope scope(mpi::comm("self"));
+        EXPECT_EQ( mpi::comm().name(), "self" );
+    }
+    EXPECT_EQ( mpi::comm().name(), "comm1" );
+
+    eckit::mpi::setCommDefault("world");
+}
+
+}  // namespace atlas::test
+
+#if ATLAS_HAVE_MPI
+#define OMPI_SKIP_MPICXX 1
+#include <mpi.h>
+namespace atlas::test {
+CASE ("test_mpi_scope_with_int and deep nesting") {
+    constexpr bool eckit_unregister_comm_not_available = not ATLAS_ECKIT_VERSION_AT_LEAST(2, 0, 0);
+    MPI_Comm comm1, comm2;
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_split(MPI_COMM_WORLD, rank%2, rank, &comm1);
+    MPI_Comm_split(MPI_COMM_WORLD, rank%2, rank, &comm2);
+    int comm1_int = MPI_Comm_c2f(comm1);
+    int comm2_int = MPI_Comm_c2f(comm2);
+    int world_int = MPI_Comm_c2f(MPI_COMM_WORLD);
+    EXPECT_EQ( mpi::comm().name(), "world");
+    {
+        mpi::Scope scope(comm1_int);
+        EXPECT_EQ( mpi::comm().name(), "int." + std::to_string(comm1_int) );
+        {
+            mpi::Scope scope2(comm2_int);
+            EXPECT_EQ( mpi::comm().name(), "int." + std::to_string(comm2_int) );
+            {
+                mpi::Scope scope3(comm1_int);
+                EXPECT_EQ( mpi::comm().name(), "int." + std::to_string(comm1_int) );
+                {
+                    mpi::Scope scope4(world_int);
+                    EXPECT_EQ( mpi::comm().name(), "world");
+                }
+                EXPECT_EQ( mpi::comm().name(), "int." + std::to_string(comm1_int) );
+            }
+            EXPECT( mpi::has_comm("int." + std::to_string(comm1_int)) );
+        }
+        EXPECT( not mpi::has_comm("int." + std::to_string(comm2_int)) || eckit_unregister_comm_not_available );
+        EXPECT_EQ( mpi::comm().name(), "int." + std::to_string(comm1_int) );
+    }
+    EXPECT( not mpi::has_comm("int." + std::to_string(comm2_int)) || eckit_unregister_comm_not_available );
+    EXPECT_EQ( mpi::comm().name(), "world");
+    MPI_Comm_free(&comm1);
+    MPI_Comm_free(&comm2);
+}
+}  // namespace atlas::test
+#endif
+
+
+int main(int argc, char* argv[]) {
+    return atlas::test::run(argc, argv);
+}


### PR DESCRIPTION
- Foremost this PR fixes #186 with a refactored `atlas::mpi::Scope`
- Further interoperability with communicators referenced by integer value
- Deprecation of `atlas::mpi::push/pop` in favour of `atlas::mpi::scope::push/pop`


<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-348
<!-- STATIC-ANALYSIS_END -->