### PR TITLE
Fix device state handling in halo exchange

### DIFF
--- a/src/atlas/interpolation/method/Method.cc
+++ b/src/atlas/interpolation/method/Method.cc
@@ -527,7 +527,7 @@ void Method::do_execute(const Field& src, Field& tgt, Metadata&) const {
     ATLAS_TRACE("atlas::interpolation::method::Method::do_execute()");
 
      if (src.hostNeedsUpdate() && src.deviceNeedsUpdate()) {
-            throw_AssertionFailed("Inconsistent memory state flags - we will not be able to "
+            throw_AssertionFailed("Inconsistent memory state flags for field "+src.name()+"  (hostNeedsUpdate && deviceNeedsUpdate) - we will not be able to "
                                   "determine which memory space to perform the halo exchange on",
                                   Here());
     }

--- a/src/atlas/parallel/HaloExchange.h
+++ b/src/atlas/parallel/HaloExchange.h
@@ -218,7 +218,8 @@ void HaloExchange::execute(array::Array& field, bool on_device) const {
     deallocate_buffer<DATA_TYPE>(inner_buffer, inner_size, on_device);
     deallocate_buffer<DATA_TYPE>(halo_buffer, halo_size, on_device);
 
-    on_device ? field.setHostNeedsUpdate(true) : field.setDeviceNeedsUpdate(true);
+    field.setDeviceNeedsUpdate(!on_device);
+    field.setHostNeedsUpdate(on_device);
     if (update_device_at_end) {
         field.syncDevice();
     }
@@ -283,7 +284,8 @@ void HaloExchange::execute_adjoint(array::Array& field, bool on_device) const {
     deallocate_buffer<DATA_TYPE>(halo_buffer, halo_size, on_device);
     deallocate_buffer<DATA_TYPE>(inner_buffer, inner_size, on_device);
 
-    on_device ? field.setHostNeedsUpdate(true) : field.setDeviceNeedsUpdate(true);
+    field.setDeviceNeedsUpdate(!on_device);
+    field.setHostNeedsUpdate(on_device);
     if (update_device_at_end) {
         field.syncDevice();
     }


### PR DESCRIPTION
## Summary
Fix halo exchange state updates on device and add clearer interpolation diagnostics when host/device state flags are inconsistent.

## Why
The functional fix and the extra debug information address the same host/device state-management problem and make failures easier to diagnose.

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-370
<!-- STATIC-ANALYSIS_END -->