### PR TITLE
Add Fortran FieldSet shape API and fast paths

### DIFF
--- a/src/atlas/field/FieldSet.cc
+++ b/src/atlas/field/FieldSet.cc
@@ -375,6 +375,14 @@ void FieldSetImpl::syncDevice(std::initializer_list<int> findices) const {
 // C wrapper interfaces to C++ routines
 extern "C" {
 
+void atlas__FieldSet__shapef(FieldSetImpl* This, char* name, int*& shape, int& rank) {
+    atlas__Field__shapef(This->field(name).get(), shape, rank);
+}
+
+void atlas__FieldSet__shapef_by_idx(FieldSetImpl* This, int& idx, int*& shape, int& rank) {
+    atlas__Field__shapef(This->operator[](idx).get(), shape, rank);
+}
+
 void atlas__FieldSet__data_int_specf(FieldSetImpl* This, char* name, int*& data, int& rank, int*& shapef, int*& stridesf) {
     atlas__Field__data_int_specf(This->field(name).get(), data, rank, shapef, stridesf);
 }
@@ -405,6 +413,156 @@ void atlas__FieldSet__data_float_specf_by_idx(FieldSetImpl* This, int& idx, floa
 
 void atlas__FieldSet__data_double_specf_by_idx(FieldSetImpl* This, int& idx, double*& data, int& rank, int*& shapef, int*& stridesf) {
     atlas__Field__data_double_specf(This->operator[](idx).get(), data, rank, shapef, stridesf);
+}
+
+void atlas__FieldSet__device_data_int_specf(FieldSetImpl* This, char* name, int*& data, int& rank, int*& shapef,
+                                            int*& stridesf) {
+    atlas__Field__device_data_int_specf(This->field(name).get(), data, rank, shapef, stridesf);
+}
+
+void atlas__FieldSet__device_data_long_specf(FieldSetImpl* This, char* name, long*& data, int& rank, int*& shapef,
+                                             int*& stridesf) {
+    atlas__Field__device_data_long_specf(This->field(name).get(), data, rank, shapef, stridesf);
+}
+
+void atlas__FieldSet__device_data_float_specf(FieldSetImpl* This, char* name, float*& data, int& rank, int*& shapef,
+                                              int*& stridesf) {
+    atlas__Field__device_data_float_specf(This->field(name).get(), data, rank, shapef, stridesf);
+}
+
+void atlas__FieldSet__device_data_double_specf(FieldSetImpl* This, char* name, double*& data, int& rank,
+                                               int*& shapef, int*& stridesf) {
+    atlas__Field__device_data_double_specf(This->field(name).get(), data, rank, shapef, stridesf);
+}
+
+void atlas__FieldSet__device_data_int_specf_by_idx(FieldSetImpl* This, int& idx, int*& data, int& rank,
+                                                   int*& shapef, int*& stridesf) {
+    atlas__Field__device_data_int_specf(This->operator[](idx).get(), data, rank, shapef, stridesf);
+}
+
+void atlas__FieldSet__device_data_long_specf_by_idx(FieldSetImpl* This, int& idx, long*& data, int& rank,
+                                                    int*& shapef, int*& stridesf) {
+    atlas__Field__device_data_long_specf(This->operator[](idx).get(), data, rank, shapef, stridesf);
+}
+
+void atlas__FieldSet__device_data_float_specf_by_idx(FieldSetImpl* This, int& idx, float*& data, int& rank,
+                                                     int*& shapef, int*& stridesf) {
+    atlas__Field__device_data_float_specf(This->operator[](idx).get(), data, rank, shapef, stridesf);
+}
+
+void atlas__FieldSet__device_data_double_specf_by_idx(FieldSetImpl* This, int& idx, double*& data, int& rank,
+                                                      int*& shapef, int*& stridesf) {
+    atlas__Field__device_data_double_specf(This->operator[](idx).get(), data, rank, shapef, stridesf);
+}
+
+void atlas__FieldSet__set_host_needs_update(FieldSetImpl* This, int value) {
+    This->setHostNeedsUpdate(value);
+}
+
+void atlas__FieldSet__set_host_needs_update_name(FieldSetImpl* This, char* name, int value) {
+    This->field(name).setHostNeedsUpdate(value);
+}
+
+void atlas__FieldSet__set_host_needs_update_by_idx(FieldSetImpl* This, int& idx, int value) {
+    This->operator[](idx).setHostNeedsUpdate(value);
+}
+
+void atlas__FieldSet__set_device_needs_update(FieldSetImpl* This, int value) {
+    This->setDeviceNeedsUpdate(value);
+}
+
+void atlas__FieldSet__set_device_needs_update_name(FieldSetImpl* This, char* name, int value) {
+    This->field(name).setDeviceNeedsUpdate(value);
+}
+
+void atlas__FieldSet__set_device_needs_update_by_idx(FieldSetImpl* This, int& idx, int value) {
+    This->operator[](idx).setDeviceNeedsUpdate(value);
+}
+
+void atlas__FieldSet__sync_host_device(FieldSetImpl* This) {
+    for (auto field : *This) {
+        field.syncHostDevice();
+    }
+}
+
+void atlas__FieldSet__sync_host_device_name(FieldSetImpl* This, char* name) {
+    This->field(name).syncHostDevice();
+}
+
+void atlas__FieldSet__sync_host_device_by_idx(FieldSetImpl* This, int& idx) {
+    This->operator[](idx).syncHostDevice();
+}
+
+void atlas__FieldSet__sync_host(FieldSetImpl* This) {
+    This->syncHost();
+}
+
+void atlas__FieldSet__sync_host_name(FieldSetImpl* This, char* name) {
+    This->field(name).syncHost();
+}
+
+void atlas__FieldSet__sync_host_by_idx(FieldSetImpl* This, int& idx) {
+    This->operator[](idx).syncHost();
+}
+
+void atlas__FieldSet__sync_device(FieldSetImpl* This) {
+    This->syncDevice();
+}
+
+void atlas__FieldSet__sync_device_name(FieldSetImpl* This, char* name) {
+    This->field(name).syncDevice();
+}
+
+void atlas__FieldSet__sync_device_by_idx(FieldSetImpl* This, int& idx) {
+    This->operator[](idx).syncDevice();
+}
+
+void atlas__FieldSet__allocate_device(FieldSetImpl* This) {
+    This->allocateDevice();
+}
+
+void atlas__FieldSet__allocate_device_name(FieldSetImpl* This, char* name) {
+    This->field(name).allocateDevice();
+}
+
+void atlas__FieldSet__allocate_device_by_idx(FieldSetImpl* This, int& idx) {
+    This->operator[](idx).allocateDevice();
+}
+
+void atlas__FieldSet__update_device(FieldSetImpl* This) {
+    This->updateDevice();
+}
+
+void atlas__FieldSet__update_device_name(FieldSetImpl* This, char* name) {
+    This->field(name).updateDevice();
+}
+
+void atlas__FieldSet__update_device_by_idx(FieldSetImpl* This, int& idx) {
+    This->operator[](idx).updateDevice();
+}
+
+void atlas__FieldSet__update_host(FieldSetImpl* This) {
+    This->updateHost();
+}
+
+void atlas__FieldSet__update_host_name(FieldSetImpl* This, char* name) {
+    This->field(name).updateHost();
+}
+
+void atlas__FieldSet__update_host_by_idx(FieldSetImpl* This, int& idx) {
+    This->operator[](idx).updateHost();
+}
+
+void atlas__FieldSet__deallocate_device(FieldSetImpl* This) {
+    This->deallocateDevice();
+}
+
+void atlas__FieldSet__deallocate_device_name(FieldSetImpl* This, char* name) {
+    This->field(name).deallocateDevice();
+}
+
+void atlas__FieldSet__deallocate_device_by_idx(FieldSetImpl* This, int& idx) {
+    This->operator[](idx).deallocateDevice();
 }
 
 

--- a/src/atlas/field/FieldSet.h
+++ b/src/atlas/field/FieldSet.h
@@ -193,6 +193,8 @@ const char* atlas__FieldSet__name(FieldSetImpl* This);
 idx_t atlas__FieldSet__size(const FieldSetImpl* This);
 FieldImpl* atlas__FieldSet__field_by_name(FieldSetImpl* This, char* name);
 FieldImpl* atlas__FieldSet__field_by_idx(FieldSetImpl* This, idx_t idx);
+void atlas__FieldSet__shapef(FieldSetImpl* This, char* name, int*& shape, int& rank);
+void atlas__FieldSet__shapef_by_idx(FieldSetImpl* This, int& idx, int*& shape, int& rank);
 void atlas__FieldSet__data_int_specf(FieldSetImpl* This, char* name, int*& field_data, int& rank, int*& field_shapef,
                                   int*& field_stridesf);
 void atlas__FieldSet__data_long_specf(FieldSetImpl* This, char* name, long*& field_data, int& rank, int*& field_shapef,
@@ -209,6 +211,49 @@ void atlas__FieldSet__data_float_specf_by_idx(FieldSetImpl* This, int& idx, floa
                                     int*& field_stridesf);
 void atlas__FieldSet__data_double_specf_by_idx(FieldSetImpl* This, int& idx, double*& field_data, int& rank, int*& field_shapef,
                                      int*& field_stridesf);
+void atlas__FieldSet__device_data_int_specf(FieldSetImpl* This, char* name, int*& field_data, int& rank,
+                                            int*& field_shapef, int*& field_stridesf);
+void atlas__FieldSet__device_data_long_specf(FieldSetImpl* This, char* name, long*& field_data, int& rank,
+                                             int*& field_shapef, int*& field_stridesf);
+void atlas__FieldSet__device_data_float_specf(FieldSetImpl* This, char* name, float*& field_data, int& rank,
+                                              int*& field_shapef, int*& field_stridesf);
+void atlas__FieldSet__device_data_double_specf(FieldSetImpl* This, char* name, double*& field_data, int& rank,
+                                               int*& field_shapef, int*& field_stridesf);
+void atlas__FieldSet__device_data_int_specf_by_idx(FieldSetImpl* This, int& idx, int*& field_data, int& rank,
+                                                   int*& field_shapef, int*& field_stridesf);
+void atlas__FieldSet__device_data_long_specf_by_idx(FieldSetImpl* This, int& idx, long*& field_data, int& rank,
+                                                    int*& field_shapef, int*& field_stridesf);
+void atlas__FieldSet__device_data_float_specf_by_idx(FieldSetImpl* This, int& idx, float*& field_data, int& rank,
+                                                     int*& field_shapef, int*& field_stridesf);
+void atlas__FieldSet__device_data_double_specf_by_idx(FieldSetImpl* This, int& idx, double*& field_data, int& rank,
+                                                      int*& field_shapef, int*& field_stridesf);
+void atlas__FieldSet__set_host_needs_update(FieldSetImpl* This, int value);
+void atlas__FieldSet__set_host_needs_update_name(FieldSetImpl* This, char* name, int value);
+void atlas__FieldSet__set_host_needs_update_by_idx(FieldSetImpl* This, int& idx, int value);
+void atlas__FieldSet__set_device_needs_update(FieldSetImpl* This, int value);
+void atlas__FieldSet__set_device_needs_update_name(FieldSetImpl* This, char* name, int value);
+void atlas__FieldSet__set_device_needs_update_by_idx(FieldSetImpl* This, int& idx, int value);
+void atlas__FieldSet__sync_host_device(FieldSetImpl* This);
+void atlas__FieldSet__sync_host_device_name(FieldSetImpl* This, char* name);
+void atlas__FieldSet__sync_host_device_by_idx(FieldSetImpl* This, int& idx);
+void atlas__FieldSet__sync_host(FieldSetImpl* This);
+void atlas__FieldSet__sync_host_name(FieldSetImpl* This, char* name);
+void atlas__FieldSet__sync_host_by_idx(FieldSetImpl* This, int& idx);
+void atlas__FieldSet__sync_device(FieldSetImpl* This);
+void atlas__FieldSet__sync_device_name(FieldSetImpl* This, char* name);
+void atlas__FieldSet__sync_device_by_idx(FieldSetImpl* This, int& idx);
+void atlas__FieldSet__allocate_device(FieldSetImpl* This);
+void atlas__FieldSet__allocate_device_name(FieldSetImpl* This, char* name);
+void atlas__FieldSet__allocate_device_by_idx(FieldSetImpl* This, int& idx);
+void atlas__FieldSet__update_device(FieldSetImpl* This);
+void atlas__FieldSet__update_device_name(FieldSetImpl* This, char* name);
+void atlas__FieldSet__update_device_by_idx(FieldSetImpl* This, int& idx);
+void atlas__FieldSet__update_host(FieldSetImpl* This);
+void atlas__FieldSet__update_host_name(FieldSetImpl* This, char* name);
+void atlas__FieldSet__update_host_by_idx(FieldSetImpl* This, int& idx);
+void atlas__FieldSet__deallocate_device(FieldSetImpl* This);
+void atlas__FieldSet__deallocate_device_name(FieldSetImpl* This, char* name);
+void atlas__FieldSet__deallocate_device_by_idx(FieldSetImpl* This, int& idx);
 void atlas__FieldSet__set_dirty(FieldSetImpl* This, int value);
 void atlas__FieldSet__halo_exchange(FieldSetImpl* This, int on_device);
 }

--- a/src/atlas_f/field/atlas_FieldSet_module.fypp
+++ b/src/atlas_f/field/atlas_FieldSet_module.fypp
@@ -227,8 +227,7 @@ end subroutine
 
 subroutine access_device_data_${dtype}$_r${rank}$_by_name(this, name, field)
   use fckit_c_interop_module, only: c_str
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
   use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_long, c_float, c_double
   class(atlas_FieldSet), intent(in) :: this
   character(len=*), intent(in) :: name
@@ -237,18 +236,14 @@ subroutine access_device_data_${dtype}$_r${rank}$_by_name(this, name, field)
   type(c_ptr) :: shape_cptr
   type(c_ptr) :: strides_cptr
   integer(c_int) :: rank
-  type(atlas_Field) :: field_sel
-  field_sel = this%field(name)
-  call atlas__Field__device_data_${ctype}$_specf(field_sel%CPTR_PGIBUG_A, field_cptr, rank, shape_cptr, strides_cptr)
+  call atlas__FieldSet__device_data_${ctype}$_specf(this%CPTR_PGIBUG_A, c_str(name), field_cptr, rank, shape_cptr, strides_cptr)
   call array_c_to_f(field_cptr, rank, shape_cptr, strides_cptr, field)
 end subroutine
 
 !-------------------------------------------------------------------------------
 
 subroutine access_device_data_${dtype}$_r${rank}$_by_idx(this, idx, field)
-  use fckit_c_interop_module, only: c_str
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
   use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_long, c_float, c_double
   class(atlas_FieldSet), intent(in) :: this
   integer, intent(in) :: idx
@@ -257,9 +252,7 @@ subroutine access_device_data_${dtype}$_r${rank}$_by_idx(this, idx, field)
   type(c_ptr) :: shape_cptr
   type(c_ptr) :: strides_cptr
   integer(c_int) :: rank
-  type(atlas_Field) :: field_loc
-  field_loc = this%field(idx)
-  call atlas__Field__device_data_${ctype}$_specf(field_loc%CPTR_PGIBUG_A, field_cptr, rank, shape_cptr, strides_cptr)
+  call atlas__FieldSet__device_data_${ctype}$_specf_by_idx(this%CPTR_PGIBUG_A, idx-1, field_cptr, rank, shape_cptr, strides_cptr)
   call array_c_to_f(field_cptr, rank, shape_cptr, strides_cptr, field)
 end subroutine
 
@@ -381,50 +374,74 @@ end function
 !-------------------------------------------------------------------------------
 
 function shape_array_by_name(this, name) result(shape)
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
+  use fckit_c_interop_module, only: c_str
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_f_pointer
   class(atlas_FieldSet), intent(in) :: this
   character(len=*), intent(in) :: name
   integer, allocatable :: shape(:)
-  type(atlas_Field) :: field
-  field = this%field(name)
-  shape = field%shape()
+  type(c_ptr) :: shape_c_ptr
+  integer, pointer :: shape_f_ptr(:)
+  integer(c_int) :: field_rank
+  call atlas__FieldSet__shapef(this%CPTR_PGIBUG_A, c_str(name), shape_c_ptr, field_rank)
+  call c_f_pointer ( shape_c_ptr , shape_f_ptr , (/field_rank/) )
+  allocate( shape(field_rank) )
+  shape(:) = shape_f_ptr(:)
 end function
 
 !-------------------------------------------------------------------------------
 
 function shape_idx_by_name(this, name, dim_idx) result(shape_val)
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
+  use fckit_c_interop_module, only: c_str
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_f_pointer
+  @:ENABLE_ATLAS_MACROS()
   class(atlas_FieldSet), intent(in) :: this
   character(len=*), intent(in) :: name
   integer, intent(in) :: dim_idx
   integer :: shape_val
-  type(atlas_Field) :: field
-  field = this%field(name)
-  shape_val = field%shape(dim_idx)
+  type(c_ptr) :: shape_c_ptr
+  integer, pointer :: shape_f_ptr(:)
+  integer(c_int) :: field_rank
+  call atlas__FieldSet__shapef(this%CPTR_PGIBUG_A, c_str(name), shape_c_ptr, field_rank)
+  call c_f_pointer ( shape_c_ptr , shape_f_ptr , (/field_rank/) )
+  @:ATLAS_ASSERT( dim_idx <= field_rank )
+  shape_val = shape_f_ptr(dim_idx)
 end function
 
 !-------------------------------------------------------------------------------
 
 function shape_array_by_idx(this, idx) result(shape)
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_f_pointer
   class(atlas_FieldSet), intent(in) :: this
   integer, intent(in) :: idx
   integer, allocatable :: shape(:)
-  type(atlas_Field) :: field
-  field = this%field(idx)
-  shape = field%shape()
+  type(c_ptr) :: shape_c_ptr
+  integer, pointer :: shape_f_ptr(:)
+  integer(c_int) :: field_rank
+  call atlas__FieldSet__shapef_by_idx(this%CPTR_PGIBUG_A, idx-1, shape_c_ptr, field_rank)
+  call c_f_pointer ( shape_c_ptr , shape_f_ptr , (/field_rank/) )
+  allocate( shape(field_rank) )
+  shape(:) = shape_f_ptr(:)
 end function
 
 !-------------------------------------------------------------------------------
 
 function shape_idx_by_idx(this, idx, dim_idx) result(shape_val)
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_f_pointer
+  @:ENABLE_ATLAS_MACROS()
   class(atlas_FieldSet), intent(in) :: this
   integer, intent(in) :: idx, dim_idx
   integer :: shape_val
-  type(atlas_Field) :: field
-  field = this%field(idx)
-  shape_val = field%shape(dim_idx)
+  type(c_ptr) :: shape_c_ptr
+  integer, pointer :: shape_f_ptr(:)
+  integer(c_int) :: field_rank
+  call atlas__FieldSet__shapef_by_idx(this%CPTR_PGIBUG_A, idx-1, shape_c_ptr, field_rank)
+  call c_f_pointer ( shape_c_ptr , shape_f_ptr , (/field_rank/) )
+  @:ATLAS_ASSERT( dim_idx <= field_rank )
+  shape_val = shape_f_ptr(dim_idx)
 end function
 
 !-------------------------------------------------------------------------------
@@ -446,34 +463,27 @@ end subroutine
 
 subroutine set_host_needs_update_value(this, value)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
   class(atlas_FieldSet), intent(inout) :: this
   logical, intent(in), optional :: value
-  type(atlas_Field) :: field
-  integer(c_int) :: i, value_int
+  integer(c_int) :: value_int
   value_int = 1
   if (present(value)) then
     if (.not. value) then
       value_int = 0
     end if
   end if
-  do i = 1, this%size()
-    field = this%field(i)
-    call atlas__Field__set_host_needs_update(field%CPTR_PGIBUG_A, value_int)
-  end do
+  call atlas__FieldSet__set_host_needs_update(this%CPTR_PGIBUG_A, value_int)
 end subroutine
 
 !-------------------------------------------------------------------------------
 
 subroutine set_host_needs_update_idx(this, field_indices, value)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
   class(atlas_FieldSet), intent(inout) :: this
   integer, intent(in) :: field_indices(:)
   logical, intent(in), optional :: value
-  type(atlas_Field) :: field
   integer(c_int) :: i, value_int
   value_int = 1
   if (present(value)) then
@@ -482,8 +492,7 @@ subroutine set_host_needs_update_idx(this, field_indices, value)
     end if
   end if
   do i = 1, size(field_indices)
-    field = this%field(field_indices(i))
-    call atlas__Field__set_host_needs_update(field%CPTR_PGIBUG_A, value_int)
+    call atlas__FieldSet__set_host_needs_update_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1, value_int)
   end do
 end subroutine
 
@@ -491,12 +500,11 @@ end subroutine
 
 subroutine set_host_needs_update_name(this, field_names, value)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
+  use fckit_c_interop_module, only: c_str
   class(atlas_FieldSet), intent(inout) :: this
   character(*), intent(in) :: field_names(:)
   logical, intent(in), optional :: value
-  type(atlas_Field) :: field
   integer(c_int) :: i, value_int
   value_int = 1
   if (present(value)) then
@@ -505,8 +513,7 @@ subroutine set_host_needs_update_name(this, field_names, value)
     end if
   end if
   do i = 1, size(field_names)
-    field = this%field(field_names(i))
-    call atlas__Field__set_host_needs_update(field%CPTR_PGIBUG_A, value_int)
+    call atlas__FieldSet__set_host_needs_update_name(this%CPTR_PGIBUG_A, c_str(field_names(i)), value_int)
   end do
 end subroutine
 
@@ -514,34 +521,27 @@ end subroutine
 
 subroutine set_device_needs_update_value(this, value)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
   class(atlas_FieldSet), intent(inout) :: this
   logical, intent(in), optional :: value
-  type(atlas_Field) :: field
-  integer(c_int) :: i, value_int
+  integer(c_int) :: value_int
   value_int = 1
   if (present(value)) then
     if (.not. value) then
       value_int = 0
     end if
   end if
-  do i = 1, this%size()
-    field = this%field(i)
-    call atlas__Field__set_device_needs_update(field%CPTR_PGIBUG_A, value_int)
-  end do
+  call atlas__FieldSet__set_device_needs_update(this%CPTR_PGIBUG_A, value_int)
 end subroutine
 
 !-------------------------------------------------------------------------------
 
 subroutine set_device_needs_update_idx(this, field_indices, value)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
   class(atlas_FieldSet), intent(inout) :: this
   integer, intent(in) :: field_indices(:)
   logical, intent(in), optional :: value
-  type(atlas_Field) :: field
   integer(c_int) :: i, value_int
   value_int = 1
   if (present(value)) then
@@ -550,8 +550,7 @@ subroutine set_device_needs_update_idx(this, field_indices, value)
     end if
   end if
   do i = 1, size(field_indices)
-    field = this%field(field_indices(i))
-    call atlas__Field__set_device_needs_update(field%CPTR_PGIBUG_A, value_int)
+    call atlas__FieldSet__set_device_needs_update_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1, value_int)
   end do
 end subroutine
 
@@ -559,12 +558,11 @@ end subroutine
 
 subroutine set_device_needs_update_name(this, field_names, value)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
+  use fckit_c_interop_module, only: c_str
   class(atlas_FieldSet), intent(inout) :: this
   character(*), intent(in) :: field_names(:)
   logical, intent(in), optional :: value
-  type(atlas_Field) :: field
   integer(c_int) :: i, value_int
   value_int = 1
   if (present(value)) then
@@ -573,8 +571,7 @@ subroutine set_device_needs_update_name(this, field_names, value)
     end if
   end if
   do i = 1, size(field_names)
-    field = this%field(field_names(i))
-    call atlas__Field__set_device_needs_update(field%CPTR_PGIBUG_A, value_int)
+    call atlas__FieldSet__set_device_needs_update_name(this%CPTR_PGIBUG_A, c_str(field_names(i)), value_int)
   end do
 end subroutine
 
@@ -582,22 +579,16 @@ end subroutine
 
 subroutine sync_host_device_idx(this, field_indices)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
   class(atlas_FieldSet), intent(inout) :: this
   integer, intent(in), optional :: field_indices(:)
-  type(atlas_Field) :: field
   integer(c_int) :: i
   if (present(field_indices)) then
     do i = 1, size(field_indices)
-      field = this%field(field_indices(i))
-      call atlas__Field__sync_host_device(field%CPTR_PGIBUG_A)
+      call atlas__FieldSet__sync_host_device_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1)
     end do
   else
