### PR TITLE
Implement BlockStructuredColumns::checksum

### DIFF
--- a/src/atlas/array/native/NativeArrayView.cc
+++ b/src/atlas/array/native/NativeArrayView.cc
@@ -74,35 +74,39 @@ void ArrayView<Value, Rank>::dump(std::ostream& os) const {
 // Explicit instantiation
 namespace atlas {
 namespace array {
-#define EXPLICIT_TEMPLATE_INSTANTIATION(Rank)                                                           \
-    template class ArrayView<int, Rank>;                                                                \
-    template class ArrayView<const int, Rank>;                                                          \
-    template class ArrayView<long, Rank>;                                                               \
-    template class ArrayView<const long, Rank>;                                                         \
-    template class ArrayView<unsigned int, Rank>;                                                       \
-    template class ArrayView<const unsigned int, Rank>;                                                 \
-    template class ArrayView<long unsigned, Rank>;                                                      \
-    template class ArrayView<const long unsigned, Rank>;                                                \
-    template class ArrayView<float, Rank>;                                                              \
-    template class ArrayView<const float, Rank>;                                                        \
-    template class ArrayView<double, Rank>;                                                             \
-    template class ArrayView<const double, Rank>;                                                       \
-    template void ArrayView<int, Rank>::assign<true, nullptr>(int const&);                              \
-    template void ArrayView<long, Rank>::assign<true, nullptr>(long const&);                            \
-    template void ArrayView<float, Rank>::assign<true, nullptr>(float const&);                          \
-    template void ArrayView<double, Rank>::assign<true, nullptr>(double const&);                        \
-    template void ArrayView<int, Rank>::assign<true, nullptr>(std::initializer_list<int> const&);       \
-    template void ArrayView<long, Rank>::assign<true, nullptr>(std::initializer_list<long> const&);     \
-    template void ArrayView<float, Rank>::assign<true, nullptr>(std::initializer_list<float> const&);   \
-    template void ArrayView<double, Rank>::assign<true, nullptr>(std::initializer_list<double> const&); \
-    template void ArrayView<int, Rank>::assign<true, nullptr>(ArrayView<int, Rank> const&);             \
-    template void ArrayView<long, Rank>::assign<true, nullptr>(ArrayView<long, Rank> const&);           \
-    template void ArrayView<float, Rank>::assign<true, nullptr>(ArrayView<float, Rank> const&);         \
-    template void ArrayView<double, Rank>::assign<true, nullptr>(ArrayView<double, Rank> const&);       \
-    template void ArrayView<int, Rank>::assign<true, nullptr>(LocalView<int, Rank> const&);             \
-    template void ArrayView<long, Rank>::assign<true, nullptr>(LocalView<long, Rank> const&);           \
-    template void ArrayView<float, Rank>::assign<true, nullptr>(LocalView<float, Rank> const&);         \
-    template void ArrayView<double, Rank>::assign<true, nullptr>(LocalView<double, Rank> const&);
+#define EXPLICIT_TEMPLATE_INSTANTIATION(Rank)                                                                         \
+    template class ArrayView<int, Rank>;                                                                              \
+    template class ArrayView<const int, Rank>;                                                                        \
+    template class ArrayView<long, Rank>;                                                                             \
+    template class ArrayView<const long, Rank>;                                                                       \
+    template class ArrayView<unsigned int, Rank>;                                                                     \
+    template class ArrayView<const unsigned int, Rank>;                                                               \
+    template class ArrayView<long unsigned, Rank>;                                                                    \
+    template class ArrayView<const long unsigned, Rank>;                                                              \
+    template class ArrayView<float, Rank>;                                                                            \
+    template class ArrayView<const float, Rank>;                                                                      \
+    template class ArrayView<double, Rank>;                                                                           \
+    template class ArrayView<const double, Rank>;                                                                     \
+    template void ArrayView<int, Rank>::assign<true, nullptr>(int const&);                                            \
+    template void ArrayView<long, Rank>::assign<true, nullptr>(long const&);                                          \
+    template void ArrayView<float, Rank>::assign<true, nullptr>(float const&);                                        \
+    template void ArrayView<double, Rank>::assign<true, nullptr>(double const&);                                      \
+    template void ArrayView<unsigned long, Rank>::assign<true, nullptr>(unsigned long const&);                        \
+    template void ArrayView<int, Rank>::assign<true, nullptr>(std::initializer_list<int> const&);                     \
+    template void ArrayView<long, Rank>::assign<true, nullptr>(std::initializer_list<long> const&);                   \
+    template void ArrayView<float, Rank>::assign<true, nullptr>(std::initializer_list<float> const&);                 \
+    template void ArrayView<double, Rank>::assign<true, nullptr>(std::initializer_list<double> const&);               \
+    template void ArrayView<unsigned long, Rank>::assign<true, nullptr>(std::initializer_list<unsigned long> const&); \
+    template void ArrayView<int, Rank>::assign<true, nullptr>(ArrayView<int, Rank> const&);                           \
+    template void ArrayView<long, Rank>::assign<true, nullptr>(ArrayView<long, Rank> const&);                         \
+    template void ArrayView<float, Rank>::assign<true, nullptr>(ArrayView<float, Rank> const&);                       \
+    template void ArrayView<double, Rank>::assign<true, nullptr>(ArrayView<double, Rank> const&);                     \
+    template void ArrayView<unsigned long, Rank>::assign<true, nullptr>(ArrayView<unsigned long, Rank> const&);       \
+    template void ArrayView<int, Rank>::assign<true, nullptr>(LocalView<int, Rank> const&);                           \
+    template void ArrayView<long, Rank>::assign<true, nullptr>(LocalView<long, Rank> const&);                         \
+    template void ArrayView<float, Rank>::assign<true, nullptr>(LocalView<float, Rank> const&);                       \
+    template void ArrayView<double, Rank>::assign<true, nullptr>(LocalView<double, Rank> const&);                     \
+    template void ArrayView<unsigned long, Rank>::assign<true, nullptr>(LocalView<unsigned long, Rank> const&);
 
 // For each NDims in [1..9]
 EXPLICIT_TEMPLATE_INSTANTIATION(1)

--- a/src/atlas/functionspace/detail/BlockStructuredColumns.cc
+++ b/src/atlas/functionspace/detail/BlockStructuredColumns.cc
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "eckit/utils/MD5.h"
 
@@ -164,6 +165,9 @@ void transpose_nonblocked_to_blocked(const Field& nonblocked, Field& blocked, co
     else if (kind == array::DataType::kind<long>()) {
         block_copy<long>(nonblocked, blocked, fs);
     }
+    else if (kind == array::DataType::kind<unsigned long>()) {
+        block_copy<unsigned long>(nonblocked, blocked, fs);
+    }
     else if (kind == array::DataType::kind<float>()) {
         block_copy<float>(nonblocked, blocked, fs);
     }
@@ -182,6 +186,9 @@ void transpose_blocked_to_nonblocked(const Field& blocked, Field& nonblocked, co
     }
     else if (kind == array::DataType::kind<long>()) {
         rev_block_copy<long>(blocked, nonblocked, fs);
+    }
+    else if (kind == array::DataType::kind<unsigned long>()) {
+        rev_block_copy<unsigned long>(blocked, nonblocked, fs);
     }
     else if (kind == array::DataType::kind<float>()) {
         rev_block_copy<float>(blocked, nonblocked, fs);
@@ -354,14 +361,211 @@ void BlockStructuredColumns::gather(const Field& local, Field& global) const {
 // Checksum Field
 // ----------------------------------------------------------------------------
 
-std::string BlockStructuredColumns::checksum(const Field&) const {
-    ATLAS_NOTIMPLEMENTED;
+namespace {
+
+struct ChecksumData {
+    Field local_lane_checksums;
+    Field global_lane_checksums;
+    int root{0};
+};
+
+bool block_slice_contiguous(const Field& f) {
+    idx_t expected_stride = 1;
+    for (idx_t dim = f.rank() - 1; dim > 0; --dim) {
+        if (f.stride(dim) != expected_stride) {
+            return false;
+        }
+        expected_stride *= f.shape(dim);
+    }
+    return true;
 }
 
-std::string BlockStructuredColumns::checksum(const FieldSet&) const {
-    ATLAS_NOTIMPLEMENTED;
+template <typename T>
+void checksum_update_lane(util::checksum_t& checksum, const array::Array& f, const T* data, idx_t dim, idx_t offset) {
+    if (dim == f.rank() - 1) {
+        util::checksum_update(checksum, data + offset, 1);
+        return;
+    }
+    for (idx_t index = 0; index < f.shape(dim); ++index) {
+        checksum_update_lane(checksum, f, data, dim + 1, offset + index * f.stride(dim));
+    }
 }
 
+template <typename T>
+void update_lane_checksums_with_field_contiguous(const BlockStructuredColumns& fs, const Field& f, const T* data,
+                                                 array::ArrayView<util::checksum_t, 2>& local_lane_checksums_view) {
+    const idx_t nproma = f.shape(f.rank() - 1);
+    const idx_t full_blocks = (fs.nblks() > 0 ? fs.nblks() - 1 : 0);
+
+    if (f.rank() == 4) {
+        auto update_block = [&](idx_t jblk, idx_t block_size) {
+            const idx_t block_offset = jblk * f.stride(0);
+            const T* block_data = data + block_offset;
+            // [nblks, nvar, nlev, nproma]: iterate lev-outer, var-inner
+            // to match global field order [npoints, nlev, nvar]
+            const idx_t nvar = f.shape(1);
+            const idx_t nlev = f.shape(2);
+            const size_t lane_size = static_cast<size_t>(nvar);
+            const size_t lane_stride = static_cast<size_t>(nlev * nproma);
+            for (idx_t jlev = 0; jlev < nlev; ++jlev) {
+                for (idx_t jlane = 0; jlane < block_size; ++jlane) {
+                    const T* lane_data = block_data + jlev * nproma + jlane;
+                    util::checksum_update(local_lane_checksums_view(jblk, jlane), lane_data, lane_size, lane_stride);
+                }
+            }
+        };
+
+        atlas_omp_parallel_for(idx_t jblk = 0; jblk < full_blocks; ++jblk) {
+            update_block(jblk, nproma);
+        }
+        if (fs.nblks() > 0) {
+            update_block(fs.nblks() - 1, fs.block_size(fs.nblks() - 1));
+        }
+    }
+    else {
+        const size_t lane_stride = static_cast<size_t>(nproma);
+        size_t lane_size{1};
+        for (idx_t dim = 1; dim < f.rank() - 1; ++dim) {
+            lane_size *= f.shape(dim);
+        }
+        auto update_block = [&](idx_t jblk, idx_t block_size) {
+            const idx_t block_offset = jblk * f.stride(0);
+            const T* block_data = data + block_offset;
+            for (idx_t jlane = 0; jlane < block_size; ++jlane) {
+                const T* lane_data = block_data + jlane;
+                util::checksum_update(local_lane_checksums_view(jblk, jlane), lane_data, lane_size, lane_stride);
+            }
+        };
+
+        atlas_omp_parallel_for(idx_t jblk = 0; jblk < full_blocks; ++jblk) {
+            update_block(jblk, nproma);
+        }
+        if (fs.nblks() > 0) {
+            update_block(fs.nblks() - 1, fs.block_size(fs.nblks() - 1));
+        }
+    }
+}
+
+template <typename T>
+void update_lane_checksums_with_field(const BlockStructuredColumns& fs, const Field& f,
+                                      ChecksumData& checksum_data) {
+    auto local_lane_checksums_view = array::make_view<util::checksum_t, 2>(checksum_data.local_lane_checksums);
+    const auto* data = f.array().host_data<T>();
+    if (block_slice_contiguous(f)) {
+        update_lane_checksums_with_field_contiguous(fs, f, data, local_lane_checksums_view);
+        return;
+    }
+
+    // A fallback; we should usually not be here normally, as a field block is usually contiguous
+    const idx_t lane_stride = f.stride(f.rank() - 1);
+    atlas_omp_parallel_for (idx_t jblk = 0; jblk < fs.nblks(); ++jblk) {
+        const idx_t block_offset = jblk * f.stride(0);
+        const idx_t block_size   = fs.block_size(jblk);
+        if (f.rank() == 4) {
+            // Iterate lev-outer, var-inner to match global field order [npoints, nlev, nvar]
+            const idx_t nvar = f.shape(1);
+            const idx_t nlev = f.shape(2);
+            for (idx_t jlane = 0; jlane < block_size; ++jlane) {
+                util::checksum_t lane_checksum = local_lane_checksums_view(jblk, jlane);
+                for (idx_t jlev = 0; jlev < nlev; ++jlev) {
+                    for (idx_t jvar = 0; jvar < nvar; ++jvar) {
+                        const idx_t offset = block_offset + jlane * lane_stride + jvar * f.stride(1) + jlev * f.stride(2);
+                        util::checksum_update(lane_checksum, data + offset, size_t{1});
+                    }
+                }
+                local_lane_checksums_view(jblk, jlane) = lane_checksum;
+            }
+        }
+        else {
+            for (idx_t jlane = 0; jlane < block_size; ++jlane) {
+                util::checksum_t lane_checksum = local_lane_checksums_view(jblk, jlane);
+                checksum_update_lane(lane_checksum, f, data, idx_t{1}, block_offset + jlane * lane_stride);
+                local_lane_checksums_view(jblk, jlane) = lane_checksum;
+            }
+        }
+    }
+}
+
+void update_lane_checksums_with_field_dynamic(const BlockStructuredColumns& fs, const Field& f,
+                                              ChecksumData& checksum_data) {
+    switch (f.datatype().kind()) {
+        case array::DataType::kind<int>():    return update_lane_checksums_with_field<int>(fs, f, checksum_data);
+        case array::DataType::kind<long>():   return update_lane_checksums_with_field<long>(fs, f, checksum_data);
+        case array::DataType::kind<float>():  return update_lane_checksums_with_field<float>(fs, f, checksum_data);
+        case array::DataType::kind<double>(): return update_lane_checksums_with_field<double>(fs, f, checksum_data);
+        default:
+            throw_Exception("datatype not supported", Here());
+    }
+}
+
+ChecksumData get_checksum_data(const BlockStructuredColumns& fs) {
+    pluto::scope scope;
+    pluto::host::set_default_resource(pluto::host_pool_resource());
+    ChecksumData checksum_data;
+    checksum_data.root = 0;
+    checksum_data.local_lane_checksums = fs.createField(option::name("checksum_local_lane_checksums") |
+                                                        option::datatypeT<util::checksum_t>() |
+                                                        option::levels(0));
+    checksum_data.global_lane_checksums = fs.createField(checksum_data.local_lane_checksums, option::global(checksum_data.root));
+    auto local_lane_checksums_view = array::make_view<util::checksum_t, 2>(checksum_data.local_lane_checksums);
+    local_lane_checksums_view.assign(0);
+    return checksum_data;
+}
+
+util::checksum_t checksum_from_lane_states(const BlockStructuredColumns& fs, ChecksumData& checksum_data) {
+    auto& local_lane_checksums = checksum_data.local_lane_checksums;
+    auto local_lane_checksums_view = array::make_view<util::checksum_t, 2>(local_lane_checksums);
+    for (idx_t jblk = 0; jblk < fs.nblks(); ++jblk) {
+        for (idx_t jlane = 0; jlane < fs.nproma(); ++jlane) {
+            local_lane_checksums_view(jblk, jlane) = util::checksum_digest(local_lane_checksums_view(jblk, jlane));
+        }
+    }
+
+    if (mpi::comm().size() == 1) {
+        ATLAS_ASSERT(local_lane_checksums.contiguous());
+        const auto* local_lane_checksums_data = local_lane_checksums.array().host_data<util::checksum_t>();
+        return util::checksum(local_lane_checksums_data, static_cast<size_t>(fs.structuredcolumns().sizeOwned()));
+    }
+
+    auto& global_lane_checksums = checksum_data.global_lane_checksums;
+    fs.gather(local_lane_checksums, global_lane_checksums);
+
+    util::checksum_t global_checksum = 0;
+    if (mpi::comm().rank() == checksum_data.root) {
+        ATLAS_ASSERT(global_lane_checksums.contiguous());
+        const auto* global_lane_checksums_data = global_lane_checksums.array().host_data<util::checksum_t>();
+        global_checksum = util::checksum(global_lane_checksums_data, global_lane_checksums.size());
+    }
+    mpi::comm().broadcast(global_checksum, checksum_data.root);
+    return global_checksum;
+}
+
+util::checksum_t field_checksum(const BlockStructuredColumns& fs, const Field& f) {
+    ATLAS_ASSERT(f.rank() > 1);
+    auto checksum_data = get_checksum_data(fs);
+    update_lane_checksums_with_field_dynamic(fs, f, checksum_data);
+    return checksum_from_lane_states(fs, checksum_data);
+}
+
+util::checksum_t fieldset_checksum(const BlockStructuredColumns& fs, const FieldSet& fields) {
+    auto checksum_data = get_checksum_data(fs);
+    for (idx_t jfld = 0; jfld < fields.size(); ++jfld) {
+        update_lane_checksums_with_field_dynamic(fs, fields[jfld], checksum_data);
+    }
+    return checksum_from_lane_states(fs, checksum_data);
+}
+}  // namespace
+
+
+std::string BlockStructuredColumns::checksum(const Field& f) const {
+    ATLAS_TRACE("BlockStructuredColumns::checksum");
+    return std::to_string(field_checksum(*this, f));
+}
+
+std::string BlockStructuredColumns::checksum(const FieldSet& f) const {
+    ATLAS_TRACE("BlockStructuredColumns::checksum");
+    return std::to_string(fieldset_checksum(*this, f));
+}
 
 // ----------------------------------------------------------------------------
 

--- a/src/atlas/functionspace/detail/StructuredColumns.cc
+++ b/src/atlas/functionspace/detail/StructuredColumns.cc
@@ -609,6 +609,11 @@ void StructuredColumns::gather(const FieldSet& local_fieldset, FieldSet& global_
             parallel::Field<long> glb_field(make_leveled_view<long>(glb));
             gather().gather(&loc_field, &glb_field, nb_fields, root);
         }
+        else if (loc.datatype() == array::DataType::kind<unsigned long>()) {
+            parallel::Field<unsigned long const> loc_field(make_leveled_view<const unsigned long>(loc));
+            parallel::Field<unsigned long> glb_field(make_leveled_view<unsigned long>(glb));
+            gather().gather(&loc_field, &glb_field, nb_fields, root);
+        }
         else if (loc.datatype() == array::DataType::kind<float>()) {
             parallel::Field<float const> loc_field(make_leveled_view<const float>(loc));
             parallel::Field<float> glb_field(make_leveled_view<float>(glb));

--- a/src/atlas/util/Checksum.cc
+++ b/src/atlas/util/Checksum.cc
@@ -8,55 +8,188 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <stdint.h>
 #include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <algorithm>
+#include <iomanip>
+#include <sstream>
 
+#include "atlas/runtime/Exception.h"
 #include "atlas/util/Checksum.h"
 
 namespace atlas {
 namespace util {
 namespace {  // anonymous
 
-// Inefficient implementation of Fletcher's checksum algorithm
-static uint16_t fletcher16(const uint8_t* data, int size) {
-    uint16_t s1(0), s2(0);
-    for (int i = 0; i < size; ++i) {
-        s1 = (s1 + data[i]) % 255;
-        s2 = (s2 + s1) % 255;
-    }
-    s2 <<= 8;
-    s2 |= s1;
-    return s2;
+template <typename Value>
+const char* as_bytes(const Value values[], size_t size) {
+    return size ? reinterpret_cast<const char*>(values) : nullptr;
 }
+
+template <typename Value>
+size_t byte_size(size_t size) {
+    return size * sizeof(Value) / sizeof(char);
+}
+
+typedef union {
+  checksum_t checksum;
+  uint16_t c[2];
+} Fletcher16;
+
+static void fletcher16_reset(Fletcher16& f) {
+  f.c[0] = 0;
+  f.c[1] = 0;
+}
+
+static void fletcher16_update(Fletcher16& f, const uint8_t* data, size_t size) {
+  uint32_t c0 = f.c[0];
+  uint32_t c1 = f.c[1];
+  while(size > 0) {
+    size_t blocklen = size;
+    if (blocklen > 5802) {
+      blocklen = 5802;
+    }
+    size -= blocklen;
+    do {
+      c0 = c0 + *data++;
+      c1 = c1 + c0;
+    } while (--blocklen);
+    c0 = c0 % 0xff;
+    c1 = c1 % 0xff;
+  }
+  f.c[0] = c0;
+  f.c[1] = c1;
+}
+
+static void fletcher16_update(Fletcher16& f, const uint8_t* data, size_t size, size_t stride, size_t chunk) {
+  if (stride == 1 && chunk == 1) {
+    fletcher16_update(f, data, size);
+    return;
+  }
+
+  uint32_t c0 = f.c[0];
+  uint32_t c1 = f.c[1];
+  const size_t max_blocklen = std::max(size_t{1}, size_t{5802} / chunk);
+  while (size > 0) {
+    size_t blocklen = size;
+    if (blocklen > max_blocklen) {
+      blocklen = max_blocklen;
+    }
+    size -= blocklen;
+    do {
+      for (size_t byte = 0; byte < chunk; ++byte) {
+        c0 = c0 + data[byte];
+        c1 = c1 + c0;
+      }
+      data += stride;
+    } while (--blocklen);
+    c0 = c0 % 0xff;
+    c1 = c1 % 0xff;
+  }
+  f.c[0] = c0;
+  f.c[1] = c1;
+}
+
+static uint16_t fletcher16_finish(const Fletcher16& f) {
+  uint32_t c0 = f.c[0];
+  uint32_t c1 = f.c[1];
+  return (c1 << 8 | c0);
+}
+
+static uint16_t fletcher16(const uint8_t* data, size_t size) {
+  Fletcher16 checksum;
+  fletcher16_reset(checksum);
+  fletcher16_update(checksum, data, size);
+  return fletcher16_finish(checksum);
+}
+
 
 }  // namespace
 
+void checksum_reset(checksum_t& checksum) {
+  fletcher16_reset(reinterpret_cast<Fletcher16&>(checksum));
+}
+
+static void checksum_update(checksum_t& checksum, const char* data, size_t bytes) {
+  fletcher16_update(reinterpret_cast<Fletcher16&>(checksum), reinterpret_cast<const uint8_t*>(data), bytes);
+}
+
+template <typename Value>
+static void checksum_update_strided(checksum_t& checksum, const Value values[], size_t size, size_t stride) {
+  auto& f = reinterpret_cast<Fletcher16&>(checksum);
+  const auto* data = reinterpret_cast<const uint8_t*>(values);
+  const size_t value_bytes = sizeof(Value);
+  const size_t stride_bytes = stride * value_bytes;
+  fletcher16_update(f, data, size, stride_bytes, value_bytes);
+}
+
+checksum_t checksum_digest(const checksum_t& checksum) {
+    return fletcher16_finish(reinterpret_cast<const Fletcher16&>(checksum));
+}
+
 static checksum_t checksum(const char* data, size_t size) {
-    // return fletcher64( reinterpret_cast<const uint32_t*>(data),
-    // size/sizeof(uint32_t) );
-    // return fletcher32( reinterpret_cast<const uint16_t*>(data),
-    // size/sizeof(uint16_t) );
     return fletcher16(reinterpret_cast<const uint8_t*>(data), size / sizeof(uint8_t));
 }
 
 checksum_t checksum(const int values[], size_t size) {
-    return checksum(reinterpret_cast<const char*>(&values[0]), size * sizeof(int) / sizeof(char));
+  return checksum(as_bytes(values, size), byte_size<int>(size));
 }
 
 checksum_t checksum(const long values[], size_t size) {
-    return checksum(reinterpret_cast<const char*>(&values[0]), size * sizeof(long) / sizeof(char));
+  return checksum(as_bytes(values, size), byte_size<long>(size));
 }
 
 checksum_t checksum(const float values[], size_t size) {
-    return checksum(reinterpret_cast<const char*>(&values[0]), size * sizeof(float) / sizeof(char));
+  return checksum(as_bytes(values, size), byte_size<float>(size));
 }
 
 checksum_t checksum(const double values[], size_t size) {
-    return checksum(reinterpret_cast<const char*>(&values[0]), size * sizeof(double) / sizeof(char));
+  return checksum(as_bytes(values, size), byte_size<double>(size));
 }
 
 checksum_t checksum(const checksum_t values[], size_t size) {
-    return checksum(reinterpret_cast<const char*>(&values[0]), size * sizeof(checksum_t) / sizeof(char));
+  return checksum(as_bytes(values, size), byte_size<checksum_t>(size));
+}
+
+void checksum_update(checksum_t& c, const int values[], size_t size) {
+  checksum_update(c, as_bytes(values, size), byte_size<int>(size));
+}
+
+void checksum_update(checksum_t& c, const long values[], size_t size) {
+  checksum_update(c, as_bytes(values, size), byte_size<long>(size));
+}
+
+void checksum_update(checksum_t& c, const float values[], size_t size) {
+  checksum_update(c, as_bytes(values, size), byte_size<float>(size));
+}
+
+void checksum_update(checksum_t& c, const double values[], size_t size) {
+  checksum_update(c, as_bytes(values, size), byte_size<double>(size));
+}
+
+void checksum_update(checksum_t& c, const checksum_t values[], size_t size) {
+  checksum_update(c, as_bytes(values, size), byte_size<checksum_t>(size));
+}
+
+void checksum_update(checksum_t& c, const int values[], size_t size, size_t stride) {
+  checksum_update_strided(c, values, size, stride);
+}
+
+void checksum_update(checksum_t& c, const long values[], size_t size, size_t stride) {
+  checksum_update_strided(c, values, size, stride);
+}
+
+void checksum_update(checksum_t& c, const float values[], size_t size, size_t stride) {
+  checksum_update_strided(c, values, size, stride);
+}
+
+void checksum_update(checksum_t& c, const double values[], size_t size, size_t stride) {
+  checksum_update_strided(c, values, size, stride);
+}
+
+void checksum_update(checksum_t& c, const checksum_t values[], size_t size, size_t stride) {
+  checksum_update_strided(c, values, size, stride);
 }
 
 }  // namespace util

--- a/src/atlas/util/Checksum.cc
+++ b/src/atlas/util/Checksum.cc
@@ -32,10 +32,10 @@ size_t byte_size(size_t size) {
     return size * sizeof(Value) / sizeof(char);
 }
 
-typedef union {
+union Fletcher16 {
   checksum_t checksum;
   uint16_t c[2];
-} Fletcher16;
+};
 
 static void fletcher16_reset(Fletcher16& f) {
   f.c[0] = 0;

--- a/src/atlas/util/Checksum.h
+++ b/src/atlas/util/Checksum.h
@@ -10,7 +10,11 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
+#include <cstdint>
+#include <string>
+#include <type_traits>
 
 namespace atlas {
 namespace util {
@@ -22,6 +26,19 @@ checksum_t checksum(const long values[], size_t size);
 checksum_t checksum(const float values[], size_t size);
 checksum_t checksum(const double values[], size_t size);
 checksum_t checksum(const checksum_t values[], size_t size);
+
+void checksum_update(checksum_t&, const int values[], size_t size);
+void checksum_update(checksum_t&, const long values[], size_t size);
+void checksum_update(checksum_t&, const float values[], size_t size);
+void checksum_update(checksum_t&, const double values[], size_t size);
+void checksum_update(checksum_t&, const checksum_t values[], size_t size);
+void checksum_update(checksum_t&, const int values[], size_t size, size_t stride);
+void checksum_update(checksum_t&, const long values[], size_t size, size_t stride);
+void checksum_update(checksum_t&, const float values[], size_t size, size_t stride);
+void checksum_update(checksum_t&, const double values[], size_t size, size_t stride);
+void checksum_update(checksum_t&, const checksum_t values[], size_t size, size_t stride);
+checksum_t checksum_digest(const checksum_t&);
+void checksum_reset(checksum_t&);
 
 }  // namespace util
 }  // namespace atlas

--- a/src/tests/functionspace/CMakeLists.txt
+++ b/src/tests/functionspace/CMakeLists.txt
@@ -29,7 +29,16 @@ if( HAVE_FCTEST )
     SOURCES         fctest_blockstructuredcolumns.F90
     LIBS            atlas_f
     ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-)
+  )
+
+  add_fctest( TARGET atlas_fctest_blockstructuredcolumns_checksum
+    MPI             2
+    CONDITION       eckit_HAVE_MPI AND MPI_SLOTS GREATER_EQUAL 2
+    LINKER_LANGUAGE Fortran
+    SOURCES         fctest_blockstructuredcolumns_checksum.F90
+    LIBS            atlas_f
+    ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+  )
 
 endif()
 

--- a/src/tests/functionspace/CMakeLists.txt
+++ b/src/tests/functionspace/CMakeLists.txt
@@ -93,6 +93,19 @@ ecbuild_add_test( TARGET atlas_test_blockstructuredcolumns
   CONDITION eckit_HAVE_MPI AND MPI_SLOTS GREATER_EQUAL 3
 )
 
+ecbuild_add_test( TARGET atlas_test_blockstructuredcolumns_checksum
+  SOURCES  test_blockstructuredcolumns_checksum.cc
+  LIBS     atlas
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
+
+ecbuild_add_test( TARGET atlas_test_blockstructuredcolumns_checksum_mpi
+  COMMAND   atlas_test_blockstructuredcolumns_checksum
+  MPI       4
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+  CONDITION eckit_HAVE_MPI AND MPI_SLOTS GREATER_EQUAL 4
+)
+
 ecbuild_add_test( TARGET atlas_test_pointcloud
   SOURCES  test_pointcloud.cc
   LIBS     atlas

--- a/src/tests/functionspace/fctest_blockstructuredcolumns_checksum.F90
+++ b/src/tests/functionspace/fctest_blockstructuredcolumns_checksum.F90
@@ -1,0 +1,686 @@
+! (C) Copyright 2013 ECMWF.
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation nor
+! does it submit to any jurisdiction.
+
+! This File contains Unit Tests for BlockStructuredColumns Checksum functionality.
+! Tests verify that checksums are computed correctly for fields with various
+! configurations, including multi-field fieldsets and fields wrapping slices of data.
+!
+! @author Willem Deconinck
+
+#include "fckit/fctest.h"
+
+! -----------------------------------------------------------------------------
+
+module fcta_BlockStructuredColumns_checksum_fxt
+use atlas_module
+use atlas_functionspace_blockstructuredcolumns_module
+use, intrinsic :: iso_c_binding
+implicit none
+character(len=1024) :: msg
+
+interface fill_field_with_data
+  module procedure fill_field_with_data_field
+  module procedure fill_field_with_data_real64_2d
+  module procedure fill_field_with_data_real64_3d
+  module procedure fill_field_with_data_real64_4d
+  module procedure fill_field_with_data_real32_2d
+  module procedure fill_field_with_data_real32_3d
+  module procedure fill_field_with_data_real32_4d
+end interface
+
+contains
+
+  ! Helper to fill a field deterministically based on functionspace global_index.
+  ! This makes values reproducible for different MPI partitionings.
+  subroutine fill_field_with_data_field(fs, field, seed)
+    type(atlas_functionspace_BlockStructuredColumns), intent(in) :: fs
+    type(atlas_Field), intent(inout) :: field
+    integer, intent(in) :: seed
+    real(c_double), pointer :: data_2d(:,:)
+    real(c_double), pointer :: data_3d(:,:,:)
+    real(c_float), pointer :: data_2d_f(:,:)
+    real(c_float), pointer :: data_3d_f(:,:,:)
+    
+    if( field%rank() == 2 ) then
+      if( field%kind() == atlas_real(c_double) ) then
+        call field%data(data_2d)
+        call fill_field_with_data_real64_2d(fs, data_2d, seed)
+      else if( field%kind() == atlas_real(c_float) ) then
+        call field%data(data_2d_f)
+        call fill_field_with_data_real32_2d(fs, data_2d_f, seed)
+      endif
+    else if( field%rank() == 3 ) then
+      if( field%kind() == atlas_real(c_double) ) then
+        call field%data(data_3d)
+        call fill_field_with_data_real64_3d(fs, data_3d, seed)
+      else if( field%kind() == atlas_real(c_float) ) then
+        call field%data(data_3d_f)
+        call fill_field_with_data_real32_3d(fs, data_3d_f, seed)
+      endif
+    endif
+  end subroutine fill_field_with_data_field
+
+  subroutine fill_field_with_data_real64_2d(fs, data, seed)
+    type(atlas_functionspace_BlockStructuredColumns), intent(in) :: fs
+    real(c_double), intent(inout) :: data(:,:)
+    integer, intent(in) :: seed
+    type(atlas_Field) :: field_global_index
+    integer(ATLAS_KIND_GIDX), pointer :: global_index(:)
+    integer(ATLAS_KIND_IDX) :: jblk, jpt, i
+
+    field_global_index = fs%global_index()
+    call field_global_index%data(global_index)
+
+    data = real(seed, c_double)
+    do jblk = 1, fs%nblks()
+      do i = 1, fs%block_size(jblk)
+        jpt = fs%block_begin(jblk) + i - 1
+        data(i,jblk) = real(seed, c_double) + real(global_index(jpt), c_double)
+      enddo
+    enddo
+    call field_global_index%final()
+  end subroutine fill_field_with_data_real64_2d
+
+  subroutine fill_field_with_data_real32_2d(fs, data, seed)
+    type(atlas_functionspace_BlockStructuredColumns), intent(in) :: fs
+    real(c_float), intent(inout) :: data(:,:)
+    integer, intent(in) :: seed
+    type(atlas_Field) :: field_global_index
+    integer(ATLAS_KIND_GIDX), pointer :: global_index(:)
+    integer(ATLAS_KIND_IDX) :: jblk, jpt, i
+
+    field_global_index = fs%global_index()
+    call field_global_index%data(global_index)
+
+    data = real(seed, c_float)
+    do jblk = 1, fs%nblks()
+      do i = 1, fs%block_size(jblk)
+        jpt = fs%block_begin(jblk) + i - 1
+        data(i,jblk) = real(seed, c_float) + real(global_index(jpt), c_float)
+      enddo
+    enddo
+    call field_global_index%final()
+  end subroutine fill_field_with_data_real32_2d
+
+  subroutine fill_field_with_data_real64_3d(fs, data, seed)
+    type(atlas_functionspace_BlockStructuredColumns), intent(in) :: fs
+    real(c_double), intent(inout) :: data(:,:,:)
+    integer, intent(in) :: seed
+    type(atlas_Field) :: field_global_index
+    integer(ATLAS_KIND_GIDX), pointer :: global_index(:)
+    integer(ATLAS_KIND_IDX) :: jblk, jpt, i
+    integer :: j
+
+    field_global_index = fs%global_index()
+    call field_global_index%data(global_index)
+
+    data = real(seed, c_double)
+    do jblk = 1, fs%nblks()
+      do i = 1, fs%block_size(jblk)
+        jpt = fs%block_begin(jblk) + i - 1
+        do j = 1, size(data,2)
+          data(i,j,jblk) = real(seed, c_double) + real(global_index(jpt), c_double) + real(j, c_double)
+        enddo
+      enddo
+    enddo
+    call field_global_index%final()
+  end subroutine fill_field_with_data_real64_3d
+
+  subroutine fill_field_with_data_real32_3d(fs, data, seed)
+    type(atlas_functionspace_BlockStructuredColumns), intent(in) :: fs
+    real(c_float), intent(inout) :: data(:,:,:)
+    integer, intent(in) :: seed
+    type(atlas_Field) :: field_global_index
+    integer(ATLAS_KIND_GIDX), pointer :: global_index(:)
+    integer(ATLAS_KIND_IDX) :: jblk, jpt, i
+    integer :: j
+
+    field_global_index = fs%global_index()
+    call field_global_index%data(global_index)
+
+    data = real(seed, c_float)
+    do jblk = 1, fs%nblks()
+      do i = 1, fs%block_size(jblk)
+        jpt = fs%block_begin(jblk) + i - 1
+        do j = 1, size(data,2)
+          data(i,j,jblk) = real(seed, c_float) + real(global_index(jpt), c_float) + real(j, c_float)
+        enddo
+      enddo
+    enddo
+    call field_global_index%final()
+  end subroutine fill_field_with_data_real32_3d
+
+  subroutine fill_field_with_data_real64_4d(fs, data, seed)
+    type(atlas_functionspace_BlockStructuredColumns), intent(in) :: fs
+    real(c_double), intent(inout) :: data(:,:,:,:)
+    integer, intent(in) :: seed
+    type(atlas_Field) :: field_global_index
+    integer(ATLAS_KIND_GIDX), pointer :: global_index(:)
+    integer(ATLAS_KIND_IDX) :: jblk, jpt, i
+    integer :: j, k
+
+    field_global_index = fs%global_index()
+    call field_global_index%data(global_index)
+
+    data = real(seed, c_double)
+    do jblk = 1, fs%nblks()
+      do i = 1, fs%block_size(jblk)
+        jpt = fs%block_begin(jblk) + i - 1
+        do j = 1, size(data,2)
+          do k = 1, size(data,3)
+            data(i,j,k,jblk) = real(seed, c_double) + real(global_index(jpt), c_double) + real(j, c_double) + real(k, c_double)
+          enddo
+        enddo
+      enddo
+    enddo
+    call field_global_index%final()
+  end subroutine fill_field_with_data_real64_4d
+
+  subroutine fill_field_with_data_real32_4d(fs, data, seed)
+    type(atlas_functionspace_BlockStructuredColumns), intent(in) :: fs
+    real(c_float), intent(inout) :: data(:,:,:,:)
+    integer, intent(in) :: seed
+    type(atlas_Field) :: field_global_index
+    integer(ATLAS_KIND_GIDX), pointer :: global_index(:)
+    integer(ATLAS_KIND_IDX) :: jblk, jpt, i
+    integer :: j, k
+
+    field_global_index = fs%global_index()
+    call field_global_index%data(global_index)
+
+    data = real(seed, c_float)
+    do jblk = 1, fs%nblks()
+      do i = 1, fs%block_size(jblk)
+        jpt = fs%block_begin(jblk) + i - 1
+        do j = 1, size(data,2)
+          do k = 1, size(data,3)
+            data(i,j,k,jblk) = real(seed, c_float) + real(global_index(jpt), c_float) + real(j, c_float) + real(k, c_float)
+          enddo
+        enddo
+      enddo
+    enddo
+    call field_global_index%final()
+  end subroutine fill_field_with_data_real32_4d
+
+end module
+
+! -----------------------------------------------------------------------------
+
+TESTSUITE_WITH_FIXTURE(fcta_BlockStructuredColumns_checksum, fcta_BlockStructuredColumns_checksum_fxt)
+
+! -----------------------------------------------------------------------------
+
+TESTSUITE_INIT
+  call atlas_library%initialise()
+END_TESTSUITE_INIT
+
+! -----------------------------------------------------------------------------
+
+TESTSUITE_FINALIZE
+  call atlas_library%finalise()
+END_TESTSUITE_FINALIZE
+
+! ============================================================================
+! Test: Checksum for single field (double precision, no levels)
+! ============================================================================
+TEST( test_blockstructuredcolumns_checksum_single_field_2d )
+use atlas_functionspace_blockstructuredcolumns_module
+use fckit_mpi_module
+implicit none
+type(atlas_StructuredGrid) :: grid
+type(atlas_functionspace_BlockStructuredColumns) :: fs
+type(atlas_Field) :: field1, field2
+character(len=256) :: checksum1, checksum2
+type(fckit_mpi_comm) :: mpi
+
+mpi = fckit_mpi_comm()
+
+grid = atlas_StructuredGrid("O8")
+fs = atlas_functionspace_BlockStructuredColumns(grid, halo=0, nproma=4)
+
+! Create two identical fields and verify checksums are equal
+field1 = fs%create_field(name="field1", kind=atlas_real(c_double))
+field2 = fs%create_field(name="field2", kind=atlas_real(c_double))
+
+call fill_field_with_data(fs, field1, 42)
+call fill_field_with_data(fs, field2, 42)
+
+checksum1 = fs%checksum(field1)
+checksum2 = fs%checksum(field2)
+
+if( mpi%rank() == 0 ) then
+  write(msg,*) "Checksum 1: ", trim(checksum1)
+  call atlas_log%info(msg)
+  write(msg,*) "Checksum 2: ", trim(checksum2)
+  call atlas_log%info(msg)
+endif
+
+FCTEST_CHECK_EQUAL( checksum1, checksum2 )
+
+call field1%final()
+call field2%final()
+call fs%final()
+call grid%final()
+END_TEST
+
+! ============================================================================
+! Test: Checksum for single field (float precision, with levels)
+! ============================================================================
+TEST( test_blockstructuredcolumns_checksum_3d_field )
+use atlas_functionspace_blockstructuredcolumns_module
+use fckit_mpi_module
+implicit none
+type(atlas_StructuredGrid) :: grid
+type(atlas_functionspace_BlockStructuredColumns) :: fs
+type(atlas_Field) :: field
+character(len=256) :: checksum1, checksum2
+type(fckit_mpi_comm) :: mpi
+
+mpi = fckit_mpi_comm()
+
+grid = atlas_StructuredGrid("O8")
+fs = atlas_functionspace_BlockStructuredColumns(grid, halo=0, nproma=4, levels=5)
+
+field = fs%create_field(name="field", kind=atlas_real(c_float))
+
+call fill_field_with_data(fs, field, 123)
+
+! First checksum
+checksum1 = fs%checksum(field)
+
+! Recompute should give same checksum
+checksum2 = fs%checksum(field)
+
+if( mpi%rank() == 0 ) then
+  write(msg,*) "3D Field Checksum 1: ", trim(checksum1)
+  call atlas_log%info(msg)
+  write(msg,*) "3D Field Checksum 2: ", trim(checksum2)
+  call atlas_log%info(msg)
+endif
+
+FCTEST_CHECK_EQUAL( checksum1, checksum2 )
+
+call field%final()
+call fs%final()
+call grid%final()
+END_TEST
+
+! ============================================================================
+! Test: Checksum for fieldset with multiple fields
+! ============================================================================
+TEST( test_blockstructuredcolumns_checksum_fieldset_multiple_fields )
+use atlas_functionspace_blockstructuredcolumns_module
+use fckit_mpi_module
+implicit none
+type(atlas_StructuredGrid) :: grid
+type(atlas_functionspace_BlockStructuredColumns) :: fs
+type(atlas_Field) :: field1, field2, field3
+type(atlas_FieldSet) :: fieldset, fieldset2
+character(len=256) :: checksum1, checksum2, checksum_field1
+type(fckit_mpi_comm) :: mpi
+
+mpi = fckit_mpi_comm()
+
+grid = atlas_StructuredGrid("O8")
+fs = atlas_functionspace_BlockStructuredColumns(grid, halo=0, nproma=4)
+
+! Create three fields with different data
+field1 = fs%create_field(name="field1", kind=atlas_real(c_double))
+field2 = fs%create_field(name="field2", kind=atlas_real(c_double))
+field3 = fs%create_field(name="field3", kind=atlas_real(c_float))
+
+call fill_field_with_data(fs, field1, 100)
+call fill_field_with_data(fs, field2, 200)
+call fill_field_with_data(fs, field3, 300)
+
+! Create fieldsets with same fields in same order
+fieldset = atlas_FieldSet()
+call fieldset%add(field1)
+call fieldset%add(field2)
+call fieldset%add(field3)
+
+fieldset2 = atlas_FieldSet()
+call fieldset2%add(field1)
+call fieldset2%add(field2)
+call fieldset2%add(field3)
+
+! Checksums of identical fieldsets should match
+checksum1 = fs%checksum(fieldset)
+checksum2 = fs%checksum(fieldset2)
+
+if( mpi%rank() == 0 ) then
+  write(msg,*) "FieldSet Checksum 1: ", trim(checksum1)
+  call atlas_log%info(msg)
+  write(msg,*) "FieldSet Checksum 2: ", trim(checksum2)
+  call atlas_log%info(msg)
+endif
+
+FCTEST_CHECK_EQUAL( checksum1, checksum2 )
+
+! Also verify that individual field checksum differs from combined fieldset
+checksum_field1 = fs%checksum(field1)
+
+if( mpi%rank() == 0 ) then
+  write(msg,*) "Field 1 Checksum: ", trim(checksum_field1)
+  call atlas_log%info(msg)
+  write(msg,*) "FieldSet contains Field 1 but they have different checksums"
+  call atlas_log%info(msg)
+endif
+
+! FieldSet checksum should differ from single field checksum (contains 3 fields)
+FCTEST_CHECK( checksum1 /= checksum_field1 )
+
+call fieldset%final()
+call fieldset2%final()
+call field1%final()
+call field2%final()
+call field3%final()
+call fs%final()
+call grid%final()
+END_TEST
+
+! ============================================================================
+! Test: Checksum determinism with multiple variables per field
+! ============================================================================
+TEST( test_blockstructuredcolumns_checksum_multiple_variables )
+use atlas_functionspace_blockstructuredcolumns_module
+use fckit_mpi_module
+implicit none
+type(atlas_StructuredGrid) :: grid
+type(atlas_functionspace_BlockStructuredColumns) :: fs
+type(atlas_Field) :: field1, field2
+character(len=256) :: checksum1, checksum2
+type(fckit_mpi_comm) :: mpi
+
+mpi = fckit_mpi_comm()
+
+grid = atlas_StructuredGrid("O8")
+fs = atlas_functionspace_BlockStructuredColumns(grid, halo=0, nproma=4)
+
+! Create fields with multiple variables
+field1 = fs%create_field(name="multi_var1", kind=atlas_real(c_double), variables=3)
+field2 = fs%create_field(name="multi_var2", kind=atlas_real(c_double), variables=3)
+
+call fill_field_with_data(fs, field1, 555)
+call fill_field_with_data(fs, field2, 555)
+
+checksum1 = fs%checksum(field1)
+checksum2 = fs%checksum(field2)
+
+if( mpi%rank() == 0 ) then
+  write(msg,*) "Multi-var Checksum 1: ", trim(checksum1)
+  call atlas_log%info(msg)
+  write(msg,*) "Multi-var Checksum 2: ", trim(checksum2)
+  call atlas_log%info(msg)
+endif
+
+FCTEST_CHECK_EQUAL( checksum1, checksum2 )
+
+call field1%final()
+call field2%final()
+call fs%final()
+call grid%final()
+END_TEST
+
+! ============================================================================
+! Test: Checksum invariance with halo - should exclude halo region
+! Note: This test skipped because properly testing halo exclusion requires
+! more careful setup of owned vs halo regions. The C++ tests verify this.
+! ============================================================================
+! TEST( test_blockstructuredcolumns_checksum_halo_consistency )
+! SKIPPED - See C++ tests for halo invariance verification
+!
+
+! ============================================================================
+! Test: Checksum differs when data changes
+! ============================================================================
+TEST( test_blockstructuredcolumns_checksum_data_sensitivity )
+use atlas_functionspace_blockstructuredcolumns_module
+use fckit_mpi_module
+implicit none
+type(atlas_StructuredGrid) :: grid
+type(atlas_functionspace_BlockStructuredColumns) :: fs
+type(atlas_Field) :: field
+character(len=256) :: checksum1, checksum2
+real(c_double), pointer :: data_2d(:,:)
+type(fckit_mpi_comm) :: mpi
+
+mpi = fckit_mpi_comm()
+
+grid = atlas_StructuredGrid("O8")
+fs = atlas_functionspace_BlockStructuredColumns(grid, halo=0, nproma=4)
+
+field = fs%create_field(name="field", kind=atlas_real(c_double))
+
+! Fill with initial data
+call fill_field_with_data(fs, field, 42)
+checksum1 = fs%checksum(field)
+
+! Modify data
+call field%data(data_2d)
+data_2d = data_2d + 1.0d0
+
+checksum2 = fs%checksum(field)
+
+if( mpi%rank() == 0 ) then
+  write(msg,*) "Checksum before modification: ", trim(checksum1)
+  call atlas_log%info(msg)
+  write(msg,*) "Checksum after modification: ", trim(checksum2)
+  call atlas_log%info(msg)
+endif
+
+! Checksums should differ after data modification
+FCTEST_CHECK( checksum1 /= checksum2 )
+
+call field%final()
+call fs%final()
+call grid%final()
+END_TEST
+
+! ============================================================================
+! Test: Checksum determinism for different data types
+! ============================================================================
+TEST( test_blockstructuredcolumns_checksum_data_type_sensitivity )
+use atlas_functionspace_blockstructuredcolumns_module
+use fckit_mpi_module
+implicit none
+type(atlas_StructuredGrid) :: grid
+type(atlas_functionspace_BlockStructuredColumns) :: fs
+type(atlas_Field) :: field_double, field_float, field1, field2
+real(c_double), pointer :: data_dbl(:,:), data_dbl2(:,:)
+real(c_float), pointer :: data_flt(:,:)
+character(len=256) :: checksum_double, checksum_float, checksum1, checksum2
+type(fckit_mpi_comm) :: mpi
+
+mpi = fckit_mpi_comm()
+
+grid = atlas_StructuredGrid("O16")
+fs = atlas_functionspace_BlockStructuredColumns(grid, halo=0, nproma=8)
+
+! ========================================================================
+! Test 1: Fields created through functionspace, data wraps internal buffers
+! (This demonstrates how BlockStructuredColumns manages field data internally)
+! ========================================================================
+field_double = fs%create_field(name="field_double", kind=atlas_real(c_double))
+field_float = fs%create_field(name="field_float", kind=atlas_real(c_float))
+
+! Access and fill the wrapped data
+call field_double%data(data_dbl)
+call field_float%data(data_flt)
+
+! Fill with deterministic values
+data_dbl = 1.618033988749895d0
+data_flt = real(1.618033988749895d0, c_float)
+
+! Compute checksums
+checksum_double = fs%checksum(field_double)
+checksum_float = fs%checksum(field_float)
+
+if( mpi%rank() == 0 ) then
+  write(msg,*) "Field wrapping double precision data: ", trim(checksum_double)
+  call atlas_log%info(msg)
+  write(msg,*) "Field wrapping single precision data: ", trim(checksum_float)
+  call atlas_log%info(msg)
+  write(msg,*) "Different data types produce different checksums"
+  call atlas_log%info(msg)
+endif
+
+! Different data types should have different checksums
+FCTEST_CHECK( checksum_double /= checksum_float )
+
+! ========================================================================
+! Test 2: Demonstrates that modifying the data changes checksum
+! ========================================================================
+field1 = fs%create_field(name="field1", kind=atlas_real(c_double))
+field2 = fs%create_field(name="field2", kind=atlas_real(c_double))
+
+call field1%data(data_dbl)
+call field2%data(data_dbl2)
+
+! Fill both with same data
+data_dbl = 3.14159265358979d0
+data_dbl2 = 3.14159265358979d0
+
+checksum1 = fs%checksum(field1)
+checksum2 = fs%checksum(field2)
+
+if( mpi%rank() == 0 ) then
+  write(msg,*) "Field 1 checksum (same data): ", trim(checksum1)
+  call atlas_log%info(msg)
+  write(msg,*) "Field 2 checksum (same data): ", trim(checksum2)
+  call atlas_log%info(msg)
+endif
+
+FCTEST_CHECK_EQUAL( checksum1, checksum2 )
+
+! Modify wrapped data in field1
+data_dbl = 2.71828182845904d0
+
+checksum1 = fs%checksum(field1)
+
+if( mpi%rank() == 0 ) then
+  write(msg,*) "Field 1 checksum (modified data): ", trim(checksum1)
+  call atlas_log%info(msg)
+  write(msg,*) "Checksum changed because wrapped data was modified"
+  call atlas_log%info(msg)
+endif
+
+! Checksums should differ after modification
+FCTEST_CHECK( checksum1 /= checksum2 )
+
+call field_double%final()
+call field_float%final()
+call field1%final()
+call field2%final()
+call fs%final()
+call grid%final()
+END_TEST
+
+! ============================================================================
+! Test: Checksum consistency across rank types
+! ============================================================================
+TEST( test_blockstructuredcolumns_checksum_rank_consistency )
+use atlas_functionspace_blockstructuredcolumns_module
+use fckit_mpi_module
+implicit none
+type(atlas_StructuredGrid) :: grid
+type(atlas_functionspace_BlockStructuredColumns) :: fs
+type(atlas_Field) :: field_rank2, field_rank3, field_rank4
+character(len=256) :: checksum_r2, checksum_r3, checksum_r4
+type(fckit_mpi_comm) :: mpi
+
+mpi = fckit_mpi_comm()
+
+grid = atlas_StructuredGrid("O8")
+fs = atlas_functionspace_BlockStructuredColumns(grid, halo=0, nproma=4, levels=5)
+
+! Create fields of different ranks
+field_rank2 = fs%create_field(name="rank2_field", kind=atlas_real(c_double))
+field_rank3 = fs%create_field(name="rank3_field", kind=atlas_real(c_double), levels=5)
+field_rank4 = fs%create_field(name="rank4_field", kind=atlas_real(c_double), variables=2, levels=5)
+
+call fill_field_with_data(fs, field_rank2, 111)
+call fill_field_with_data(fs, field_rank3, 222)
+call fill_field_with_data(fs, field_rank4, 333)
+
+! Compute checksums for different rank fields
+checksum_r2 = fs%checksum(field_rank2)
+checksum_r3 = fs%checksum(field_rank3)
+checksum_r4 = fs%checksum(field_rank4)
+
+if( mpi%rank() == 0 ) then
+  write(msg,*) "Rank 2 Field Checksum: ", trim(checksum_r2)
+  call atlas_log%info(msg)
+  write(msg,*) "Rank 3 Field Checksum: ", trim(checksum_r3)
+  call atlas_log%info(msg)
+  write(msg,*) "Rank 4 Field Checksum: ", trim(checksum_r4)
+  call atlas_log%info(msg)
+  write(msg,*) "All checksums should be different (different data and shapes)"
+  call atlas_log%info(msg)
+endif
+
+! Checksums should be different (different data)
+FCTEST_CHECK( checksum_r2 /= checksum_r3 )
+FCTEST_CHECK( checksum_r3 /= checksum_r4 )
+FCTEST_CHECK( checksum_r2 /= checksum_r4 )
+
+call field_rank2%final()
+call field_rank3%final()
+call field_rank4%final()
+call fs%final()
+call grid%final()
+END_TEST
+
+TEST( test_blockstructuredcolumns_wrapped_fields )
+type(atlas_StructuredGrid) :: grid
+type(atlas_functionspace_BlockStructuredColumns) :: fs
+type(atlas_Field) :: field_1, field_2, field_3, field_gfl
+type(atlas_FieldSet) :: fieldset
+real(c_double), allocatable :: gfl(:,:,:,:)
+character(len=256) :: checksum
+integer(c_int) :: nlev = 10, nproma = 8, nvar = 3
+
+grid = atlas_StructuredGrid("O32")
+fs = atlas_functionspace_BlockStructuredColumns(grid, nproma=nproma)
+allocate(gfl(fs%nproma(),nlev,nvar,fs%nblks()))
+call fill_field_with_data(fs, gfl, 42)
+
+field_1 = atlas_Field(name="field_1", data=gfl(:,:,1,:))
+checksum = fs%checksum(field_1)  ! Should compute checksum without error on wrapped data
+write(msg,*) "Checksum for field_1 wrapping 3D slice: ", trim(checksum)
+call atlas_log%info(msg)
+FCTEST_CHECK_EQUAL(checksum, "35704")
+
+field_2 = atlas_Field(name="field_2", data=gfl(:,:,2,:))
+checksum = fs%checksum(field_2)  ! Should compute checksum without error on wrapped data
+write(msg,*) "Checksum for field_2 wrapping 3D slice: ", trim(checksum)
+call atlas_log%info(msg)
+FCTEST_CHECK_EQUAL(checksum, "12704")
+
+field_3 = atlas_Field(name="field_3", data=gfl(:,:,3,:))
+checksum = fs%checksum(field_3)  ! Should compute checksum without error on wrapped data
+write(msg,*) "Checksum for field_3 wrapping 3D slice: ", trim(checksum)
+call atlas_log%info(msg)
+FCTEST_CHECK_EQUAL(checksum, "21654")
+
+fieldset = atlas_FieldSet()
+call fieldset%add(field_1)
+call fieldset%add(field_2)
+call fieldset%add(field_3)
+checksum = fs%checksum(fieldset)  ! Should compute checksum without error on fieldset of wrapped fields
+write(msg,*) "Checksum for fieldset of 3 wrapped fields: ", trim(checksum)
+call atlas_log%info(msg)
+FCTEST_CHECK_EQUAL(checksum, "37637")
+
+field_gfl = atlas_Field(name="gfl", data=gfl(:,:,:,:))
+checksum = fs%checksum(field_gfl)  ! Should compute checksum without error on wrapped data
+write(msg,*) "Checksum for field_gfl wrapping 4D array: ", trim(checksum)
+call atlas_log%info(msg)
+FCTEST_CHECK_EQUAL(checksum, "13196")
+END_TEST
+
+END_TESTSUITE

--- a/src/tests/functionspace/test_blockstructuredcolumns_checksum.cc
+++ b/src/tests/functionspace/test_blockstructuredcolumns_checksum.cc
@@ -1,0 +1,815 @@
+/*
+ * (C) Copyright 2013 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <vector>
+#include <cmath>
+
+#include "atlas/array.h"
+#include "atlas/array/ArrayView.h"
+#include "atlas/array/MakeView.h"
+#include "atlas/field/Field.h"
+#include "atlas/field/FieldSet.h"
+#include "atlas/functionspace/BlockStructuredColumns.h"
+#include "atlas/grid/StructuredGrid.h"
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/util/Checksum.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using namespace atlas;
+using namespace atlas::functionspace;
+using namespace atlas::test;
+
+namespace {
+
+idx_t lane_value_count(const Field& field) {
+    idx_t count = 1;
+    for (idx_t dim = 1; dim < field.rank() - 1; ++dim) {
+        count *= field.shape(dim);
+    }
+    return count;
+}
+
+template <typename Value>
+void fill_block_values(Value* data, const Field& field, idx_t dim, idx_t offset, idx_t block_size, Value& next_value) {
+    if (dim == field.rank() - 1) {
+        for (idx_t jlane = 0; jlane < block_size; ++jlane) {
+            data[offset + jlane * field.stride(dim)] = next_value;
+            next_value += Value{1};
+        }
+        for (idx_t jlane = block_size; jlane < field.shape(dim); ++jlane) {
+            data[offset + jlane * field.stride(dim)] = Value{-1};
+        }
+        return;
+    }
+
+    for (idx_t index = 0; index < field.shape(dim); ++index) {
+        fill_block_values(data, field, dim + 1, offset + index * field.stride(dim), block_size, next_value);
+    }
+}
+
+template <typename Value>
+void pack_lane_values(std::vector<Value>& lane_values, const Field& field, const Value* data, idx_t dim, idx_t offset) {
+    if (dim == field.rank() - 1) {
+        lane_values.push_back(data[offset]);
+        return;
+    }
+
+    for (idx_t index = 0; index < field.shape(dim); ++index) {
+        pack_lane_values(lane_values, field, data, dim + 1, offset + index * field.stride(dim));
+    }
+}
+
+template <typename Value>
+std::string fill_field_and_expected_checksum(const BlockStructuredColumns& fs, Field& field) {
+    auto* data = field.array().host_data<Value>();
+
+    std::vector<util::checksum_t> lane_checksums;
+    lane_checksums.reserve(fs.size());
+    std::vector<Value> lane_values;
+    lane_values.reserve(lane_value_count(field));
+
+    Value next_value{1};
+    for (idx_t jblk = 0; jblk < fs.nblks(); ++jblk) {
+        auto blk = fs.block(jblk);
+        const idx_t block_offset = jblk * field.stride(0);
+        fill_block_values(data, field, 1, block_offset, blk.size(), next_value); // increments next_value
+
+        for (idx_t jrof = 0; jrof < blk.size(); ++jrof) {
+            lane_values.clear();
+            if (field.rank() == 4) {
+                // lev-outer, var-inner to match blocked checksum iteration order
+                const idx_t nvar = field.shape(1);
+                const idx_t nlev = field.shape(2);
+                for (idx_t jlev = 0; jlev < nlev; ++jlev) {
+                    for (idx_t jvar = 0; jvar < nvar; ++jvar) {
+                        lane_values.push_back(data[block_offset + jvar * field.stride(1) + jlev * field.stride(2) + jrof * field.stride(3)]);
+                    }
+                }
+            }
+            else {
+                pack_lane_values(lane_values, field, data, 1, block_offset + jrof * field.stride(field.rank() - 1));
+            }
+            lane_checksums.push_back(util::checksum(lane_values.data(), lane_values.size()));
+        }
+    }
+
+    return std::to_string(util::checksum(lane_checksums.data(), lane_checksums.size()));
+}
+
+template <typename Value>
+std::string expected_fieldset_checksum(const BlockStructuredColumns& fs, const FieldSet& fields) {
+    std::vector<util::checksum_t> lane_states(static_cast<size_t>(fs.size()));
+    for (auto& lane_state : lane_states) {
+        util::checksum_reset(lane_state);
+    }
+
+    std::vector<Value> lane_values;
+    for (idx_t jfld = 0; jfld < fields.size(); ++jfld) {
+        const Field& field = fields[jfld];
+        const auto* data   = field.array().host_data<Value>();
+
+        for (idx_t jblk = 0; jblk < fs.nblks(); ++jblk) {
+            auto blk = fs.block(jblk);
+            const idx_t block_offset = jblk * field.stride(0);
+
+            for (idx_t jrof = 0; jrof < blk.size(); ++jrof) {
+                lane_values.clear();
+                if (field.rank() == 4) {
+                    // lev-outer, var-inner to match blocked checksum iteration order
+                    const idx_t nvar = field.shape(1);
+                    const idx_t nlev = field.shape(2);
+                    for (idx_t jlev = 0; jlev < nlev; ++jlev) {
+                        for (idx_t jvar = 0; jvar < nvar; ++jvar) {
+                            lane_values.push_back(data[block_offset + jvar * field.stride(1) + jlev * field.stride(2) + jrof * field.stride(3)]);
+                        }
+                    }
+                }
+                else {
+                    pack_lane_values(lane_values, field, data, 1, block_offset + jrof * field.stride(field.rank() - 1));
+                }
+                util::checksum_update(lane_states[static_cast<size_t>(blk.index(jrof))], lane_values.data(),
+                                      lane_values.size());
+            }
+        }
+    }
+
+    std::vector<util::checksum_t> lane_digests(lane_states.size());
+    for (size_t jlane = 0; jlane < lane_states.size(); ++jlane) {
+        lane_digests[jlane] = util::checksum_digest(lane_states[jlane]);
+    }
+    return std::to_string(util::checksum(lane_digests.data(), lane_digests.size()));
+}
+
+template <typename Value>
+Field make_non_contiguous_field(const BlockStructuredColumns& fs, const util::Config& options, std::vector<Value>& rawdata) {
+    Field prototype = fs.createField<Value>(option::name("field") | options);
+
+    idx_t block_data_size = 1;
+    for (idx_t dim = 1; dim < prototype.rank(); ++dim) {
+        block_data_size *= prototype.shape(dim);
+    }
+    const idx_t block_stride = block_data_size + 5;
+
+    array::ArrayShape shape;
+    array::ArrayStrides strides;
+    shape.reserve(prototype.rank());
+    strides.resize(prototype.rank());
+    for (idx_t dim = 0; dim < prototype.rank(); ++dim) {
+        shape.emplace_back(prototype.shape(dim));
+    }
+
+    strides[prototype.rank() - 1] = 1;
+    for (idx_t dim = prototype.rank() - 2; dim > 0; --dim) {
+        strides[dim] = strides[dim + 1] * prototype.shape(dim + 1);
+    }
+    strides[0] = block_stride;
+
+    rawdata.assign(fs.nblks() * block_stride, Value{-1});
+    return Field("field", rawdata.data(), array::ArraySpec{shape, strides});
+}
+
+template <typename Value>
+Field make_block_slice_non_contiguous_field(const BlockStructuredColumns& fs, const util::Config& options,
+                                            std::vector<Value>& rawdata) {
+    constexpr idx_t inner_dim_padding = 1;
+    constexpr idx_t block_padding = 3;
+
+    Field prototype = fs.createField<Value>(option::name("field") | options);
+
+    array::ArrayShape shape = prototype.shape();
+    array::ArrayStrides strides;
+    strides.resize(prototype.rank());
+
+    strides[prototype.rank() - 1] = 1;
+    ATLAS_ASSERT(prototype.rank() > 2, "We always expect nproma to be contiguous");
+    for (idx_t dim = prototype.rank() - 2; dim > 0; --dim) {
+        // Add padding at each inner dimension so nproma-adjacent slices and higher dimensions are non-contiguous.
+        strides[dim] = strides[dim + 1] * shape[dim + 1];
+        strides[dim] += inner_dim_padding;
+    }
+    // Extra spacing between consecutive blocks in dimension 0.
+    strides[0] = strides[1] * shape[1] + block_padding;
+
+    rawdata.assign(fs.nblks() * strides[0], Value{-1});
+    return Field("field", rawdata.data(), array::ArraySpec{shape, strides});
+}
+
+template <typename Value>
+void expect_checksum_matches(const BlockStructuredColumns& fs, Field& field) {
+    auto expected_checksum = fill_field_and_expected_checksum<Value>(fs, field);
+    Log::info() << "Expected checksum: " << expected_checksum << std::endl;
+    EXPECT_EQ(fs.checksum(field), expected_checksum);
+}
+
+template <typename Value>
+void update_lane_states_with_global_field(const Field& field, std::vector<util::checksum_t>& lane_states) {
+    ATLAS_ASSERT(field.shape(0) == static_cast<idx_t>(lane_states.size()));
+
+    switch (field.rank()) {
+        case 3: {
+            auto value = array::make_view<Value, 3>(field);
+            for (idx_t point = 0; point < field.shape(0); ++point) {
+                util::checksum_update(lane_states[static_cast<size_t>(point)], &value(point, 0, 0), field.shape(1) * field.shape(2));
+            }
+            break;
+        }
+        case 2: {
+            auto value = array::make_view<Value, 2>(field);
+            for (idx_t point = 0; point < field.shape(0); ++point) {
+                util::checksum_update(lane_states[static_cast<size_t>(point)], &value(point, 0), field.shape(1));
+            }
+            break;
+        }
+        case 1: {
+            auto value = array::make_view<Value, 1>(field);
+            for (idx_t point = 0; point < field.shape(0); ++point) {
+                util::checksum_update(lane_states[static_cast<size_t>(point)], &value(point), 1);
+            }
+            break;
+        }
+        default:
+            ATLAS_NOTIMPLEMENTED;
+    }
+}
+
+util::checksum_t checksum_from_lane_states(const std::vector<util::checksum_t>& lane_states) {
+    std::vector<util::checksum_t> lane_digests(lane_states.size());
+    for (size_t point = 0; point < lane_states.size(); ++point) {
+        lane_digests[point] = util::checksum_digest(lane_states[point]);
+    }
+    return util::checksum(lane_digests.data(), lane_digests.size());
+}
+
+template <typename Value>
+util::checksum_t expected_global_field_checksum(const Field& global_field) {
+    std::vector<util::checksum_t> lane_states(static_cast<size_t>(global_field.shape(0)));
+    for (auto& lane_state : lane_states) {
+        util::checksum_reset(lane_state);
+    }
+
+    update_lane_states_with_global_field<Value>(global_field, lane_states);
+
+    return checksum_from_lane_states(lane_states);
+}
+
+template <typename Value>
+util::checksum_t expected_global_fieldset_checksum(const FieldSet& global_fields) {
+    ATLAS_ASSERT(global_fields.size() > 0);
+    const idx_t npts = global_fields[0].shape(0);
+
+    std::vector<util::checksum_t> lane_states(static_cast<size_t>(npts));
+    for (auto& lane_state : lane_states) {
+        util::checksum_reset(lane_state);
+    }
+
+    for (idx_t jfld = 0; jfld < global_fields.size(); ++jfld) {
+        const Field& global = global_fields[jfld];
+        update_lane_states_with_global_field<Value>(global, lane_states);
+    }
+
+    return checksum_from_lane_states(lane_states);
+}
+
+template <typename Value>
+util::checksum_t fill_global_field_and_expected_checksum(Field& global) {
+    auto* data = global.array().host_data<Value>();
+    Value next_value{1};
+    for (idx_t i = 0; i < global.size(); ++i) {
+        data[i] = next_value;
+        next_value += 1.;
+    }
+    return expected_global_field_checksum<Value>(global);
+}
+
+}  // namespace
+
+namespace atlas {
+namespace test {
+
+CASE("test_BlockStructuredColumns checksum includes partial last block (mpi-serial)") {
+    using Value = double;
+    mpi::Scope scope("self"); // MPI-serial execution in this scope
+
+    constexpr idx_t nlev = 4;
+    constexpr idx_t nvar = 3;
+
+    auto fs = [] {
+        auto grid = StructuredGrid("O8");
+        util::Config config;
+        config.set("halo", 0);
+        config.set("nproma", grid.size() - 1);
+        return BlockStructuredColumns(grid, config);
+    }();
+    REQUIRE(fs.size() > 1);
+    REQUIRE(fs.size() % fs.nproma() == 1);
+    REQUIRE(fs.block(fs.nblks() - 1).size() == 1);
+
+    auto run_subcase = [&](const char* label, bool use_non_contiguous) {
+        ATLAS_TRACE(label);
+        Log::info() << "Running subcase: " << label << std::endl;
+        if (use_non_contiguous) {
+            std::vector<Value> rawdata;
+            Field field = make_non_contiguous_field(fs, option::variables(nvar) | option::levels(nlev), rawdata);
+
+            EXPECT(not field.contiguous());
+            expect_checksum_matches<Value>(fs, field);
+        }
+        else {
+            Field field = fs.createField<Value>(option::name("field") | option::variables(nvar) | option::levels(nlev));
+
+            EXPECT(field.contiguous());
+            expect_checksum_matches<Value>(fs, field);
+        }
+    };
+
+    run_subcase("contiguous field", false);
+    run_subcase("non-contiguous field", true);
+}
+
+CASE("test_BlockStructuredColumns checksum for various rank fields (mpi-serial)") {
+    using Value = double;
+    mpi::Scope scope("self");
+
+    auto fs = [] {
+        StructuredGrid grid{"O8"};
+        util::Config config;
+        config.set("halo", 0);
+        config.set("nproma", grid.size() - 1);
+        return BlockStructuredColumns(grid, config);
+    }();
+
+    constexpr idx_t nvar = 3;
+    constexpr idx_t nlev = 4;
+
+    auto run_subcase = [&](const char* label, const util::Config& field_options, idx_t expected_rank) {
+        ATLAS_TRACE(label);
+        Log::info() << "Running variant: " << label << std::endl;
+
+        Field contiguous = fs.createField<Value>(option::name("field") | field_options);
+        EXPECT_EQ(contiguous.rank(), expected_rank);
+        EXPECT(contiguous.contiguous());
+        expect_checksum_matches<Value>(fs, contiguous);
+
+        std::vector<Value> rawdata;
+        Field non_contiguous = make_non_contiguous_field(fs, field_options, rawdata);
+        EXPECT_EQ(non_contiguous.rank(), expected_rank);
+        EXPECT(not non_contiguous.contiguous());
+        expect_checksum_matches<Value>(fs, non_contiguous);
+    };
+
+    run_subcase("four-dimensional field with levels and variables", option::variables(nvar) | option::levels(nlev), 4);
+    run_subcase("three-dimensional field without levels", option::variables(nvar), 3);
+    run_subcase("three-dimensional field without variables", option::levels(nlev), 3);
+    run_subcase("two-dimensional field without levels and variables", util::Config(), 2);
+}
+
+CASE("test_BlockStructuredColumns checksum in mpi-serial uses generic path for block-slice non-contiguous fields") {
+    using Value = double;
+    mpi::Scope scope("self");
+
+    constexpr idx_t root = 0;
+    constexpr idx_t nlev = 4;
+    constexpr idx_t nvar = 3;
+
+    auto fs = [] {
+        auto grid = StructuredGrid("O8");
+        util::Config config;
+        config.set("halo", 0);
+        config.set("nproma", 5);
+        return BlockStructuredColumns(grid, config);
+    }();
+
+    Field global = fs.createField<Value>(option::name("global") | option::global(root) | option::variables(nvar) |
+                                         option::levels(nlev));
+    util::checksum_t expected_checksum = 0;
+    if (mpi::comm().rank() == root) {
+        expected_checksum = fill_global_field_and_expected_checksum<Value>(global);
+    }
+    mpi::comm().broadcast(expected_checksum, root);
+
+    std::vector<Value> rawdata;
+    Field local = make_block_slice_non_contiguous_field(fs, option::variables(nvar) | option::levels(nlev), rawdata);
+    EXPECT(not local.contiguous());
+    EXPECT(local.stride(local.rank() - 2) != local.shape(local.rank() - 1));
+
+    fs.scatter(global, local);
+
+    Log::info() << "Expected checksum: " << expected_checksum << std::endl;
+    EXPECT_EQ(fs.checksum(local), std::to_string(expected_checksum));
+}
+
+CASE("test_BlockStructuredColumns checksum(fieldset) matches checksum(field) for a single field (mpi-serial)") {
+    using Value = double;
+    mpi::Scope scope("self");
+
+    constexpr idx_t nlev = 4;
+    constexpr idx_t nvar = 3;
+
+    auto fs = [] {
+        auto grid = StructuredGrid("O8");
+        util::Config config;
+        config.set("halo", 0);
+        config.set("nproma", grid.size() - 1);
+        return BlockStructuredColumns(grid, config);
+    }();
+
+    {
+        Field field = fs.createField<Value>(option::name("field") | option::variables(nvar) | option::levels(nlev));
+        fill_field_and_expected_checksum<Value>(fs, field);
+
+        FieldSet fieldset;
+        fieldset.add(field);
+
+        EXPECT_EQ(fs.checksum(fieldset), fs.checksum(field));
+    }
+
+    {
+        std::vector<Value> rawdata;
+        Field field = make_non_contiguous_field<Value>(fs, option::variables(nvar) | option::levels(nlev), rawdata);
+        fill_field_and_expected_checksum<Value>(fs, field);
+
+        FieldSet fieldset;
+        fieldset.add(field);
+
+        EXPECT_EQ(fs.checksum(fieldset), fs.checksum(field));
+    }
+}
+
+CASE("test_BlockStructuredColumns checksum(fieldset) combines all fields as lane checksum updates (mpi-serial)") {
+    using Value = double;
+    mpi::Scope scope("self");
+
+    constexpr idx_t nlev = 4;
+    constexpr idx_t nvar = 3;
+
+    auto fs = [] {
+        auto grid = StructuredGrid("O8");
+        util::Config config;
+        config.set("halo", 0);
+        config.set("nproma", 5);
+        return BlockStructuredColumns(grid, config);
+    }();
+
+    Field contiguous = fs.createField<Value>(option::name("contiguous") | option::variables(nvar) | option::levels(nlev));
+    std::vector<Value> rawdata;
+    Field non_contiguous = make_non_contiguous_field<Value>(fs, option::variables(nvar) | option::levels(nlev), rawdata);
+
+    fill_field_and_expected_checksum<Value>(fs, contiguous);
+    fill_field_and_expected_checksum<Value>(fs, non_contiguous);
+
+    FieldSet fieldset;
+    fieldset.add(contiguous);
+    fieldset.add(non_contiguous);
+
+    const std::string expected = expected_fieldset_checksum<Value>(fs, fieldset);
+    Log::info() << "Expected fieldset checksum: " << expected << std::endl;
+    EXPECT_EQ(fs.checksum(fieldset), expected);
+}
+
+template <typename Value>
+void run_mpi_checksum_caseT(const functionspace::BlockStructuredColumns& fs, idx_t nlev, idx_t nvar) {
+    constexpr idx_t root = 0;
+
+    util::Config option_nlev_nvars;
+    if (nvar > 0) {
+        option_nlev_nvars.set(option::variables(nvar));
+    }
+    if (nlev > 0) {
+        option_nlev_nvars.set(option::levels(nlev));
+    }
+
+    Field global = fs.createField<Value>(option::name("global") | option::global(root) | option_nlev_nvars);
+    util::checksum_t expected_checksum = 0;
+    if (mpi::comm().rank() == root) {
+        expected_checksum = fill_global_field_and_expected_checksum<Value>(global);
+    }
+    mpi::comm().broadcast(expected_checksum, root);
+
+    Field local = fs.createField<Value>(option::name("local") | option_nlev_nvars);
+    fs.scatter(global, local);
+    idx_t expected_rank = idx_t{2} /*nblks, nproma*/ + std::min<idx_t>(nlev,1) + std::min<idx_t>(nvar,1);
+    EXPECT_EQ(local.rank(), expected_rank);
+
+    Log::info() << "Expected checksum: " << expected_checksum << std::endl;
+    EXPECT_EQ(fs.checksum(local), std::to_string(expected_checksum));
+};
+
+void run_mpi_checksum_cases(const functionspace::BlockStructuredColumns& fs, idx_t nlev, idx_t nvar) {
+    run_mpi_checksum_caseT<double>(fs, nlev, nvar);
+    run_mpi_checksum_caseT<float>(fs, nlev, nvar);
+    run_mpi_checksum_caseT<int>(fs, nlev, nvar);
+    run_mpi_checksum_caseT<long>(fs, nlev, nvar);
+}
+
+template <typename Value>
+void run_mpi_fieldset_checksum_caseT(const functionspace::BlockStructuredColumns& fs, idx_t nlev, idx_t nvar) {
+    constexpr idx_t root = 0;
+
+    util::Config option_nlev_nvars;
+    if (nvar > 0) {
+        option_nlev_nvars.set(option::variables(nvar));
+    }
+    if (nlev > 0) {
+        option_nlev_nvars.set(option::levels(nlev));
+    }
+
+    Field global_a = fs.createField<Value>(option::name("global_a") | option::global(root) | option_nlev_nvars);
+    Field global_b = fs.createField<Value>(option::name("global_b") | option::global(root) | option_nlev_nvars);
+
+    util::checksum_t expected_fieldset = 0;
+    if (mpi::comm().rank() == root) {
+        fill_global_field_and_expected_checksum<Value>(global_a);
+        fill_global_field_and_expected_checksum<Value>(global_b);
+
+        FieldSet global_fieldset;
+        global_fieldset.add(global_a);
+        global_fieldset.add(global_b);
+        expected_fieldset = expected_global_fieldset_checksum<Value>(global_fieldset);
+    }
+    mpi::comm().broadcast(expected_fieldset, root);
+
+    Field local_a = fs.createField<Value>(option::name("local_a") | option_nlev_nvars);
+    Field local_b = fs.createField<Value>(option::name("local_b") | option_nlev_nvars);
+    fs.scatter(global_a, local_a);
+    fs.scatter(global_b, local_b);
+
+    FieldSet local_fieldset;
+    local_fieldset.add(local_a);
+    local_fieldset.add(local_b);
+
+    Log::info() << "Expected fieldset checksum (MPI): " << expected_fieldset << std::endl;
+    EXPECT_EQ(fs.checksum(local_fieldset), std::to_string(expected_fieldset));
+}
+
+void run_mpi_fieldset_checksum_cases(const functionspace::BlockStructuredColumns& fs, idx_t nlev, idx_t nvar) {
+    run_mpi_fieldset_checksum_caseT<double>(fs, nlev, nvar);
+    run_mpi_fieldset_checksum_caseT<float>(fs, nlev, nvar);
+    run_mpi_fieldset_checksum_caseT<int>(fs, nlev, nvar);
+    run_mpi_fieldset_checksum_caseT<long>(fs, nlev, nvar);
+}
+
+
+CASE("test_BlockStructuredColumns checksum is deterministic in MPI") {
+    auto fs = [] {
+        auto grid = StructuredGrid("O8");
+        util::Config config;
+        config.set("halo", 0);
+        config.set("nproma", 8);
+        return BlockStructuredColumns(grid, config);
+    }();
+
+    constexpr idx_t nlev = 4;
+    constexpr idx_t nvar = 3;
+
+    auto run_subcase = [&](const char* label, idx_t levels, idx_t vars) {
+        Log::info() << "Running subcase: " << label << std::endl;
+        run_mpi_checksum_cases(fs, levels, vars);
+    };
+
+    run_subcase("with variables and levels", nlev, nvar);
+    run_subcase("with variables and no levels", 0, nvar);
+    run_subcase("with levels and no variables", nlev, 0);
+    run_subcase("with no variables and no levels", 0, 0);
+}
+
+CASE("test_BlockStructuredColumns checksum(fieldset) is deterministic in MPI") {
+    auto fs = [] {
+        auto grid = StructuredGrid("O8");
+        util::Config config;
+        config.set("halo", 0);
+        config.set("nproma", 8);
+        return BlockStructuredColumns(grid, config);
+    }();
+
+    constexpr idx_t nlev = 4;
+    constexpr idx_t nvar = 3;
+
+    auto run_subcase = [&](const char* label, idx_t levels, idx_t vars) {
+        Log::info() << "Running fieldset subcase: " << label << std::endl;
+        run_mpi_fieldset_checksum_cases(fs, levels, vars);
+    };
+
+    run_subcase("with variables and levels", nlev, nvar);
+    run_subcase("with variables and no levels", 0, nvar);
+    run_subcase("with levels and no variables", nlev, 0);
+    run_subcase("with no variables and no levels", 0, 0);
+}
+
+CASE("test_BlockStructuredColumns checksum with halo=2 (mpi-serial)") {
+    using Value = double;
+    mpi::Scope scope("self");
+
+    constexpr idx_t nlev = 4;
+    constexpr idx_t nvar = 3;
+
+    auto grid = StructuredGrid("O8");
+    auto fs_h0 = [&] {
+        util::Config config;
+        config.set("halo", 0);
+        config.set("nproma", 8);
+        return BlockStructuredColumns(grid, config);
+    }();
+    auto fs_h2 = [&] {
+        util::Config config;
+        config.set("halo", 2);
+        config.set("nproma", 8);
+        return BlockStructuredColumns(grid, config);
+    }();
+
+    Field field_h0 = fs_h0.createField<Value>(option::name("field_h0") | option::variables(nvar) | option::levels(nlev));
+    fill_field_and_expected_checksum<Value>(fs_h0, field_h0);
+
+    Field global = fs_h0.createField<Value>(option::name("global") | option::global(0) | option::variables(nvar) | option::levels(nlev));
+    fs_h0.gather(field_h0, global);
+
+    Field field_h2 = fs_h2.createField<Value>(option::name("field_h2") | option::variables(nvar) | option::levels(nlev));
+    fs_h2.scatter(global, field_h2);
+
+    EXPECT_EQ(fs_h0.checksum(field_h0), fs_h2.checksum(field_h2));
+
+    std::vector<Value> rawdata;
+    Field non_contiguous = make_non_contiguous_field<Value>(fs_h2, option::variables(nvar) | option::levels(nlev), rawdata);
+    EXPECT(not non_contiguous.contiguous());
+    fill_field_and_expected_checksum<Value>(fs_h2, non_contiguous);
+    EXPECT_EQ(fs_h2.checksum(non_contiguous), fs_h2.checksum(non_contiguous));
+}
+
+CASE("test_BlockStructuredColumns checksum(fieldset) with halo=2 (mpi-serial)") {
+    using Value = double;
+    mpi::Scope scope("self");
+
+    constexpr idx_t nlev = 4;
+    constexpr idx_t nvar = 3;
+
+    auto grid = StructuredGrid("O8");
+    auto fs_h0 = [&] {
+        util::Config config;
+        config.set("halo", 0);
+        config.set("nproma", 8);
+        return BlockStructuredColumns(grid, config);
+    }();
+    auto fs_h2 = [&] {
+        util::Config config;
+        config.set("halo", 2);
+        config.set("nproma", 8);
+        return BlockStructuredColumns(grid, config);
+    }();
+
+    Field field_h0_a = fs_h0.createField<Value>(option::name("field_h0_a") | option::variables(nvar) | option::levels(nlev));
+    Field field_h0_b = fs_h0.createField<Value>(option::name("field_h0_b") | option::variables(2));
+    fill_field_and_expected_checksum<Value>(fs_h0, field_h0_a);
+    fill_field_and_expected_checksum<Value>(fs_h0, field_h0_b);
+
+    Field global_a = fs_h0.createField<Value>(option::name("global_a") | option::global(0) | option::variables(nvar) | option::levels(nlev));
+    Field global_b = fs_h0.createField<Value>(option::name("global_b") | option::global(0) | option::variables(2));
+    fs_h0.gather(field_h0_a, global_a);
+    fs_h0.gather(field_h0_b, global_b);
+
+    Field field_h2_a = fs_h2.createField<Value>(option::name("field_h2_a") | option::variables(nvar) | option::levels(nlev));
+    Field field_h2_b = fs_h2.createField<Value>(option::name("field_h2_b") | option::variables(2));
+    fs_h2.scatter(global_a, field_h2_a);
+    fs_h2.scatter(global_b, field_h2_b);
+
+    FieldSet fieldset_h0;
+    FieldSet fieldset_h2;
+    fieldset_h0.add(field_h0_a);
+    fieldset_h0.add(field_h0_b);
+    fieldset_h2.add(field_h2_a);
+    fieldset_h2.add(field_h2_b);
+
+    EXPECT_EQ(fs_h0.checksum(fieldset_h0), fs_h2.checksum(fieldset_h2));
+}
+
+CASE("test_BlockStructuredColumns checksum with halo=2 matches halo=0 exactly (mpi-serial)") {
+    using Value = double;
+    mpi::Scope scope("self");
+
+    auto grid = StructuredGrid("O8");
+    auto fs_h0 = [&] {
+        util::Config config;
+        config.set("halo", 0);
+        config.set("nproma", 8);
+        return BlockStructuredColumns(grid, config);
+    }();
+    auto fs_h2 = [&] {
+        util::Config config;
+        config.set("halo", 2);
+        config.set("nproma", 8);
+        return BlockStructuredColumns(grid, config);
+    }();
+
+    Field field_h0 = fs_h0.createField<Value>(option::name("field_h0") | option::variables(3) | option::levels(4));
+    fill_field_and_expected_checksum<Value>(fs_h0, field_h0);
+
+    Field global = fs_h0.createField<Value>(option::name("global") | option::global(0) | option::variables(3) | option::levels(4));
+    fs_h0.gather(field_h0, global);
+
+    Field field_h2 = fs_h2.createField<Value>(option::name("field_h2") | option::variables(3) | option::levels(4));
+    fs_h2.scatter(global, field_h2);
+    EXPECT_EQ(fs_h0.checksum(field_h0), fs_h2.checksum(field_h2));
+
+    Field field_h0_b = fs_h0.createField<Value>(option::name("field_h0_b") | option::variables(2));
+    fill_field_and_expected_checksum<Value>(fs_h0, field_h0_b);
+    Field global_b = fs_h0.createField<Value>(option::name("global_b") | option::global(0) | option::variables(2));
+    fs_h0.gather(field_h0_b, global_b);
+    Field field_h2_b = fs_h2.createField<Value>(option::name("field_h2_b") | option::variables(2));
+    fs_h2.scatter(global_b, field_h2_b);
+
+    FieldSet fieldset_h0;
+    FieldSet fieldset_h2;
+    fieldset_h0.add(field_h0);
+    fieldset_h0.add(field_h0_b);
+    fieldset_h2.add(field_h2);
+    fieldset_h2.add(field_h2_b);
+    EXPECT_EQ(fs_h0.checksum(fieldset_h0), fs_h2.checksum(fieldset_h2));
+}
+
+CASE("test_BlockStructuredColumns checksum with halo=2 matches halo=0 exactly (MPI)") {
+    using Value = double;
+
+    constexpr idx_t root = 0;
+    auto grid = StructuredGrid("O8");
+    auto fs_h0 = [&] {
+        util::Config config;
+        config.set("halo", 0);
+        config.set("nproma", 8);
+        return BlockStructuredColumns(grid, config);
+    }();
+    auto fs_h2 = [&] {
+        util::Config config;
+        config.set("halo", 2);
+        config.set("nproma", 8);
+        return BlockStructuredColumns(grid, config);
+    }();
+
+    auto check_field_checksum_stable_with_halo = [&](const util::Config& options, Value first_value) {
+        Field global = fs_h0.createField<Value>(option::name("global") | option::global(root) | options);
+        if (mpi::comm().rank() == root) {
+            fill_global_field_and_expected_checksum<Value>(global);
+            // restart with requested first value for a deterministic variant per case
+            auto* data = global.array().host_data<Value>();
+            Value next = first_value;
+            for (idx_t i = 0; i < global.size(); ++i) {
+                data[i] = next;
+                next += Value{1};
+            }
+        }
+
+        Field local_h0 = fs_h0.createField<Value>(option::name("local_h0") | options);
+        Field local_h2 = fs_h2.createField<Value>(option::name("local_h2") | options);
+        fs_h0.scatter(global, local_h0);
+        fs_h2.scatter(global, local_h2);
+        EXPECT_EQ(fs_h0.checksum(local_h0), fs_h2.checksum(local_h2));
+    };
+
+    check_field_checksum_stable_with_halo(option::variables(3) | option::levels(4), Value{24000});
+    check_field_checksum_stable_with_halo(option::variables(3), Value{25000});
+    check_field_checksum_stable_with_halo(option::levels(4), Value{26000});
+    check_field_checksum_stable_with_halo(util::Config{}, Value{27000});
+
+    auto check_fieldset_checksum_stable_with_halo = [&](const util::Config& options_a, const util::Config& options_b) {
+        Field global_a = fs_h0.createField<Value>(option::name("global_a") | option::global(root) |
+                                                option::variables(2) | option::levels(3));
+        Field global_b = fs_h0.createField<Value>(option::name("global_b") | option::global(root) | option::variables(4));
+        if (mpi::comm().rank() == root) {
+            fill_global_field_and_expected_checksum<Value>(global_a);
+            fill_global_field_and_expected_checksum<Value>(global_b);
+        }
+
+        Field local_h0_a = fs_h0.createField<Value>(option::name("local_h0_a") | option::variables(2) | option::levels(3));
+        Field local_h0_b = fs_h0.createField<Value>(option::name("local_h0_b") | option::variables(4));
+        Field local_h2_a = fs_h2.createField<Value>(option::name("local_h2_a") | option::variables(2) | option::levels(3));
+        Field local_h2_b = fs_h2.createField<Value>(option::name("local_h2_b") | option::variables(4));
+
+        fs_h0.scatter(global_a, local_h0_a);
+        fs_h0.scatter(global_b, local_h0_b);
+        fs_h2.scatter(global_a, local_h2_a);
+        fs_h2.scatter(global_b, local_h2_b);
+
+        FieldSet fieldset_h0;
+        FieldSet fieldset_h2;
+        fieldset_h0.add(local_h0_a);
+        fieldset_h0.add(local_h0_b);
+        fieldset_h2.add(local_h2_a);
+        fieldset_h2.add(local_h2_b);
+        EXPECT_EQ(fs_h0.checksum(fieldset_h0), fs_h2.checksum(fieldset_h2));
+    };
+
+    check_fieldset_checksum_stable_with_halo(/*a*/ option::variables(2) | option::levels(3), /*b*/ option::variables(4));
+
+}
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}

--- a/src/tests/util/CMakeLists.txt
+++ b/src/tests/util/CMakeLists.txt
@@ -53,7 +53,7 @@ if( HAVE_FCTEST )
   )
 endif()
 
-foreach( test util earth flags polygon point )
+foreach( test util earth flags polygon point checksum )
   ecbuild_add_test( TARGET atlas_test_${test}
     SOURCES test_${test}.cc
     LIBS atlas

--- a/src/tests/util/test_checksum.cc
+++ b/src/tests/util/test_checksum.cc
@@ -1,0 +1,217 @@
+/*
+ * (C) Copyright 2013 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <vector>
+
+#include "atlas/util/Checksum.h"
+#include "tests/AtlasTestEnvironment.h"
+
+namespace atlas {
+namespace test {
+namespace {
+
+template <typename Value>
+util::checksum_t streamed_checksum(const std::vector<Value>& values, std::size_t split1, std::size_t split2) {
+    util::checksum_t checksum{};
+    util::checksum_reset(checksum);
+
+    util::checksum_update(checksum, values.data(), split1);
+    util::checksum_update(checksum, values.data() + split1, split2);
+    util::checksum_update(checksum, values.data() + split1 + split2, values.size() - split1 - split2);
+
+    return util::checksum_digest(checksum);
+}
+
+template <typename Value>
+void expect_streaming_matches_oneshot(const std::vector<Value>& values, std::size_t split1, std::size_t split2) {
+    EXPECT_EQ(util::checksum(values.data(), values.size()), streamed_checksum(values, split1, split2));
+}
+
+template <typename Value>
+void expect_zero_length_is_supported() {
+    std::vector<Value> values;
+
+    util::checksum_t checksum{};
+    util::checksum_reset(checksum);
+    util::checksum_update(checksum, values.data(), values.size());
+
+    EXPECT_EQ(util::checksum(values.data(), values.size()), 0ul);
+    EXPECT_EQ(util::checksum_digest(checksum), 0ul);
+}
+
+template <typename Value>
+void expect_strided_matches_selected(const std::vector<Value>& values, std::size_t count, std::size_t stride) {
+    std::vector<Value> selected(count);
+    for (std::size_t i = 0; i < count; ++i) {
+        selected[i] = values[i * stride];
+    }
+
+    util::checksum_t checksum{};
+    util::checksum_reset(checksum);
+    util::checksum_update(checksum, values.data(), count, stride);
+
+    EXPECT_EQ(util::checksum_digest(checksum), util::checksum(selected.data(), selected.size()));
+}
+
+template <typename Value>
+void expect_zero_length_strided_is_supported(const std::vector<Value>& values, std::size_t stride) {
+    util::checksum_t checksum{};
+    util::checksum_reset(checksum);
+    util::checksum_update(checksum, values.data(), 0, stride);
+    EXPECT_EQ(util::checksum_digest(checksum), 0ul);
+}
+}  // namespace
+
+CASE("checksum streaming matches one-shot for int") {
+    std::vector<int> values(257);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = static_cast<int>(i * 17 + 3);
+    }
+
+    expect_streaming_matches_oneshot(values, 13, 101);
+}
+
+CASE("checksum streaming matches one-shot for long") {
+    std::vector<long> values(129);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = static_cast<long>(i * 101 + 7);
+    }
+
+    expect_streaming_matches_oneshot(values, 17, 53);
+}
+
+CASE("checksum streaming matches one-shot for float") {
+    std::vector<float> values(73);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = 0.25f * static_cast<float>(i + 1) * static_cast<float>(i + 5);
+    }
+
+    expect_streaming_matches_oneshot(values, 11, 29);
+}
+
+CASE("checksum streaming matches one-shot for double") {
+    std::vector<double> values(37);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = 0.5 * static_cast<double>(i + 1) * static_cast<double>(i + 3);
+    }
+
+    expect_streaming_matches_oneshot(values, 5, 11);
+}
+
+CASE("checksum streaming matches one-shot for checksum_t") {
+    std::vector<util::checksum_t> values(19);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = static_cast<util::checksum_t>(i * 1009u + 11u);
+    }
+
+    expect_streaming_matches_oneshot(values, 4, 7);
+}
+
+CASE("checksum supports zero-length int input") {
+    expect_zero_length_is_supported<int>();
+}
+
+CASE("checksum supports zero-length long input") {
+    expect_zero_length_is_supported<long>();
+}
+
+CASE("checksum supports zero-length float input") {
+    expect_zero_length_is_supported<float>();
+}
+
+CASE("checksum supports zero-length double input") {
+    expect_zero_length_is_supported<double>();
+}
+
+CASE("checksum supports zero-length checksum_t input") {
+    expect_zero_length_is_supported<util::checksum_t>();
+}
+
+CASE("checksum strided update matches selected values for int") {
+    std::vector<int> values(300);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = static_cast<int>(i * 13 + 5);
+    }
+
+    expect_strided_matches_selected(values, 73, 3);
+    expect_strided_matches_selected(values, 100, 1);
+    expect_zero_length_strided_is_supported(values, 7);
+}
+
+CASE("checksum strided update matches selected values for long") {
+    std::vector<long> values(260);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = static_cast<long>(i * 71 + 17);
+    }
+
+    expect_strided_matches_selected(values, 52, 5);
+    expect_strided_matches_selected(values, 87, 1);
+    expect_zero_length_strided_is_supported(values, 9);
+}
+
+CASE("checksum strided update matches selected values for float") {
+    std::vector<float> values(210);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = 0.125f * static_cast<float>((i + 2) * (i + 7));
+    }
+
+    expect_strided_matches_selected(values, 42, 4);
+    expect_strided_matches_selected(values, 64, 1);
+    expect_zero_length_strided_is_supported(values, 11);
+}
+
+CASE("checksum strided update matches selected values for double") {
+    std::vector<double> values(205);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = 0.0625 * static_cast<double>((i + 3) * (i + 9));
+    }
+
+    expect_strided_matches_selected(values, 41, 5);
+    expect_strided_matches_selected(values, 70, 1);
+    expect_zero_length_strided_is_supported(values, 13);
+}
+
+CASE("checksum strided update matches selected values for checksum_t") {
+    std::vector<util::checksum_t> values(190);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = static_cast<util::checksum_t>(i * 4099u + 29u);
+    }
+
+    expect_strided_matches_selected(values, 38, 5);
+    expect_strided_matches_selected(values, 55, 1);
+    expect_zero_length_strided_is_supported(values, 15);
+}
+
+CASE("checksum reset clears state") {
+    std::vector<int> values(32);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = static_cast<int>(i * 9 + 1);
+    }
+
+    util::checksum_t checksum{};
+    util::checksum_reset(checksum);
+    util::checksum_update(checksum, values.data(), 10);
+    util::checksum_reset(checksum);
+    util::checksum_update(checksum, values.data(), values.size());
+
+    EXPECT_EQ(util::checksum_digest(checksum), util::checksum(values.data(), values.size()));
+}
+
+CASE ("test_vector") {
+    std::vector<int> int_vector = {1, 2};
+    EXPECT_EQ( util::checksum(int_vector.data(), int_vector.size()), 0x1003);
+}
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}


### PR DESCRIPTION
## Summary
- Add streaming functionality to util::checksum via util::checksum_update
- The new `util::checksum_update` also takes a stride argument for checksumming strided data.
- Add complete implementation for `BlockStructuredColumns::checksum()` on host.

## Why
The `BlockStructuredColumns::checksum` is crucial for debugging and verification

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-371
<!-- STATIC-ANALYSIS_END -->