### PR TITLE
Fix atlas_test_functionspace when TESSELATION feature is not enabled (fixes #354)

### DIFF
--- a/src/tests/functionspace/test_functionspace.cc
+++ b/src/tests/functionspace/test_functionspace.cc
@@ -643,6 +643,7 @@ CASE("test_SpectralFunctionSpace_norm") {
         }
     }
 }
+#endif
 
 template <typename T>
 mdspan<T,dims<1>> make_mdspan(std::vector<T>& v) {
@@ -654,6 +655,11 @@ mdspan<T,extents<size_t,dynamic_extent,N>> make_mdspan(std::vector<std::array<T,
 }
 
 CASE("test_functionspace_grid") {
+    if (not ATLAS_HAVE_TESSELATION) {
+        Log::info() << "Skipping test_functionspace_grid since tessellation is not available" << std::endl;
+        return;
+    }
+
     // Create list of points and construct Grid from them
     std::vector<PointXY> points = {
         {0.0, 5.0}, {0.0, 0.0}, {10.0, 0.0}, {15.0, 0.0}, {5.0, 5.0}, {15.0, 5.0}
@@ -725,8 +731,6 @@ CASE("test_functionspace_grid") {
     functionspace::Spectral spectral(159);
     EXPECT_THROWS(spectral.grid());
 }
-
-#endif
 
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
### Description
As described in #354 the test "atlas_test_functionspace" should not fail when `TESSELATION=OFF`

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-355
<!-- STATIC-ANALYSIS_END -->