-    do i = 1, this%size()
-      field = this%field(i)
-      call atlas__Field__sync_host_device(field%CPTR_PGIBUG_A)
-    end do
+    call atlas__FieldSet__sync_host_device(this%CPTR_PGIBUG_A)
   end if
 end subroutine
 
@@ -605,15 +596,13 @@ end subroutine
 
 subroutine sync_host_device_name(this, field_names)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
+  use fckit_c_interop_module, only: c_str
   class(atlas_FieldSet), intent(inout) :: this
   character(*), intent(in) :: field_names(:)
-  type(atlas_Field) :: field
   integer(c_int) :: i
   do i = 1, size(field_names)
-    field = this%field(field_names(i))
-    call atlas__Field__sync_host_device(field%CPTR_PGIBUG_A)
+    call atlas__FieldSet__sync_host_device_name(this%CPTR_PGIBUG_A, c_str(field_names(i)))
   end do
 end subroutine
 
@@ -621,22 +610,16 @@ end subroutine
 
 subroutine sync_host_idx(this, field_indices)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
   class(atlas_FieldSet), intent(inout) :: this
   integer, intent(in), optional :: field_indices(:)
-  type(atlas_Field) :: field
   integer(c_int) :: i
   if (present(field_indices)) then
     do i = 1, size(field_indices)
