### PR TITLE
Preserve field names in createField(Field)

### DIFF
--- a/src/atlas/functionspace/EdgeColumns.cc
+++ b/src/atlas/functionspace/EdgeColumns.cc
@@ -319,7 +319,7 @@ Field EdgeColumns::createField(const eckit::Configuration& options) const {
 }
 
 Field EdgeColumns::createField(const Field& other, const eckit::Configuration& config) const {
-    return createField(option::datatype(other.datatype()) | option::levels(other.levels()) |
+    return createField(option::name(other.name()) | option::datatype(other.datatype()) | option::levels(other.levels()) |
                        option::variables(other.variables()) | config);
 }
 

--- a/src/atlas/functionspace/PointCloud.cc
+++ b/src/atlas/functionspace/PointCloud.cc
@@ -550,7 +550,7 @@ Field PointCloud::createField(const eckit::Configuration& options) const {
 }
 
 Field PointCloud::createField(const Field& other, const eckit::Configuration& config) const {
-    return createField(option::datatype(other.datatype()) | option::levels(other.levels()) |
+    return createField(option::name(other.name()) |option::datatype(other.datatype()) | option::levels(other.levels()) |
                        option::variables(other.variables()) |
                        option::type(other.metadata().getString("type", "scalar")) | config);
 }

--- a/src/atlas/functionspace/Spectral.cc
+++ b/src/atlas/functionspace/Spectral.cc
@@ -254,7 +254,8 @@ Field Spectral::createField(const eckit::Configuration& options) const {
 }
 
 Field Spectral::createField(const Field& other, const eckit::Configuration& config) const {
-    return createField(option::datatype(other.datatype()) | option::levels(other.levels()) | config);
+    return createField(option::name(other.name()) | option::datatype(other.datatype()) | option::levels(other.levels()) |
+                       config);
 }
 
 void Spectral::gather(const FieldSet& local_fieldset, FieldSet& global_fieldset) const {

--- a/src/atlas/functionspace/detail/StructuredColumns.cc
+++ b/src/atlas/functionspace/detail/StructuredColumns.cc
@@ -580,7 +580,7 @@ Field StructuredColumns::createField(const eckit::Configuration& options) const 
 }
 
 Field StructuredColumns::createField(const Field& other, const eckit::Configuration& config) const {
-    return createField(option::datatype(other.datatype()) | option::levels(other.levels()) |
+    return createField(option::name(other.name()) | option::datatype(other.datatype()) | option::levels(other.levels()) |
                        option::variables(other.variables()) |
                        option::type(other.metadata().getString("type", "scalar")) | config);
 }

--- a/src/tests/functionspace/fctest_functionspace.F90
+++ b/src/tests/functionspace/fctest_functionspace.F90
@@ -774,7 +774,7 @@ template = field
 
 field = fs%create_field(template,global=.true.)
 FCTEST_CHECK_EQUAL( field%rank() , 2 )
-FCTEST_CHECK_EQUAL( field%name() , "" )
+FCTEST_CHECK_EQUAL( field%name() , "field" ) ! copied from template
 call field%final()
 
 field = fs%create_field(template,name="field",global=.true.)

--- a/src/tests/functionspace/test_functionspace.cc
+++ b/src/tests/functionspace/test_functionspace.cc
@@ -507,6 +507,64 @@ CASE("test_SpectralFunctionSpace") {
     EXPECT(columns_scalar.shape(1) == nb_levels);
 }
 
+CASE("test_createField_copy_preserves_name") {
+    auto expect_copy_preserves_name = [](const auto& fs, const std::string& name, const auto& options) {
+        Field source = fs.template createField<double>(option::name(name) | options);
+        Field copy   = fs.createField(source);
+
+        EXPECT(copy.name() == name);
+    };
+
+    SECTION("CellColumns") {
+        Mesh mesh = StructuredMeshGenerator().generate(Grid("O8"));
+        CellColumns cell_fs(mesh);
+
+        expect_copy_preserves_name(cell_fs, "cell-source", option::levels(2) | option::variables(3));
+    }
+
+    SECTION("EdgeColumns") {
+        Mesh mesh = StructuredMeshGenerator().generate(Grid("O8"));
+        EdgeColumns edge_fs(mesh);
+
+        expect_copy_preserves_name(edge_fs, "edge-source", option::levels(2) | option::variables(3));
+    }
+
+    SECTION("NodeColumns") {
+        Mesh mesh = StructuredMeshGenerator().generate(Grid("O8"));
+        NodeColumns node_fs(mesh);
+
+        expect_copy_preserves_name(node_fs, "node-source", option::levels(2) | option::variables(3));
+    }
+
+    SECTION("PointCloud") {
+        Grid grid("O8");
+        PointCloud pointcloud_fs(grid);
+
+        expect_copy_preserves_name(pointcloud_fs, "pointcloud-source", option::levels(2) | option::variables(3));
+    }
+
+    SECTION("StructuredColumns") {
+        StructuredGrid grid("O8");
+        StructuredColumns structured_fs(grid, option::levels(2));
+
+        expect_copy_preserves_name(structured_fs, "structured-source", option::levels(2) | option::variables(3));
+    }
+
+    SECTION("BlockStructuredColumns") {
+        StructuredGrid grid("O8");
+        BlockStructuredColumns blockstructured_fs(grid, option::levels(2) | option::nproma(4));
+
+        expect_copy_preserves_name(blockstructured_fs, "blockstructured-source",
+                                   option::levels(2) | option::variables(3));
+    }
+
+    SECTION("Spectral") {
+        Spectral spectral_fs(159);
+
+        expect_copy_preserves_name(spectral_fs, "spectral-source", option::levels(2));
+    }
+}
+
 #if ATLAS_HAVE_TRANS
 
 CASE("test_SpectralFunctionSpace_trans_dist") {


### PR DESCRIPTION
## Summary
Copy field names when creating new fields from existing fields in `PointCloud` and `StructuredColumns`.

## Why
This preserves field identity across `createField(Field)` calls and avoids dropping metadata that callers expect to remain intact.

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-372
<!-- STATIC-ANALYSIS_END -->