### PR TITLE
Demonstrate use of SphericalMeanValue with vector interpolation

### DIFF
--- a/src/atlas/interpolation/method/MethodFactory.cc
+++ b/src/atlas/interpolation/method/MethodFactory.cc
@@ -28,6 +28,7 @@
 #include "unstructured/FiniteElement.h"
 #include "unstructured/ConservativeSphericalPolygonInterpolation.h"
 #include "unstructured/UnstructuredBilinearLonLat.h"
+#include "unstructured/SphericalMeanValue.h"
 
 
 namespace atlas {
@@ -55,6 +56,7 @@ void force_link() {
             MethodBuilder<method::SphericalVector>();
             MethodBuilder<method::Binning>();
             MethodBuilder<method::ConservativeSphericalPolygonInterpolation>();
+            MethodBuilder<method::SphericalMeanValue>();
         }
     } link;
 }

--- a/src/tests/interpolation/test_interpolation_spherical_vector.cc
+++ b/src/tests/interpolation/test_interpolation_spherical_vector.cc
@@ -132,7 +132,7 @@ struct InterpSchemeFixtures {
       static const auto cubedsphereBilinear = option::type("cubedsphere-bilinear") | Config("adjoint", true);
       static const auto sphericalMeanValue  = option::type("spherical-mean-value") | Config("normalisation", false);
       static const auto sphericalMeanValueNormalised =
-          option::type("spherical-mean-value-normalised") | Config("normalisation", true);
+          option::type("spherical-mean-value") | Config("normalisation", true);
       static const auto finiteElement = option::type("finite-element") | Config("adjoint", true);
       static const auto structuredLinear =
           option::type("structured-bilinear") | option::halo(1) | Config("adjoint", true);

--- a/src/tests/interpolation/test_interpolation_spherical_vector.cc
+++ b/src/tests/interpolation/test_interpolation_spherical_vector.cc
@@ -129,33 +129,29 @@ struct FieldSpecFixtures {
 // Helper struct to key different interpolation schemes to strings
 struct InterpSchemeFixtures {
   static const Config& get(const std::string& fixture) {
-    static const auto cubedsphereBilinear =
-        option::type("cubedsphere-bilinear") | Config("adjoint", true);
-    static const auto finiteElement =
-        option::type("finite-element") | Config("adjoint", true);
-    static const auto structuredLinear = option::type("structured-bilinear") |
-                                         option::halo(1) |
-                                         Config("adjoint", true);
-    static const auto structuredCubic = option::type("structured-bicubic") |
-                                        option::halo(2) |
-                                        Config("adjoint", true);
-    static const auto sphericalVector =
-        option::type("spherical-vector") | Config("adjoint", true);
+      static const auto cubedsphereBilinear = option::type("cubedsphere-bilinear") | Config("adjoint", true);
+      static const auto sphericalMeanValue  = option::type("spherical-mean-value") | Config("normalisation", false);
+      static const auto sphericalMeanValueNormalised =
+          option::type("spherical-mean-value-normalised") | Config("normalisation", true);
+      static const auto finiteElement = option::type("finite-element") | Config("adjoint", true);
+      static const auto structuredLinear =
+          option::type("structured-bilinear") | option::halo(1) | Config("adjoint", true);
+      static const auto structuredCubic =
+          option::type("structured-bicubic") | option::halo(2) | Config("adjoint", true);
+      static const auto sphericalVector = option::type("spherical-vector") | Config("adjoint", true);
 
-    static const auto interpSchemes = std::map<std::string_view, Config>{
-        {"cubedsphere_bilinear", cubedsphereBilinear},
-        {"finite_element", finiteElement},
-        {"structured_linear", structuredLinear},
-        {"structured_cubic", structuredCubic},
-        {"cubedsphere_bilinear_spherical",
-         sphericalVector | Config("scheme", cubedsphereBilinear)},
-        {"finite_element_spherical",
-         sphericalVector | Config("scheme", finiteElement)},
-        {"structured_linear_spherical",
-         sphericalVector | Config("scheme", structuredLinear)},
-        {"structured_cubic_spherical",
-         sphericalVector | Config("scheme", structuredCubic)}};
-    return interpSchemes.at(fixture);
+      static const auto interpSchemes = std::map<std::string_view, Config>{
+          {"cubedsphere_bilinear", cubedsphereBilinear},
+          {"finite_element", finiteElement},
+          {"structured_linear", structuredLinear},
+          {"structured_cubic", structuredCubic},
+          {"cubedsphere_bilinear_spherical", sphericalVector | Config("scheme", cubedsphereBilinear)},
+          {"finite_element_spherical", sphericalVector | Config("scheme", finiteElement)},
+          {"structured_linear_spherical", sphericalVector | Config("scheme", structuredLinear)},
+          {"structured_cubic_spherical", sphericalVector | Config("scheme", structuredCubic)},
+          {"spherical_mean_value", sphericalVector | Config("scheme", sphericalMeanValue)},
+          {"spherical_mean_value_normalised", sphericalVector | Config("scheme", sphericalMeanValueNormalised)}};
+      return interpSchemes.at(fixture);
   }
 };
 
@@ -484,6 +480,91 @@ CASE("structured columns O96 vector interpolation (2d-field, 2-vector, hi-res)")
                           .set("tol", 0.000044);
 
   testInterpolation<Rank2dField>((config));
+}
+
+CASE("cubed sphere CS-LFR-48 scalar spherical mean value interpolation (3d-field, scalar)") {
+    const auto config = Config("source_fixture", "cubedsphere_mesh")
+                            .set("target_fixture", "gaussian_mesh")
+                            .set("field_spec_fixture", "scalar")
+                            .set("interp_fixture", "spherical_mean_value")
+                            .set("file_id", "spherical_vector_cs2")
+                            .set("tol", 0.00096);
+
+    testInterpolation<Rank3dField>((config));
+}
+
+CASE("cubed sphere CS-LFR-48 scalar normalised spherical mean value interpolation (3d-field, scalar)") {
+    const auto config = Config("source_fixture", "cubedsphere_mesh")
+                            .set("target_fixture", "gaussian_mesh")
+                            .set("field_spec_fixture", "scalar")
+                            .set("interp_fixture", "spherical_mean_value_normalised")
+                            .set("file_id", "spherical_vector_cs2")
+                            .set("tol", 0.00096);
+
+    testInterpolation<Rank3dField>((config));
+}
+
+CASE("cubed sphere CS-LFR-48 vector spherical mean value interpolation (3d-field, 2-vector)") {
+    const auto config = Config("source_fixture", "cubedsphere_mesh")
+                            .set("target_fixture", "gaussian_mesh")
+                            .set("field_spec_fixture", "2vector")
+                            .set("interp_fixture", "spherical_mean_value")
+                            .set("file_id", "spherical_vector_cs2")
+                            .set("tol", 0.00018);
+
+    testInterpolation<Rank3dField>((config));
+}
+
+
+CASE("cubed sphere CS-LFR-48 vector normalised spherical mean value interpolation (3d-field, 2-vector)") {
+    const auto config = Config("source_fixture", "cubedsphere_mesh")
+                            .set("target_fixture", "gaussian_mesh")
+                            .set("field_spec_fixture", "2vector")
+                            .set("interp_fixture", "spherical_mean_value_normalised")
+                            .set("file_id", "spherical_vector_cs2")
+                            .set("tol", 0.00018);
+
+    testInterpolation<Rank3dField>((config));
+}
+
+CASE("cubed sphere CS-LFR-48 vector spherical mean value interpolation (3d-field, 3-vector)") {
+    const auto config = Config("source_fixture", "cubedsphere_mesh")
+                            .set("target_fixture", "gaussian_mesh")
+                            .set("field_spec_fixture", "3vector")
+                            .set("interp_fixture", "spherical_mean_value")
+                            .set("file_id", "spherical_vector_cs3")
+                            .set("tol", 0.00096);
+
+    testInterpolation<Rank3dField>((config));
+}
+
+CASE("cubed sphere CS-LFR-48 vector normalised spherical mean value interpolation (3d-field, 3-vector)") {
+    const auto config = Config("source_fixture", "cubedsphere_mesh")
+                            .set("target_fixture", "gaussian_mesh")
+                            .set("field_spec_fixture", "3vector")
+                            .set("interp_fixture", "spherical_mean_value_normalised")
+                            .set("file_id", "spherical_vector_cs3")
+                            .set("tol", 0.00096);
+
+    testInterpolation<Rank3dField>((config));
+}
+
+CASE("cubed sphere CS-LFR-48 (spherical mean value) to empty point cloud") {
+    const auto config = Config("source_fixture", "cubedsphere_mesh")
+                            .set("target_fixture", "empty_point_cloud")
+                            .set("field_spec_fixture", "2vector")
+                            .set("interp_fixture", "spherical_mean_value");
+
+    testInterpolation<Rank2dField>((config));
+}
+
+CASE("cubed sphere CS-LFR-48 (normalised spherical mean value) to empty point cloud") {
+    const auto config = Config("source_fixture", "cubedsphere_mesh")
+                            .set("target_fixture", "empty_point_cloud")
+                            .set("field_spec_fixture", "2vector")
+                            .set("interp_fixture", "spherical_mean_value_normalised");
+
+    testInterpolation<Rank2dField>((config));
 }
 
 CASE("separate vector field components") {


### PR DESCRIPTION
### Description

This PR adds the spherical mean value interpolator introduced in #329 to the MethodFactory class and adds corresponding tests to the spherical vector interpolator testing. 

The testing acts as a demonstration of how the spherical mean value interpolator should be used in tandem with the vector interpolator.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 