-      field = this%field(field_indices(i))
-      call atlas__Field__sync_host(field%CPTR_PGIBUG_A)
+      call atlas__FieldSet__sync_host_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1)
     end do
   else
-    do i = 1, this%size()
-      field = this%field(i)
-      call atlas__Field__sync_host(field%CPTR_PGIBUG_A)
-    end do
+    call atlas__FieldSet__sync_host(this%CPTR_PGIBUG_A)
   end if
 end subroutine
 
@@ -644,15 +627,13 @@ end subroutine
 
 subroutine sync_host_name(this, field_names)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
+  use fckit_c_interop_module, only: c_str
   class(atlas_FieldSet), intent(inout) :: this
   character(*), intent(in) :: field_names(:)
-  type(atlas_Field) :: field
   integer(c_int) :: i
   do i = 1, size(field_names)
-    field = this%field(field_names(i))
-    call atlas__Field__sync_host(field%CPTR_PGIBUG_A)
+    call atlas__FieldSet__sync_host_name(this%CPTR_PGIBUG_A, c_str(field_names(i)))
   end do
 end subroutine
 
@@ -660,22 +641,16 @@ end subroutine
 
 subroutine sync_device_idx(this, field_indices)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
   class(atlas_FieldSet), intent(inout) :: this
   integer, intent(in), optional :: field_indices(:)
-  type(atlas_Field) :: field
   integer(c_int) :: i
   if (present(field_indices)) then
     do i = 1, size(field_indices)
-      field = this%field(field_indices(i))
-      call atlas__Field__sync_device(field%CPTR_PGIBUG_A)
+      call atlas__FieldSet__sync_device_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1)
     end do
   else
-    do i = 1, this%size()
-      field = this%field(i)
-      call atlas__Field__sync_device(field%CPTR_PGIBUG_A)
-    end do
+    call atlas__FieldSet__sync_device(this%CPTR_PGIBUG_A)
   end if
 end subroutine
 
@@ -683,15 +658,13 @@ end subroutine
 
 subroutine sync_device_name(this, field_names)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
+  use fckit_c_interop_module, only: c_str
   class(atlas_FieldSet), intent(inout) :: this
   character(*), intent(in) :: field_names(:)
-  type(atlas_Field) :: field
   integer(c_int) :: i
   do i = 1, size(field_names)
-    field = this%field(field_names(i))
-    call atlas__Field__sync_device(field%CPTR_PGIBUG_A)
+    call atlas__FieldSet__sync_device_name(this%CPTR_PGIBUG_A, c_str(field_names(i)))
   end do
 end subroutine
 
@@ -699,22 +672,16 @@ end subroutine
 
 subroutine allocate_device_idx(this, field_indices)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
   class(atlas_FieldSet), intent(inout) :: this
   integer, intent(in), optional :: field_indices(:)
-  type(atlas_Field) :: field
   integer(c_int) :: i
   if (present(field_indices)) then
     do i = 1, size(field_indices)
-      field = this%field(field_indices(i))
-      call atlas__Field__allocate_device(field%CPTR_PGIBUG_A)
+      call atlas__FieldSet__allocate_device_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1)
     end do
   else
-    do i = 1, this%size()
-      field = this%field(i)
-      call atlas__Field__allocate_device(field%CPTR_PGIBUG_A)
-    end do
+    call atlas__FieldSet__allocate_device(this%CPTR_PGIBUG_A)
   end if
 end subroutine
 
@@ -722,15 +689,13 @@ end subroutine
 
 subroutine allocate_device_name(this, field_names)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
+  use fckit_c_interop_module, only: c_str
   class(atlas_FieldSet), intent(inout) :: this
   character(*), intent(in) :: field_names(:)
-  type(atlas_Field) :: field
   integer(c_int) :: i
   do i = 1, size(field_names)
-    field = this%field(field_names(i))
-    call atlas__Field__allocate_device(field%CPTR_PGIBUG_A)
+    call atlas__FieldSet__allocate_device_name(this%CPTR_PGIBUG_A, c_str(field_names(i)))
   end do
 end subroutine
 
@@ -738,22 +703,16 @@ end subroutine
 
 subroutine update_device_idx(this, field_indices)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
   class(atlas_FieldSet), intent(inout) :: this
   integer, intent(in), optional :: field_indices(:)
-  type(atlas_Field) :: field
   integer(c_int) :: i
   if (present(field_indices)) then
     do i = 1, size(field_indices)
-      field = this%field(field_indices(i))
-      call atlas__Field__update_device(field%CPTR_PGIBUG_A)
+      call atlas__FieldSet__update_device_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1)
     end do
   else
-    do i = 1, this%size()
-      field = this%field(i)
-      call atlas__Field__update_device(field%CPTR_PGIBUG_A)
-    end do
+    call atlas__FieldSet__update_device(this%CPTR_PGIBUG_A)
   end if
 end subroutine
 
@@ -761,15 +720,13 @@ end subroutine
 
 subroutine update_device_name(this, field_names)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
+  use fckit_c_interop_module, only: c_str
   class(atlas_FieldSet), intent(inout) :: this
   character(*), intent(in) :: field_names(:)
-  type(atlas_Field) :: field
   integer(c_int) :: i
   do i = 1, size(field_names)
-    field = this%field(field_names(i))
-    call atlas__Field__update_device(field%CPTR_PGIBUG_A)
+    call atlas__FieldSet__update_device_name(this%CPTR_PGIBUG_A, c_str(field_names(i)))
   end do
 end subroutine
 
@@ -777,22 +734,16 @@ end subroutine
 
 subroutine update_host_idx(this, field_indices)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
   class(atlas_FieldSet), intent(inout) :: this
   integer, intent(in), optional :: field_indices(:)
-  type(atlas_Field) :: field
   integer(c_int) :: i
   if (present(field_indices)) then
     do i = 1, size(field_indices)
-      field = this%field(field_indices(i))
-      call atlas__Field__update_host(field%CPTR_PGIBUG_A)
+      call atlas__FieldSet__update_host_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1)
     end do
   else
-    do i = 1, this%size()
-      field = this%field(i)
-      call atlas__Field__update_host(field%CPTR_PGIBUG_A)
-    end do
+    call atlas__FieldSet__update_host(this%CPTR_PGIBUG_A)
   end if
 end subroutine
 
@@ -800,15 +751,13 @@ end subroutine
 
 subroutine update_host_name(this, field_names)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
+  use fckit_c_interop_module, only: c_str
   class(atlas_FieldSet), intent(inout) :: this
   character(*), intent(in) :: field_names(:)
-  type(atlas_Field) :: field
   integer(c_int) :: i
   do i = 1, size(field_names)
-    field = this%field(field_names(i))
-    call atlas__Field__update_host(field%CPTR_PGIBUG_A)
+    call atlas__FieldSet__update_host_name(this%CPTR_PGIBUG_A, c_str(field_names(i)))
   end do
 end subroutine
 
@@ -816,22 +765,16 @@ end subroutine
 
 subroutine deallocate_device_idx(this, field_indices)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
   class(atlas_FieldSet), intent(inout) :: this
   integer, optional :: field_indices(:)
-  type(atlas_Field) :: field
   integer(c_int) :: i
   if (present(field_indices)) then
     do i = 1, size(field_indices)
-      field = this%field(field_indices(i))
-      call atlas__Field__deallocate_device(field%CPTR_PGIBUG_A)
+      call atlas__FieldSet__deallocate_device_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1)
     end do
   else
-    do i = 1, this%size()
-      field = this%field(i)
-      call atlas__Field__deallocate_device(field%CPTR_PGIBUG_A)
-    end do
+    call atlas__FieldSet__deallocate_device(this%CPTR_PGIBUG_A)
   end if
 end subroutine
 
@@ -839,15 +782,13 @@ end subroutine
 
 subroutine deallocate_device_name(this, field_names)
   use, intrinsic :: iso_c_binding, only : c_int
-  use atlas_field_c_binding
-  use atlas_Field_module, only: atlas_Field
+  use atlas_fieldset_c_binding
+  use fckit_c_interop_module, only: c_str
   class(atlas_FieldSet), intent(inout) :: this
   character(*), intent(in) :: field_names(:)
-  type(atlas_Field) :: field
   integer(c_int) :: i
   do i = 1, size(field_names)
-    field = this%field(field_names(i))
-    call atlas__Field__deallocate_device(field%CPTR_PGIBUG_A)
+    call atlas__FieldSet__deallocate_device_name(this%CPTR_PGIBUG_A, c_str(field_names(i)))
   end do
 end subroutine
 

--- a/src/atlas_f/field/atlas_FieldSet_module.fypp
+++ b/src/atlas_f/field/atlas_FieldSet_module.fypp
@@ -56,6 +56,12 @@ contains
   generic :: add => add_field, add_fieldset
   generic :: field => field_by_name, field_by_idx_int, field_by_idx_long
 
+  procedure, private :: shape_array_by_name
+  procedure, private :: shape_idx_by_name
+  procedure, private :: shape_array_by_idx
+  procedure, private :: shape_idx_by_idx
+  generic, public :: shape => shape_array_by_name, shape_idx_by_name, shape_array_by_idx, shape_idx_by_idx
+
   procedure, public :: set_dirty
   procedure, public :: halo_exchange
 
@@ -370,6 +376,55 @@ function field_by_idx_int(this,idx) result(field)
   type(atlas_Field) :: field
   field = atlas_Field( atlas__FieldSet__field_by_idx(this%CPTR_PGIBUG_A, int(idx-1_c_int,ATLAS_KIND_IDX) ) ) ! C index
   call field%return()
+end function
+
+!-------------------------------------------------------------------------------
+
+function shape_array_by_name(this, name) result(shape)
+  use atlas_Field_module, only: atlas_Field
+  class(atlas_FieldSet), intent(in) :: this
+  character(len=*), intent(in) :: name
+  integer, allocatable :: shape(:)
+  type(atlas_Field) :: field
+  field = this%field(name)
+  shape = field%shape()
+end function
+
+!-------------------------------------------------------------------------------
+
+function shape_idx_by_name(this, name, dim_idx) result(shape_val)
+  use atlas_Field_module, only: atlas_Field
+  class(atlas_FieldSet), intent(in) :: this
+  character(len=*), intent(in) :: name
+  integer, intent(in) :: dim_idx
+  integer :: shape_val
+  type(atlas_Field) :: field
+  field = this%field(name)
+  shape_val = field%shape(dim_idx)
+end function
+
+!-------------------------------------------------------------------------------
+
+function shape_array_by_idx(this, idx) result(shape)
+  use atlas_Field_module, only: atlas_Field
+  class(atlas_FieldSet), intent(in) :: this
+  integer, intent(in) :: idx
+  integer, allocatable :: shape(:)
+  type(atlas_Field) :: field
+  field = this%field(idx)
+  shape = field%shape()
+end function
+
+!-------------------------------------------------------------------------------
+
+function shape_idx_by_idx(this, idx, dim_idx) result(shape_val)
+  use atlas_Field_module, only: atlas_Field
+  class(atlas_FieldSet), intent(in) :: this
+  integer, intent(in) :: idx, dim_idx
+  integer :: shape_val
+  type(atlas_Field) :: field
+  field = this%field(idx)
+  shape_val = field%shape(dim_idx)
 end function
 
 !-------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Add the Fortran `fieldset%shape(...)` API and remove intermediate field materialization from `atlas_FieldSet` convenience wrappers where direct fieldset access is available.

## Why
This extends the Fortran API and improves the efficiency of common `FieldSet` access paths by routing through direct fieldset bindings.

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-376
<!-- STATIC-ANALYSIS_END -->