### PR TITLE
Remove CPTR_PGIBUG workaround from Fortran bindings

### DIFF
--- a/src/atlas_f/atlas_f.h.in
+++ b/src/atlas_f/atlas_f.h.in
@@ -30,12 +30,6 @@
 
 #define ATLAS_FINAL FCKIT_FINAL
 
-#ifndef PGIBUG_ATLAS_197
-#define CPTR_PGIBUG_A c_ptr()
-#define CPTR_PGIBUG_B c_ptr()
-#define PGIBUG_ATLAS_197 0
-#endif
-
 #define ATLAS_FCKIT_VERSION_AT_LEAST(x, y, z) (ATLAS_FCKIT_VERSION_INT >= x * 10000 + y * 100 + z)
 
 #endif

--- a/src/atlas_f/domain/atlas_Domain_module.F90
+++ b/src/atlas_f/domain/atlas_Domain_module.F90
@@ -90,7 +90,7 @@ function atlas_Domain__ctor_config(config) result(this)
   use, intrinsic :: iso_c_binding, only : c_ptr
   type(atlas_Domain) :: this
   type(atlas_Config) :: config
-  call this%reset_c_ptr( atlas__Domain__ctor_config(config%CPTR_PGIBUG_B) )
+  call this%reset_c_ptr( atlas__Domain__ctor_config(config%c_ptr()) )
   call this%return()
 end function
 
@@ -102,7 +102,7 @@ function atlas_Domain__type(this) result(type_)
   character(len=:), allocatable :: type_
   type(c_ptr) :: type_c_str
   integer :: size
-  call atlas__Domain__type(this%CPTR_PGIBUG_A, type_c_str, size )
+  call atlas__Domain__type(this%c_ptr(), type_c_str, size )
   type_ = c_ptr_to_string(type_c_str)
   call c_ptr_free(type_c_str)
 end function
@@ -115,7 +115,7 @@ function hash(this)
   character(len=:), allocatable :: hash
   type(c_ptr) :: hash_c_str
   integer :: size
-  call atlas__Domain__hash(this%CPTR_PGIBUG_A, hash_c_str, size )
+  call atlas__Domain__hash(this%c_ptr(), hash_c_str, size )
   hash = c_ptr_to_string(hash_c_str)
   call c_ptr_free(hash_c_str)
 end function
@@ -124,7 +124,7 @@ function spec(this)
   use atlas_Domain_c_binding
   class(atlas_Domain), intent(in) :: this
   type(atlas_Config) :: spec
-  spec = atlas_Config( atlas__Domain__spec(this%CPTR_PGIBUG_A) )
+  spec = atlas_Config( atlas__Domain__spec(this%c_ptr()) )
   call spec%return()
 end function
 
@@ -143,28 +143,28 @@ function north(this) result(value)
   use atlas_Domain_c_binding
   class(atlas_LonLatRectangularDomain), intent(in) :: this
   real(c_double) :: value
-  value = atlas__LonLatRectangularDomain__north(this%CPTR_PGIBUG_A)
+  value = atlas__LonLatRectangularDomain__north(this%c_ptr())
 end function
 
 function west(this) result(value)
   use atlas_Domain_c_binding
   class(atlas_LonLatRectangularDomain), intent(in) :: this
   real(c_double) :: value
-  value = atlas__LonLatRectangularDomain__west(this%CPTR_PGIBUG_A)
+  value = atlas__LonLatRectangularDomain__west(this%c_ptr())
 end function
 
 function south(this) result(value)
   use atlas_Domain_c_binding
   class(atlas_LonLatRectangularDomain), intent(in) :: this
   real(c_double) :: value
-  value = atlas__LonLatRectangularDomain__south(this%CPTR_PGIBUG_A)
+  value = atlas__LonLatRectangularDomain__south(this%c_ptr())
 end function
 
 function east(this) result(value)
   use atlas_Domain_c_binding
   class(atlas_LonLatRectangularDomain), intent(in) :: this
   real(c_double) :: value
-  value = atlas__LonLatRectangularDomain__east(this%CPTR_PGIBUG_A)
+  value = atlas__LonLatRectangularDomain__east(this%c_ptr())
 end function
 
 !------------------------------------------------------------------------------

--- a/src/atlas_f/field/atlas_FieldSet_module.fypp
+++ b/src/atlas_f/field/atlas_FieldSet_module.fypp
@@ -165,7 +165,7 @@ subroutine access_data_${dtype}$_r${rank}$_by_name(this, name, field)
   type(c_ptr) :: shape_cptr
   type(c_ptr) :: strides_cptr
   integer(c_int) :: rank
-  call atlas__FieldSet__data_${ctype}$_specf(this%CPTR_PGIBUG_A, c_str(name), field_cptr, rank, shape_cptr, strides_cptr)
+  call atlas__FieldSet__data_${ctype}$_specf(this%c_ptr(), c_str(name), field_cptr, rank, shape_cptr, strides_cptr)
   call array_c_to_f(field_cptr, rank, shape_cptr, strides_cptr, field)
 end subroutine
 subroutine access_data_${dtype}$_r${rank}$_by_idx(this, idx, field)
@@ -179,7 +179,7 @@ subroutine access_data_${dtype}$_r${rank}$_by_idx(this, idx, field)
   type(c_ptr) :: shape_cptr
   type(c_ptr) :: strides_cptr
   integer(c_int) :: rank
-  call atlas__FieldSet__data_${ctype}$_specf_by_idx(this%CPTR_PGIBUG_A, idx-1, field_cptr, rank, shape_cptr, strides_cptr)
+  call atlas__FieldSet__data_${ctype}$_specf_by_idx(this%c_ptr(), idx-1, field_cptr, rank, shape_cptr, strides_cptr)
   call array_c_to_f(field_cptr, rank, shape_cptr, strides_cptr, field)
 end subroutine
 subroutine access_data_${dtype}$_r${rank}$_slice_by_name(this, name, slice, iblk)
@@ -236,7 +236,7 @@ subroutine access_device_data_${dtype}$_r${rank}$_by_name(this, name, field)
   type(c_ptr) :: shape_cptr
   type(c_ptr) :: strides_cptr
   integer(c_int) :: rank
-  call atlas__FieldSet__device_data_${ctype}$_specf(this%CPTR_PGIBUG_A, c_str(name), field_cptr, rank, shape_cptr, strides_cptr)
+  call atlas__FieldSet__device_data_${ctype}$_specf(this%c_ptr(), c_str(name), field_cptr, rank, shape_cptr, strides_cptr)
   call array_c_to_f(field_cptr, rank, shape_cptr, strides_cptr, field)
 end subroutine
 
@@ -252,7 +252,7 @@ subroutine access_device_data_${dtype}$_r${rank}$_by_idx(this, idx, field)
   type(c_ptr) :: shape_cptr
   type(c_ptr) :: strides_cptr
   integer(c_int) :: rank
-  call atlas__FieldSet__device_data_${ctype}$_specf_by_idx(this%CPTR_PGIBUG_A, idx-1, field_cptr, rank, shape_cptr, strides_cptr)
+  call atlas__FieldSet__device_data_${ctype}$_specf_by_idx(this%c_ptr(), idx-1, field_cptr, rank, shape_cptr, strides_cptr)
   call array_c_to_f(field_cptr, rank, shape_cptr, strides_cptr, field)
 end subroutine
 
@@ -295,7 +295,7 @@ function FieldSet__name(this) result(fieldset_name)
   class(atlas_FieldSet), intent(in) :: this
   character(len=:), allocatable :: fieldset_name
   type(c_ptr) :: fieldset_name_c_str
-  fieldset_name_c_str = atlas__FieldSet__name(this%CPTR_PGIBUG_A)
+  fieldset_name_c_str = atlas__FieldSet__name(this%c_ptr())
   fieldset_name = c_ptr_to_string(fieldset_name_c_str)
 end function FieldSet__name
 
@@ -304,14 +304,14 @@ subroutine add_field(this,field)
   use atlas_Field_module, only: atlas_Field
   class(atlas_FieldSet), intent(in) :: this
   type(atlas_Field), intent(in) :: field
-  call atlas__FieldSet__add_field(this%CPTR_PGIBUG_A, field%CPTR_PGIBUG_A)
+  call atlas__FieldSet__add_field(this%c_ptr(), field%c_ptr())
 end subroutine
 
 subroutine add_fieldset(this,fset)
   use atlas_fieldset_c_binding
   class(atlas_FieldSet), intent(inout) :: this
   class(atlas_FieldSet), intent(in) :: fset
-  call atlas__FieldSet__add_fieldset(this%CPTR_PGIBUG_A, fset%CPTR_PGIBUG_A)
+  call atlas__FieldSet__add_fieldset(this%c_ptr(), fset%c_ptr())
 end subroutine
 
 function has(this,name) result(flag)
@@ -322,7 +322,7 @@ function has(this,name) result(flag)
   character(len=*), intent(in) :: name
   logical :: flag
   integer(c_int) :: rc
-  rc = atlas__FieldSet__has_field(this%CPTR_PGIBUG_A, c_str(name))
+  rc = atlas__FieldSet__has_field(this%c_ptr(), c_str(name))
   if( rc == 0 ) then
     flag = .False.
   else
@@ -335,7 +335,7 @@ function FieldSet__size(this) result(nb_fields)
   use atlas_fieldset_c_binding
   class(atlas_FieldSet), intent(in) :: this
   integer(ATLAS_KIND_IDX) :: nb_fields
-  nb_fields = atlas__FieldSet__size(this%CPTR_PGIBUG_A)
+  nb_fields = atlas__FieldSet__size(this%c_ptr())
 end function
 
 function field_by_name(this,name) result(field)
@@ -345,7 +345,7 @@ function field_by_name(this,name) result(field)
   class(atlas_FieldSet), intent(in) :: this
   character(len=*), intent(in) :: name
   type(atlas_Field) :: field
-  field = atlas_Field( atlas__FieldSet__field_by_name(this%CPTR_PGIBUG_A, c_str(name) ) )
+  field = atlas_Field( atlas__FieldSet__field_by_name(this%c_ptr(), c_str(name) ) )
   call field%return()
 end function
 
@@ -356,7 +356,7 @@ function field_by_idx_long(this,idx) result(field)
   class(atlas_FieldSet), intent(in) :: this
   integer(c_long), intent(in) :: idx
   type(atlas_Field) :: field
-  field = atlas_Field( atlas__FieldSet__field_by_idx(this%CPTR_PGIBUG_A, int(idx-1_c_long,ATLAS_KIND_IDX) ) ) ! C index
+  field = atlas_Field( atlas__FieldSet__field_by_idx(this%c_ptr(), int(idx-1_c_long,ATLAS_KIND_IDX) ) ) ! C index
   call field%return()
 end function
 
@@ -367,7 +367,7 @@ function field_by_idx_int(this,idx) result(field)
   class(atlas_FieldSet), intent(in) :: this
   integer(c_int), intent(in) :: idx
   type(atlas_Field) :: field
-  field = atlas_Field( atlas__FieldSet__field_by_idx(this%CPTR_PGIBUG_A, int(idx-1_c_int,ATLAS_KIND_IDX) ) ) ! C index
+  field = atlas_Field( atlas__FieldSet__field_by_idx(this%c_ptr(), int(idx-1_c_int,ATLAS_KIND_IDX) ) ) ! C index
   call field%return()
 end function
 
@@ -383,7 +383,7 @@ function shape_array_by_name(this, name) result(shape)
   type(c_ptr) :: shape_c_ptr
   integer, pointer :: shape_f_ptr(:)
   integer(c_int) :: field_rank
-  call atlas__FieldSet__shapef(this%CPTR_PGIBUG_A, c_str(name), shape_c_ptr, field_rank)
+  call atlas__FieldSet__shapef(this%c_ptr(), c_str(name), shape_c_ptr, field_rank)
   call c_f_pointer ( shape_c_ptr , shape_f_ptr , (/field_rank/) )
   allocate( shape(field_rank) )
   shape(:) = shape_f_ptr(:)
@@ -403,7 +403,7 @@ function shape_idx_by_name(this, name, dim_idx) result(shape_val)
   type(c_ptr) :: shape_c_ptr
   integer, pointer :: shape_f_ptr(:)
   integer(c_int) :: field_rank
-  call atlas__FieldSet__shapef(this%CPTR_PGIBUG_A, c_str(name), shape_c_ptr, field_rank)
+  call atlas__FieldSet__shapef(this%c_ptr(), c_str(name), shape_c_ptr, field_rank)
   call c_f_pointer ( shape_c_ptr , shape_f_ptr , (/field_rank/) )
   @:ATLAS_ASSERT( dim_idx <= field_rank )
   shape_val = shape_f_ptr(dim_idx)
@@ -420,7 +420,7 @@ function shape_array_by_idx(this, idx) result(shape)
   type(c_ptr) :: shape_c_ptr
   integer, pointer :: shape_f_ptr(:)
   integer(c_int) :: field_rank
-  call atlas__FieldSet__shapef_by_idx(this%CPTR_PGIBUG_A, idx-1, shape_c_ptr, field_rank)
+  call atlas__FieldSet__shapef_by_idx(this%c_ptr(), idx-1, shape_c_ptr, field_rank)
   call c_f_pointer ( shape_c_ptr , shape_f_ptr , (/field_rank/) )
   allocate( shape(field_rank) )
   shape(:) = shape_f_ptr(:)
@@ -438,7 +438,7 @@ function shape_idx_by_idx(this, idx, dim_idx) result(shape_val)
   type(c_ptr) :: shape_c_ptr
   integer, pointer :: shape_f_ptr(:)
   integer(c_int) :: field_rank
-  call atlas__FieldSet__shapef_by_idx(this%CPTR_PGIBUG_A, idx-1, shape_c_ptr, field_rank)
+  call atlas__FieldSet__shapef_by_idx(this%c_ptr(), idx-1, shape_c_ptr, field_rank)
   call c_f_pointer ( shape_c_ptr , shape_f_ptr , (/field_rank/) )
   @:ATLAS_ASSERT( dim_idx <= field_rank )
   shape_val = shape_f_ptr(dim_idx)
@@ -456,7 +456,7 @@ subroutine halo_exchange(this,on_device)
   if( present(on_device) ) then
     if( on_device ) on_device_int = 1
   endif
-  call atlas__FieldSet__halo_exchange(this%CPTR_PGIBUG_A, on_device_int)
+  call atlas__FieldSet__halo_exchange(this%c_ptr(), on_device_int)
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -473,7 +473,7 @@ subroutine set_host_needs_update_value(this, value)
       value_int = 0
     end if
   end if
-  call atlas__FieldSet__set_host_needs_update(this%CPTR_PGIBUG_A, value_int)
+  call atlas__FieldSet__set_host_needs_update(this%c_ptr(), value_int)
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -492,7 +492,7 @@ subroutine set_host_needs_update_idx(this, field_indices, value)
     end if
   end if
   do i = 1, size(field_indices)
-    call atlas__FieldSet__set_host_needs_update_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1, value_int)
+    call atlas__FieldSet__set_host_needs_update_by_idx(this%c_ptr(), field_indices(i)-1, value_int)
   end do
 end subroutine
 
@@ -513,7 +513,7 @@ subroutine set_host_needs_update_name(this, field_names, value)
     end if
   end if
   do i = 1, size(field_names)
-    call atlas__FieldSet__set_host_needs_update_name(this%CPTR_PGIBUG_A, c_str(field_names(i)), value_int)
+    call atlas__FieldSet__set_host_needs_update_name(this%c_ptr(), c_str(field_names(i)), value_int)
   end do
 end subroutine
 
@@ -531,7 +531,7 @@ subroutine set_device_needs_update_value(this, value)
       value_int = 0
     end if
   end if
-  call atlas__FieldSet__set_device_needs_update(this%CPTR_PGIBUG_A, value_int)
+  call atlas__FieldSet__set_device_needs_update(this%c_ptr(), value_int)
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -550,7 +550,7 @@ subroutine set_device_needs_update_idx(this, field_indices, value)
     end if
   end if
   do i = 1, size(field_indices)
-    call atlas__FieldSet__set_device_needs_update_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1, value_int)
+    call atlas__FieldSet__set_device_needs_update_by_idx(this%c_ptr(), field_indices(i)-1, value_int)
   end do
 end subroutine
 
@@ -571,7 +571,7 @@ subroutine set_device_needs_update_name(this, field_names, value)
     end if
   end if
   do i = 1, size(field_names)
-    call atlas__FieldSet__set_device_needs_update_name(this%CPTR_PGIBUG_A, c_str(field_names(i)), value_int)
+    call atlas__FieldSet__set_device_needs_update_name(this%c_ptr(), c_str(field_names(i)), value_int)
   end do
 end subroutine
 
@@ -585,10 +585,10 @@ subroutine sync_host_device_idx(this, field_indices)
   integer(c_int) :: i
   if (present(field_indices)) then
     do i = 1, size(field_indices)
-      call atlas__FieldSet__sync_host_device_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1)
+      call atlas__FieldSet__sync_host_device_by_idx(this%c_ptr(), field_indices(i)-1)
     end do
   else
-    call atlas__FieldSet__sync_host_device(this%CPTR_PGIBUG_A)
+    call atlas__FieldSet__sync_host_device(this%c_ptr())
   end if
 end subroutine
 
@@ -602,7 +602,7 @@ subroutine sync_host_device_name(this, field_names)
   character(*), intent(in) :: field_names(:)
   integer(c_int) :: i
   do i = 1, size(field_names)
-    call atlas__FieldSet__sync_host_device_name(this%CPTR_PGIBUG_A, c_str(field_names(i)))
+    call atlas__FieldSet__sync_host_device_name(this%c_ptr(), c_str(field_names(i)))
   end do
 end subroutine
 
@@ -616,10 +616,10 @@ subroutine sync_host_idx(this, field_indices)
   integer(c_int) :: i
   if (present(field_indices)) then
     do i = 1, size(field_indices)
-      call atlas__FieldSet__sync_host_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1)
+      call atlas__FieldSet__sync_host_by_idx(this%c_ptr(), field_indices(i)-1)
     end do
   else
-    call atlas__FieldSet__sync_host(this%CPTR_PGIBUG_A)
+    call atlas__FieldSet__sync_host(this%c_ptr())
   end if
 end subroutine
 
@@ -633,7 +633,7 @@ subroutine sync_host_name(this, field_names)
   character(*), intent(in) :: field_names(:)
   integer(c_int) :: i
   do i = 1, size(field_names)
-    call atlas__FieldSet__sync_host_name(this%CPTR_PGIBUG_A, c_str(field_names(i)))
+    call atlas__FieldSet__sync_host_name(this%c_ptr(), c_str(field_names(i)))
   end do
 end subroutine
 
@@ -647,10 +647,10 @@ subroutine sync_device_idx(this, field_indices)
   integer(c_int) :: i
   if (present(field_indices)) then
     do i = 1, size(field_indices)
-      call atlas__FieldSet__sync_device_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1)
+      call atlas__FieldSet__sync_device_by_idx(this%c_ptr(), field_indices(i)-1)
     end do
   else
-    call atlas__FieldSet__sync_device(this%CPTR_PGIBUG_A)
+    call atlas__FieldSet__sync_device(this%c_ptr())
   end if
 end subroutine
 
@@ -664,7 +664,7 @@ subroutine sync_device_name(this, field_names)
   character(*), intent(in) :: field_names(:)
   integer(c_int) :: i
   do i = 1, size(field_names)
-    call atlas__FieldSet__sync_device_name(this%CPTR_PGIBUG_A, c_str(field_names(i)))
+    call atlas__FieldSet__sync_device_name(this%c_ptr(), c_str(field_names(i)))
   end do
 end subroutine
 
@@ -678,10 +678,10 @@ subroutine allocate_device_idx(this, field_indices)
   integer(c_int) :: i
   if (present(field_indices)) then
     do i = 1, size(field_indices)
-      call atlas__FieldSet__allocate_device_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1)
+      call atlas__FieldSet__allocate_device_by_idx(this%c_ptr(), field_indices(i)-1)
     end do
   else
-    call atlas__FieldSet__allocate_device(this%CPTR_PGIBUG_A)
+    call atlas__FieldSet__allocate_device(this%c_ptr())
   end if
 end subroutine
 
@@ -695,7 +695,7 @@ subroutine allocate_device_name(this, field_names)
   character(*), intent(in) :: field_names(:)
   integer(c_int) :: i
   do i = 1, size(field_names)
-    call atlas__FieldSet__allocate_device_name(this%CPTR_PGIBUG_A, c_str(field_names(i)))
+    call atlas__FieldSet__allocate_device_name(this%c_ptr(), c_str(field_names(i)))
   end do
 end subroutine
 
@@ -709,10 +709,10 @@ subroutine update_device_idx(this, field_indices)
   integer(c_int) :: i
   if (present(field_indices)) then
     do i = 1, size(field_indices)
-      call atlas__FieldSet__update_device_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1)
+      call atlas__FieldSet__update_device_by_idx(this%c_ptr(), field_indices(i)-1)
     end do
   else
-    call atlas__FieldSet__update_device(this%CPTR_PGIBUG_A)
+    call atlas__FieldSet__update_device(this%c_ptr())
   end if
 end subroutine
 
@@ -726,7 +726,7 @@ subroutine update_device_name(this, field_names)
   character(*), intent(in) :: field_names(:)
   integer(c_int) :: i
   do i = 1, size(field_names)
-    call atlas__FieldSet__update_device_name(this%CPTR_PGIBUG_A, c_str(field_names(i)))
+    call atlas__FieldSet__update_device_name(this%c_ptr(), c_str(field_names(i)))
   end do
 end subroutine
 
@@ -740,10 +740,10 @@ subroutine update_host_idx(this, field_indices)
   integer(c_int) :: i
   if (present(field_indices)) then
     do i = 1, size(field_indices)
-      call atlas__FieldSet__update_host_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1)
+      call atlas__FieldSet__update_host_by_idx(this%c_ptr(), field_indices(i)-1)
     end do
   else
-    call atlas__FieldSet__update_host(this%CPTR_PGIBUG_A)
+    call atlas__FieldSet__update_host(this%c_ptr())
   end if
 end subroutine
 
@@ -757,7 +757,7 @@ subroutine update_host_name(this, field_names)
   character(*), intent(in) :: field_names(:)
   integer(c_int) :: i
   do i = 1, size(field_names)
-    call atlas__FieldSet__update_host_name(this%CPTR_PGIBUG_A, c_str(field_names(i)))
+    call atlas__FieldSet__update_host_name(this%c_ptr(), c_str(field_names(i)))
   end do
 end subroutine
 
@@ -771,10 +771,10 @@ subroutine deallocate_device_idx(this, field_indices)
   integer(c_int) :: i
   if (present(field_indices)) then
     do i = 1, size(field_indices)
-      call atlas__FieldSet__deallocate_device_by_idx(this%CPTR_PGIBUG_A, field_indices(i)-1)
+      call atlas__FieldSet__deallocate_device_by_idx(this%c_ptr(), field_indices(i)-1)
     end do
   else
-    call atlas__FieldSet__deallocate_device(this%CPTR_PGIBUG_A)
+    call atlas__FieldSet__deallocate_device(this%c_ptr())
   end if
 end subroutine
 
@@ -788,7 +788,7 @@ subroutine deallocate_device_name(this, field_names)
   character(*), intent(in) :: field_names(:)
   integer(c_int) :: i
   do i = 1, size(field_names)
-    call atlas__FieldSet__deallocate_device_name(this%CPTR_PGIBUG_A, c_str(field_names(i)))
+    call atlas__FieldSet__deallocate_device_name(this%c_ptr(), c_str(field_names(i)))
   end do
 end subroutine
 
@@ -809,7 +809,7 @@ subroutine set_dirty(this,value)
   else
       value_int = 1
   endif
-  call atlas__FieldSet__set_dirty(this%CPTR_PGIBUG_A, value_int)
+  call atlas__FieldSet__set_dirty(this%c_ptr(), value_int)
 end subroutine
 
 !-------------------------------------------------------------------------------

--- a/src/atlas_f/field/atlas_Field_module.fypp
+++ b/src/atlas_f/field/atlas_Field_module.fypp
@@ -222,7 +222,7 @@ subroutine access_data_${dtype}$_r${rank}$(this, field)
   type(c_ptr) :: shape_cptr
   type(c_ptr) :: strides_cptr
   integer(c_int) :: rank
-  call atlas__Field__data_${ctype}$_specf(this%CPTR_PGIBUG_A, field_cptr, rank, shape_cptr, strides_cptr)
+  call atlas__Field__data_${ctype}$_specf(this%c_ptr(), field_cptr, rank, shape_cptr, strides_cptr)
   call array_c_to_f(field_cptr,rank,shape_cptr,strides_cptr, field)
 end subroutine
 
@@ -235,7 +235,7 @@ subroutine access_device_data_${dtype}$_r${rank}$(this, field)
   type(c_ptr) :: shape_cptr
   type(c_ptr) :: strides_cptr
   integer(c_int) :: rank
-  call atlas__Field__device_data_${ctype}$_specf(this%CPTR_PGIBUG_A, field_cptr, rank, shape_cptr, strides_cptr)
+  call atlas__Field__device_data_${ctype}$_specf(this%c_ptr(), field_cptr, rank, shape_cptr, strides_cptr)
   call array_c_to_f(field_cptr,rank,shape_cptr,strides_cptr, field)
 end subroutine
 
@@ -254,7 +254,7 @@ subroutine access_data_${dtype}$_r${rank}$_slice(this, slice, iblk)
   type(c_ptr) :: shape_cptr
   type(c_ptr) :: strides_cptr
   integer(c_int) :: rank
-  call atlas__Field__data_${ctype}$_specf(this%CPTR_PGIBUG_A, field_cptr, rank, shape_cptr, strides_cptr)
+  call atlas__Field__data_${ctype}$_specf(this%c_ptr(), field_cptr, rank, shape_cptr, strides_cptr)
   call array_c_to_f(field_cptr, rank, shape_cptr, strides_cptr, field)
 #:if rank > 1
   slice => field(${dimr[rank]}$, iblk)
@@ -279,7 +279,7 @@ subroutine access_data_${dtype}$_r${rank}$_shape(this, field, shape)
   type(c_ptr) :: shape_cptr
   type(c_ptr) :: strides_cptr
   integer(c_int) :: rank
-  call atlas__Field__data_${ctype}$_specf(this%CPTR_PGIBUG_A, field_cptr, rank, shape_cptr, strides_cptr)
+  call atlas__Field__data_${ctype}$_specf(this%c_ptr(), field_cptr, rank, shape_cptr, strides_cptr)
   call c_f_pointer( field_cptr, field, shape )
 end subroutine
 
@@ -368,7 +368,7 @@ function atlas_Field__create(params) result(field)
   use atlas_field_c_binding
   type(atlas_Field) :: field
   class(atlas_Config), intent(in) :: params
-  field = atlas_Field__cptr( atlas__Field__create(params%CPTR_PGIBUG_B) )
+  field = atlas_Field__cptr( atlas__Field__create(params%c_ptr()) )
   call field%return()
 end function
 
@@ -394,7 +394,7 @@ function atlas_Field__create_name_kind_shape_${dtype}$(name,kind,shape,alignment
   call params%set("name",name)
   if( present(alignment) ) call params%set("alignment",alignment)
 
-  field = atlas_Field__cptr( atlas__Field__create(params%CPTR_PGIBUG_B) )
+  field = atlas_Field__cptr( atlas__Field__create(params%c_ptr()) )
   call params%final()
   call field%return()
 end function
@@ -418,7 +418,7 @@ function atlas_Field__create_kind_shape_${dtype}$(kind,shape,alignment) result(f
   call params%set("kind",kind)
   if( present(alignment) ) call params%set("alignment",alignment)
 
-  field = atlas_Field__cptr( atlas__Field__create(params%CPTR_PGIBUG_B) )
+  field = atlas_Field__cptr( atlas__Field__create(params%c_ptr()) )
   call params%final()
   call field%return()
 end function
@@ -574,7 +574,7 @@ function Field__name(this) result(field_name)
   class(atlas_Field), intent(in) :: this
   character(len=:), allocatable :: field_name
   type(c_ptr) :: field_name_c_str
-  field_name_c_str = atlas__Field__name(this%CPTR_PGIBUG_A)
+  field_name_c_str = atlas__Field__name(this%c_ptr())
   field_name = c_ptr_to_string(field_name_c_str)
 end function Field__name
 
@@ -584,7 +584,7 @@ function Field__functionspace(this) result(functionspace)
   use atlas_field_c_binding
   type(fckit_owned_object) :: functionspace
   class(atlas_Field), intent(in) :: this
-  call functionspace%reset_c_ptr( atlas__Field__functionspace(this%CPTR_PGIBUG_A) )
+  call functionspace%reset_c_ptr( atlas__Field__functionspace(this%c_ptr()) )
   call functionspace%return()
 end function Field__functionspace
 
@@ -599,7 +599,7 @@ function Field__datatype(this) result(datatype)
   type(c_ptr) :: datatype_cptr
   integer(c_int) :: datatype_size
   integer(c_int) :: datatype_allocated
-  call atlas__Field__datatype(this%CPTR_PGIBUG_A,datatype_cptr,datatype_size,datatype_allocated)
+  call atlas__Field__datatype(this%c_ptr(),datatype_cptr,datatype_size,datatype_allocated)
   allocate(character(len=datatype_size) :: datatype )
   datatype= c_ptr_to_string(datatype_cptr)
   if( datatype_allocated == 1 ) call c_ptr_free(datatype_cptr)
@@ -611,7 +611,7 @@ function Field__size(this) result(fieldsize)
   use atlas_field_c_binding
   class(atlas_Field), intent(in) :: this
   integer :: fieldsize
-  fieldsize = atlas__Field__size(this%CPTR_PGIBUG_A)
+  fieldsize = atlas__Field__size(this%c_ptr())
 end function Field__size
 
 !-------------------------------------------------------------------------------
@@ -620,7 +620,7 @@ function Field__rank(this) result(rank)
   use atlas_field_c_binding
   class(atlas_Field), intent(in) :: this
   integer :: rank
-  rank = atlas__Field__rank(this%CPTR_PGIBUG_A)
+  rank = atlas__Field__rank(this%c_ptr())
 end function Field__rank
 
 !-------------------------------------------------------------------------------
@@ -630,7 +630,7 @@ function Field__bytes(this) result(bytes)
   use, intrinsic :: iso_c_binding, only : c_double
   class(atlas_Field), intent(in) :: this
   real(c_double) :: bytes
-  bytes = atlas__Field__bytes(this%CPTR_PGIBUG_A)
+  bytes = atlas__Field__bytes(this%c_ptr())
 end function Field__bytes
 
 !-------------------------------------------------------------------------------
@@ -639,7 +639,7 @@ function Field__kind(this) result(kind)
   use atlas_field_c_binding
   class(atlas_Field), intent(in) :: this
   integer :: kind
-  kind = atlas__Field__kind(this%CPTR_PGIBUG_A)
+  kind = atlas__Field__kind(this%c_ptr())
 end function Field__kind
 
 !-------------------------------------------------------------------------------
@@ -648,7 +648,7 @@ function Field__levels(this) result(levels)
   use atlas_field_c_binding
   class(atlas_Field), intent(in) :: this
   integer :: levels
-  levels = atlas__Field__levels(this%CPTR_PGIBUG_A)
+  levels = atlas__Field__levels(this%c_ptr())
 end function Field__levels
 
 !-------------------------------------------------------------------------------
@@ -658,7 +658,7 @@ function Field__metadata(this) result(metadata)
   use atlas_metadata_module
   class(atlas_Field), intent(in) :: this
   type(atlas_Metadata) :: Metadata
-  call metadata%reset_c_ptr( atlas__Field__metadata(this%CPTR_PGIBUG_A) )
+  call metadata%reset_c_ptr( atlas__Field__metadata(this%c_ptr()) )
 end function Field__metadata
 
 !-------------------------------------------------------------------------------
@@ -671,7 +671,7 @@ function Field__shape_array(this) result(shape)
   type(c_ptr) :: shape_c_ptr
   integer, pointer :: shape_f_ptr(:)
   integer(c_int) :: field_rank
-  call atlas__Field__shapef(this%CPTR_PGIBUG_A, shape_c_ptr, field_rank)
+  call atlas__Field__shapef(this%c_ptr(), shape_c_ptr, field_rank)
   call c_f_pointer ( shape_c_ptr , shape_f_ptr , (/field_rank/) )
   allocate( shape(field_rank) )
   shape(:) = shape_f_ptr(:)
@@ -689,7 +689,7 @@ function Field__shape_idx(this,idx) result(shape_val)
   type(c_ptr) :: shape_c_ptr
   integer, pointer :: shape_f_ptr(:)
   integer(c_int) :: field_rank
-  call atlas__Field__shapef(this%CPTR_PGIBUG_A, shape_c_ptr, field_rank)
+  call atlas__Field__shapef(this%c_ptr(), shape_c_ptr, field_rank)
   call c_f_pointer ( shape_c_ptr , shape_f_ptr , (/field_rank/) )
   @:ATLAS_ASSERT( idx <= field_rank )
   shape_val = shape_f_ptr(idx)
@@ -705,7 +705,7 @@ function Field__strides_array(this) result(strides)
   type(c_ptr) :: strides_c_ptr
   integer, pointer :: strides_f_ptr(:)
   integer(c_int) :: field_rank
-  call atlas__Field__stridesf(this%CPTR_PGIBUG_A, strides_c_ptr, field_rank)
+  call atlas__Field__stridesf(this%c_ptr(), strides_c_ptr, field_rank)
   call c_f_pointer ( strides_c_ptr , strides_f_ptr , (/field_rank/) )
   allocate( strides(field_rank) )
   strides(:) = strides_f_ptr(:)
@@ -723,7 +723,7 @@ function Field__strides_idx(this,idx) result(strides_val)
   type(c_ptr) :: strides_c_ptr
   integer, pointer :: strides_f_ptr(:)
   integer(c_int) :: field_rank
-  call atlas__Field__stridesf(this%CPTR_PGIBUG_A, strides_c_ptr, field_rank)
+  call atlas__Field__stridesf(this%c_ptr(), strides_c_ptr, field_rank)
   call c_f_pointer ( strides_c_ptr , strides_f_ptr , (/field_rank/) )
   @:ATLAS_ASSERT( idx <= field_rank )
   strides_val = strides_f_ptr(idx)
@@ -735,7 +735,7 @@ subroutine set_levels(this,nb_levels)
   use atlas_field_c_binding
   class(atlas_Field), intent(inout) :: this
   integer, intent(in) :: nb_levels
-  call atlas__field__set_levels(this%CPTR_PGIBUG_A,nb_levels)
+  call atlas__field__set_levels(this%c_ptr(),nb_levels)
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -745,7 +745,7 @@ subroutine rename_(this,name)
   use fckit_c_interop_module, only : c_str
   class(atlas_Field), intent(inout) :: this
   character(len=*), intent(in) :: name
-  call atlas__field__rename(this%CPTR_PGIBUG_A,c_str(name))
+  call atlas__field__rename(this%c_ptr(),c_str(name))
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -754,7 +754,7 @@ subroutine set_functionspace(this,functionspace)
   use atlas_field_c_binding
   class(atlas_Field), intent(inout) :: this
   class(fckit_owned_object), intent(in) :: functionspace
-  call atlas__field__set_functionspace(this%CPTR_PGIBUG_A,functionspace%CPTR_PGIBUG_A)
+  call atlas__field__set_functionspace(this%c_ptr(),functionspace%c_ptr())
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -770,7 +770,7 @@ subroutine set_host_needs_update(this,value)
       value_int = 0
     endif
   endif
-  call atlas__field__set_host_needs_update(this%CPTR_PGIBUG_A,value_int)
+  call atlas__field__set_host_needs_update(this%c_ptr(),value_int)
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -786,7 +786,7 @@ subroutine set_device_needs_update(this,value)
       value_int = 0
     endif
   endif
-  call atlas__field__set_device_needs_update(this%CPTR_PGIBUG_A,value_int)
+  call atlas__field__set_device_needs_update(this%c_ptr(),value_int)
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -795,7 +795,7 @@ function host_needs_update(this)
   use atlas_field_c_binding
   logical :: host_needs_update
   class(atlas_Field), intent(in) :: this
-  if( atlas__Field__host_needs_update(this%CPTR_PGIBUG_A) == 1 ) then
+  if( atlas__Field__host_needs_update(this%c_ptr()) == 1 ) then
     host_needs_update = .true.
   else
     host_needs_update = .false.
@@ -808,7 +808,7 @@ function device_needs_update(this)
   use atlas_field_c_binding
   logical :: device_needs_update
   class(atlas_Field), intent(in) :: this
-  if( atlas__Field__device_needs_update(this%CPTR_PGIBUG_A) == 1 ) then
+  if( atlas__Field__device_needs_update(this%c_ptr()) == 1 ) then
     device_needs_update = .true.
   else
     device_needs_update = .false.
@@ -820,7 +820,7 @@ end function
 subroutine update_device(this)
   use atlas_field_c_binding
   class(atlas_Field), intent(inout) :: this
-  call atlas__Field__update_device(this%CPTR_PGIBUG_A)
+  call atlas__Field__update_device(this%c_ptr())
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -828,7 +828,7 @@ end subroutine
 subroutine update_host(this)
   use atlas_field_c_binding
   class(atlas_Field), intent(inout) :: this
-  call atlas__Field__update_host(this%CPTR_PGIBUG_A)
+  call atlas__Field__update_host(this%c_ptr())
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -836,7 +836,7 @@ end subroutine
 subroutine sync_host_device(this)
   use atlas_field_c_binding
   class(atlas_Field), intent(inout) :: this
-  call atlas__Field__sync_host_device(this%CPTR_PGIBUG_A)
+  call atlas__Field__sync_host_device(this%c_ptr())
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -844,14 +844,14 @@ end subroutine
 subroutine sync_host(this)
   use atlas_field_c_binding
   class(atlas_Field), intent(inout) :: this
-  call atlas__Field__sync_host(this%CPTR_PGIBUG_A)
+  call atlas__Field__sync_host(this%c_ptr())
 end subroutine
 
 !-------------------------------------------------------------------------------
 subroutine sync_device(this)
   use atlas_field_c_binding
   class(atlas_Field), intent(inout) :: this
-  call atlas__Field__sync_device(this%CPTR_PGIBUG_A)
+  call atlas__Field__sync_device(this%c_ptr())
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -859,7 +859,7 @@ end subroutine
 subroutine allocate_device(this)
   use atlas_field_c_binding
   class(atlas_Field), intent(inout) :: this
-  call atlas__Field__allocate_device(this%CPTR_PGIBUG_A)
+  call atlas__Field__allocate_device(this%c_ptr())
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -867,7 +867,7 @@ end subroutine
 subroutine deallocate_device(this)
   use atlas_field_c_binding
   class(atlas_Field), intent(inout) :: this
-  call atlas__Field__deallocate_device(this%CPTR_PGIBUG_A)
+  call atlas__Field__deallocate_device(this%c_ptr())
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -876,7 +876,7 @@ function device_allocated(this)
   use atlas_field_c_binding
   logical :: device_allocated
   class(atlas_Field), intent(in) :: this
-  if( atlas__Field__device_allocated(this%CPTR_PGIBUG_A) == 1 ) then
+  if( atlas__Field__device_allocated(this%c_ptr()) == 1 ) then
     device_allocated = .true.
   else
     device_allocated = .false.
@@ -895,7 +895,7 @@ subroutine halo_exchange(this,on_device)
   if( present(on_device) ) then
     if( on_device ) on_device_int = 1
   endif
-  call atlas__Field__halo_exchange(this%CPTR_PGIBUG_A, on_device_int)
+  call atlas__Field__halo_exchange(this%c_ptr(), on_device_int)
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -915,7 +915,7 @@ subroutine set_dirty(this,value)
   else
       value_int = 1
   endif
-  call atlas__Field__set_dirty(this%CPTR_PGIBUG_A, value_int)
+  call atlas__Field__set_dirty(this%c_ptr(), value_int)
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -926,7 +926,7 @@ function dirty(this) result(value)
   class(atlas_Field), intent(inout) :: this
   logical :: value
   integer(c_int) :: value_int
-  value_int = atlas__Field__dirty(this%CPTR_PGIBUG_A)
+  value_int = atlas__Field__dirty(this%c_ptr())
   if( value_int == 0 ) then
     value = .false.
   else
@@ -940,7 +940,7 @@ function contiguous(this)
   use atlas_field_c_binding
   logical :: contiguous
   class(atlas_Field), intent(in) :: this
-  if( atlas__Field__contiguous(this%CPTR_PGIBUG_A) == 1 ) then
+  if( atlas__Field__contiguous(this%c_ptr()) == 1 ) then
     contiguous = .true.
   else
     contiguous = .false.

--- a/src/atlas_f/field/atlas_MultiField_module.F90
+++ b/src/atlas_f/field/atlas_MultiField_module.F90
@@ -81,7 +81,7 @@ function atlas_MultiField__create(params) result(field)
   use atlas_multifield_c_binding
   type(atlas_MultiField) :: field
   class(atlas_Config), intent(in) :: params
-  field = atlas_MultiField__cptr( atlas__MultiField__create(params%CPTR_PGIBUG_B) )
+  field = atlas_MultiField__cptr( atlas__MultiField__create(params%c_ptr()) )
   call field%return()
 end function
 
@@ -130,7 +130,7 @@ function MultiField__size(this) result(size)
   use atlas_multifield_c_binding
   class(atlas_MultiField), intent(in) :: this
   integer :: size
-  size = atlas__MultiField__size(this%CPTR_PGIBUG_B)
+  size = atlas__MultiField__size(this%c_ptr())
 end function
 
 !-------------------------------------------------------------------------------
@@ -140,7 +140,7 @@ function MultiField__fieldset(this) result(fset)
   class(atlas_MultiField), intent(in) :: this
   type(c_ptr) :: fset_cptr
   type(atlas_FieldSet) :: fset
-  fset_cptr = atlas__MultiField__fieldset(this%CPTR_PGIBUG_B)
+  fset_cptr = atlas__MultiField__fieldset(this%c_ptr())
   fset = atlas_FieldSet( fset_cptr )
   call fset%return()
 end function

--- a/src/atlas_f/field/atlas_State_module.F90
+++ b/src/atlas_f/field/atlas_State_module.F90
@@ -104,10 +104,10 @@ function atlas_State__generate(generator, params) result(this)
   call this%reset_c_ptr( atlas__State__new() )
 
   if( present(params) ) then
-    call atlas__State__initialize(this%CPTR_PGIBUG_A,c_str(generator),params%CPTR_PGIBUG_B)
+    call atlas__State__initialize(this%c_ptr(),c_str(generator),params%c_ptr())
   else
     p = atlas_Config()
-    call atlas__State__initialize(this%CPTR_PGIBUG_A,c_str(generator),p%CPTR_PGIBUG_B)
+    call atlas__State__initialize(this%c_ptr(),c_str(generator),p%c_ptr())
     call p%final()
   endif
   call this%return()
@@ -117,7 +117,7 @@ subroutine atlas_State__add(this,field)
   use atlas_state_c_binding
   class(atlas_State), intent(inout) :: this
   class(atlas_Field), intent(in) :: field
-  call atlas__State__add(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A)
+  call atlas__State__add(this%c_ptr(),field%c_ptr())
 end subroutine
 
 subroutine atlas_State__remove(this,name)
@@ -125,7 +125,7 @@ subroutine atlas_State__remove(this,name)
   use atlas_state_c_binding
   class(atlas_State), intent(inout) :: this
   character(len=*), intent(in) :: name
-  call atlas__State__remove(this%CPTR_PGIBUG_A,c_str(name))
+  call atlas__State__remove(this%c_ptr(),c_str(name))
 end subroutine
 
 function atlas_State__has(this,name) result(has)
@@ -135,7 +135,7 @@ function atlas_State__has(this,name) result(has)
   class(atlas_State), intent(in) :: this
   character(len=*), intent(in) :: name
   integer :: has_int
-  has_int = atlas__State__has(this%CPTR_PGIBUG_A,c_str(name))
+  has_int = atlas__State__has(this%c_ptr(),c_str(name))
   has = .False.
   if( has_int == 1 ) has = .True.
 end function
@@ -144,7 +144,7 @@ function atlas_State__size(this) result(size)
   use atlas_state_c_binding
   integer(ATLAS_KIND_IDX) :: size
   class(atlas_State), intent(in) :: this
-  size = atlas__State__size(this%CPTR_PGIBUG_A)
+  size = atlas__State__size(this%c_ptr())
 end function
 
 function atlas_State__field_by_name(this,name) result(field)
@@ -153,7 +153,7 @@ function atlas_State__field_by_name(this,name) result(field)
   type(atlas_Field) :: field
   class(atlas_State), intent(inout) :: this
   character(len=*), intent(in) :: name
-  field = atlas_Field( atlas__State__field_by_name(this%CPTR_PGIBUG_A,c_str(name)) )
+  field = atlas_Field( atlas__State__field_by_name(this%c_ptr(),c_str(name)) )
   call field%return()
 end function
 
@@ -162,7 +162,7 @@ function atlas_State__field_by_index(this,index) result(field)
   type(atlas_Field) :: field
   class(atlas_State), intent(in) :: this
   integer, intent(in) :: index
-  field = atlas_Field( atlas__State__field_by_index(this%CPTR_PGIBUG_A,int(index-1,ATLAS_KIND_IDX)) )
+  field = atlas_Field( atlas__State__field_by_index(this%c_ptr(),int(index-1,ATLAS_KIND_IDX)) )
   call field%return()
 end function
 
@@ -171,7 +171,7 @@ function atlas_State__metadata(this) result(metadata)
   use atlas_Metadata_module, only: atlas_Metadata
   type(atlas_Metadata) :: metadata
   class(atlas_State), intent(in) :: this
-  call metadata%reset_c_ptr( atlas__State__metadata(this%CPTR_PGIBUG_A) )
+  call metadata%reset_c_ptr( atlas__State__metadata(this%c_ptr()) )
 end function
 
 !-------------------------------------------------------------------------------

--- a/src/atlas_f/functionspace/atlas_FunctionSpace_module.F90
+++ b/src/atlas_f/functionspace/atlas_FunctionSpace_module.F90
@@ -97,7 +97,7 @@ function atlas_FunctionSpace__name(this) result(name)
   character(len=:), allocatable :: name
   type(c_ptr) :: name_c_str
   integer :: size
-  call atlas__FunctionSpace__name(this%CPTR_PGIBUG_A, name_c_str, size )
+  call atlas__FunctionSpace__name(this%c_ptr(), name_c_str, size )
   name = c_ptr_to_string(name_c_str)
   call c_ptr_free(name_c_str)
 end function
@@ -131,7 +131,7 @@ function create_field_args(this,kind,name,levels,variables,type,alignment,global
   if( present(type) )      call options%set("type",type)
   if( present(alignment) ) call options%set("alignment",alignment)
 
-  field = atlas_Field( atlas__FunctionSpace__create_field( this%CPTR_PGIBUG_A, options%CPTR_PGIBUG_B ) )
+  field = atlas_Field( atlas__FunctionSpace__create_field( this%c_ptr(), options%c_ptr() ) )
 
   call field%return()
   call options%final()
@@ -158,7 +158,7 @@ function create_field_template(this,template,name,global,owner) result(field)
   if( present(global) )    call options%set("global",global)
 
   field = atlas_Field( atlas__FunctionSpace__create_field_template( &
-    & this%CPTR_PGIBUG_A, template%CPTR_PGIBUG_A,options%CPTR_PGIBUG_B) )
+    & this%c_ptr(), template%c_ptr(),options%c_ptr()) )
 
   call options%final()
 
@@ -171,7 +171,7 @@ subroutine halo_exchange_fieldset(this,fieldset)
   use atlas_functionspace_c_binding
   class(atlas_Functionspace), intent(in) :: this
   type(atlas_FieldSet), intent(inout) :: fieldset
-  call atlas__FunctionSpace__halo_exchange_fieldset(this%CPTR_PGIBUG_A,fieldset%CPTR_PGIBUG_A)
+  call atlas__FunctionSpace__halo_exchange_fieldset(this%c_ptr(),fieldset%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -180,7 +180,7 @@ subroutine halo_exchange_field(this,field)
   use atlas_functionspace_c_binding
   class(atlas_Functionspace), intent(in) :: this
   type(atlas_Field), intent(inout) :: field
-  call atlas__FunctionSpace__halo_exchange_field(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A)
+  call atlas__FunctionSpace__halo_exchange_field(this%c_ptr(),field%c_ptr())
 end subroutine
 
 
@@ -190,7 +190,7 @@ subroutine adjoint_halo_exchange_fieldset(this,fieldset)
   use atlas_functionspace_c_binding
   class(atlas_Functionspace), intent(in) :: this
   type(atlas_FieldSet), intent(inout) :: fieldset
-  call atlas__FunctionSpace__adjoint_halo_exchange_fieldset(this%CPTR_PGIBUG_A,fieldset%CPTR_PGIBUG_A)
+  call atlas__FunctionSpace__adjoint_halo_exchange_fieldset(this%c_ptr(),fieldset%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -199,7 +199,7 @@ subroutine adjoint_halo_exchange_field(this,field)
   use atlas_functionspace_c_binding
   class(atlas_Functionspace), intent(in) :: this
   type(atlas_Field), intent(inout) :: field
-  call atlas__FunctionSpace__adjoint_halo_exchange_field(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A)
+  call atlas__FunctionSpace__adjoint_halo_exchange_field(this%c_ptr(),field%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -229,7 +229,7 @@ function deprecated_create_field_1(this,name,kind,levels,vars) result(field)
   opt_variables = sum(vars)
   call options%set("variables",opt_variables)
 
-  field = atlas_Field( atlas__FunctionSpace__create_field( this%CPTR_PGIBUG_A, options%CPTR_PGIBUG_B ) )
+  field = atlas_Field( atlas__FunctionSpace__create_field( this%c_ptr(), options%c_ptr() ) )
 
   call options%final()
 
@@ -252,7 +252,7 @@ function deprecated_create_field_2(this,require_name,kind,levels) result(field)
   call options%set("name",require_name)
   call options%set("levels",levels)
 
-  field = atlas_Field( atlas__FunctionSpace__create_field( this%CPTR_PGIBUG_A, options%CPTR_PGIBUG_B ) )
+  field = atlas_Field( atlas__FunctionSpace__create_field( this%c_ptr(), options%c_ptr() ) )
   call options%final()
 
   call field%return()

--- a/src/atlas_f/functionspace/atlas_functionspace_BlockStructuredColumns_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_BlockStructuredColumns_module.F90
@@ -168,8 +168,8 @@ function ctor_grid(grid, halo, nproma, levels) result(this)
   if( present(halo) )   call config%set("halo",halo)
   if( present(nproma) )   call config%set("nproma",nproma)
   if( present(levels) ) call config%set("levels",levels)
-  call this%reset_c_ptr( atlas__functionspace__BStructuredColumns__new__grid( grid%CPTR_PGIBUG_A, &
-      & config%CPTR_PGIBUG_B ) )
+  call this%reset_c_ptr( atlas__functionspace__BStructuredColumns__new__grid( grid%c_ptr(), &
+      & config%c_ptr() ) )
   call this%set_index()
   call config%final()
   call this%return()
@@ -181,8 +181,8 @@ function ctor_grid_config(grid, config) result(this)
   class(atlas_Grid), intent(in) :: grid
   type(atlas_Config), intent (in) :: config
   call this%reset_c_ptr(atlas__functionspace__BStructuredColumns__new__grid( &
-      & grid%CPTR_PGIBUG_A, &
-      & config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), &
+      & config%c_ptr() ) )
   call this%set_index()
   call this%return()
 end function
@@ -199,7 +199,7 @@ function ctor_grid_dist(grid, distribution, halo, levels) result(this)
   if( present(halo) )   call config%set("halo",halo)
   if( present(levels) ) call config%set("levels",levels)
   call this%reset_c_ptr( atlas__functionspace__BStructuredColumns__new__grid_dist( &
-      & grid%CPTR_PGIBUG_A, distribution%CPTR_PGIBUG_A, config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), distribution%c_ptr(), config%c_ptr() ) )
   call this%set_index()
   call config%final()
   call this%return()
@@ -219,8 +219,8 @@ function ctor_grid_dist_levels(grid, distribution, levels, halo) result(this)
   call config%set("levels",size(levels))
   vertical = atlas_Vertical(levels)
   call this%reset_c_ptr( atlas__functionspace__BStructuredColumns__new__grid_dist_vert( &
-      & grid%CPTR_PGIBUG_A, distribution%CPTR_PGIBUG_A, vertical%CPTR_PGIBUG_B, &
-      & config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), distribution%c_ptr(), vertical%c_ptr(), &
+      & config%c_ptr() ) )
   call this%set_index()
   call config%final()
   call vertical%final()
@@ -239,8 +239,8 @@ function ctor_grid_dist_vertical(grid, distribution, vertical, halo) result(this
   if( present(halo) )   call config%set("halo",halo)
   call config%set("levels",vertical%size())
   call this%reset_c_ptr( atlas__functionspace__BStructuredColumns__new__grid_dist_vert( &
-      & grid%CPTR_PGIBUG_A, distribution%CPTR_PGIBUG_A, vertical%CPTR_PGIBUG_B, &
-      & config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), distribution%c_ptr(), vertical%c_ptr(), &
+      & config%c_ptr() ) )
   call this%set_index()
   call config%final()
   call this%return()
@@ -253,8 +253,8 @@ function ctor_grid_dist_config(grid, distribution, config) result(this)
   type(atlas_griddistribution), intent(in) :: distribution
   type(atlas_Config), intent (in) :: config
   call this%reset_c_ptr(atlas__functionspace__BStructuredColumns__new__grid_dist_config( &
-      & grid%CPTR_PGIBUG_A, distribution%CPTR_PGIBUG_A, &
-      & config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), distribution%c_ptr(), &
+      & config%c_ptr() ) )
   call this%set_index()
   call this%return()
 end function
@@ -272,7 +272,7 @@ function ctor_grid_part(grid, partitioner, halo, levels) result(this)
   if( present(halo) )   call config%set("halo",halo)
   if( present(levels) ) call config%set("levels",levels)
   call this%reset_c_ptr( atlas__functionspace__BStructuredColumns__new__grid_part( &
-      & grid%CPTR_PGIBUG_A, partitioner%CPTR_PGIBUG_A, config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), partitioner%c_ptr(), config%c_ptr() ) )
   call this%set_index()
   call config%final()
   call this%return()
@@ -292,8 +292,8 @@ function ctor_grid_part_levels(grid, partitioner, levels, halo) result(this)
   call config%set("levels",size(levels))
   vertical = atlas_Vertical(levels)
   call this%reset_c_ptr( atlas__functionspace__BStructuredColumns__new__grid_part_vert( &
-      & grid%CPTR_PGIBUG_A, partitioner%CPTR_PGIBUG_A, vertical%CPTR_PGIBUG_B, &
-      & config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), partitioner%c_ptr(), vertical%c_ptr(), &
+      & config%c_ptr() ) )
   call this%set_index()
   call config%final()
   call vertical%final()
@@ -312,8 +312,8 @@ function ctor_grid_part_vertical(grid, partitioner, vertical, halo) result(this)
   if( present(halo) )   call config%set("halo",halo)
   call config%set("levels",vertical%size())
   call this%reset_c_ptr( atlas__functionspace__BStructuredColumns__new__grid_part_vert( &
-      & grid%CPTR_PGIBUG_A, partitioner%CPTR_PGIBUG_A, vertical%CPTR_PGIBUG_B, &
-      & config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), partitioner%c_ptr(), vertical%c_ptr(), &
+      & config%c_ptr() ) )
   call this%set_index()
   call config%final()
   call this%return()
@@ -325,7 +325,7 @@ subroutine gather_field(this,local,global)
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
   type(atlas_Field), intent(in) :: local
   type(atlas_Field), intent(inout) :: global
-  call atlas__functionspace__BStructuredColumns__gather_field(this%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A)
+  call atlas__functionspace__BStructuredColumns__gather_field(this%c_ptr(),local%c_ptr(),global%c_ptr())
 end subroutine
 
 subroutine gather_fieldset(this,local,global)
@@ -333,7 +333,7 @@ subroutine gather_fieldset(this,local,global)
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
   type(atlas_FieldSet), intent(in) :: local
   type(atlas_FieldSet), intent(inout) :: global
-  call atlas__functionspace__BStructuredColumns__gather_fieldset(this%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A)
+  call atlas__functionspace__BStructuredColumns__gather_fieldset(this%c_ptr(),local%c_ptr(),global%c_ptr())
 end subroutine
 
 subroutine scatter_field(this,global,local)
@@ -341,7 +341,7 @@ subroutine scatter_field(this,global,local)
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
   type(atlas_Field), intent(in) :: global
   type(atlas_Field), intent(inout) :: local
-  call atlas__functionspace__BStructuredColumns__scatter_field(this%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A)
+  call atlas__functionspace__BStructuredColumns__scatter_field(this%c_ptr(),global%c_ptr(),local%c_ptr())
 end subroutine
 
 subroutine scatter_fieldset(this,global,local)
@@ -349,7 +349,7 @@ subroutine scatter_fieldset(this,global,local)
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
   type(atlas_FieldSet), intent(in) :: global
   type(atlas_FieldSet), intent(inout) :: local
-  call atlas__functionspace__BStructuredColumns__scatter_fieldset(this%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A)
+  call atlas__functionspace__BStructuredColumns__scatter_fieldset(this%c_ptr(),global%c_ptr(),local%c_ptr())
 end subroutine
 
 function checksum_fieldset(this,fieldset) result(checksum)
@@ -362,7 +362,7 @@ function checksum_fieldset(this,fieldset) result(checksum)
   integer(ATLAS_KIND_IDX) :: checksum_size
   integer(c_int) :: checksum_allocated
   call atlas__fs__BStructuredColumns__checksum_fieldset( &
-    & this%CPTR_PGIBUG_A,fieldset%CPTR_PGIBUG_A,checksum_cptr,checksum_size,checksum_allocated)
+    & this%c_ptr(),fieldset%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
   allocate(character(len=checksum_size) :: checksum )
   checksum = c_ptr_to_string(checksum_cptr)
   if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
@@ -379,7 +379,7 @@ function checksum_field(this,field) result(checksum)
   integer(ATLAS_KIND_IDX) :: checksum_size
   integer(c_int) :: checksum_allocated
   call atlas__fs__BStructuredColumns__checksum_field( &
-      & this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,checksum_cptr,checksum_size,checksum_allocated)
+      & this%c_ptr(),field%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
   allocate(character(len=checksum_size) :: checksum )
   checksum = c_ptr_to_string(checksum_cptr)
   if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
@@ -393,7 +393,7 @@ subroutine set_index(this)
   integer(ATLAS_KIND_IDX), pointer :: index_fptr(:)
   integer(ATLAS_KIND_IDX) :: i_min, i_max, j_min, j_max
   integer(ATLAS_KIND_IDX) :: ni, nj
-  call atlas__fs__BStructuredColumns__index_host( this%CPTR_PGIBUG_A, index_cptr, i_min, i_max, j_min, j_max )
+  call atlas__fs__BStructuredColumns__index_host( this%c_ptr(), index_cptr, i_min, i_max, j_min, j_max )
   ni = i_max-i_min+1;
   nj = j_max-j_min+1;
   call c_f_pointer( index_cptr, index_fptr, (/ni*nj/) )
@@ -404,14 +404,14 @@ function j_begin(this) result(j)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: j
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  j = atlas__fs__BStructuredColumns__j_begin(this%CPTR_PGIBUG_A)
+  j = atlas__fs__BStructuredColumns__j_begin(this%c_ptr())
 end function
 
 function j_end(this) result(j)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: j
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  j = atlas__fs__BStructuredColumns__j_end(this%CPTR_PGIBUG_A)
+  j = atlas__fs__BStructuredColumns__j_end(this%c_ptr())
 end function
 
 function i_begin(this,j) result(i)
@@ -419,7 +419,7 @@ function i_begin(this,j) result(i)
   integer(ATLAS_KIND_IDX) :: i
   integer(ATLAS_KIND_IDX), intent(in) :: j
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  i = atlas__fs__BStructuredColumns__i_begin(this%CPTR_PGIBUG_A,j)
+  i = atlas__fs__BStructuredColumns__i_begin(this%c_ptr(),j)
 end function
 
 function i_end(this,j) result(i)
@@ -427,7 +427,7 @@ function i_end(this,j) result(i)
   integer(ATLAS_KIND_IDX) :: i
   integer(ATLAS_KIND_IDX), intent(in) :: j
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  i = atlas__fs__BStructuredColumns__i_end(this%CPTR_PGIBUG_A,j)
+  i = atlas__fs__BStructuredColumns__i_end(this%c_ptr(),j)
 end function
 
 
@@ -435,14 +435,14 @@ function j_begin_halo(this) result(j)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: j
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  j = atlas__fs__BStructuredColumns__j_begin_halo(this%CPTR_PGIBUG_A)
+  j = atlas__fs__BStructuredColumns__j_begin_halo(this%c_ptr())
 end function
 
 function j_end_halo(this) result(j)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: j
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  j = atlas__fs__BStructuredColumns__j_end_halo(this%CPTR_PGIBUG_A)
+  j = atlas__fs__BStructuredColumns__j_end_halo(this%c_ptr())
 end function
 
 function i_begin_halo(this,j) result(i)
@@ -450,7 +450,7 @@ function i_begin_halo(this,j) result(i)
   integer(ATLAS_KIND_IDX) :: i
   integer(ATLAS_KIND_IDX), intent(in) :: j
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  i = atlas__fs__BStructuredColumns__i_begin_halo(this%CPTR_PGIBUG_A,j)
+  i = atlas__fs__BStructuredColumns__i_begin_halo(this%c_ptr(),j)
 end function
 
 function i_end_halo(this,j) result(i)
@@ -458,35 +458,35 @@ function i_end_halo(this,j) result(i)
   integer(ATLAS_KIND_IDX) :: i
   integer(ATLAS_KIND_IDX), intent(in) :: j
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  i = atlas__fs__BStructuredColumns__i_end_halo(this%CPTR_PGIBUG_A,j)
+  i = atlas__fs__BStructuredColumns__i_end_halo(this%c_ptr(),j)
 end function
 
 function get_size(this) result(size)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: size
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  size = atlas__fs__BStructuredColumns__size(this%CPTR_PGIBUG_A)
+  size = atlas__fs__BStructuredColumns__size(this%c_ptr())
 end function
 
 function get_size_owned(this) result(size)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: size
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  size = atlas__fs__BStructuredColumns__sizeOwned(this%CPTR_PGIBUG_A)
+  size = atlas__fs__BStructuredColumns__sizeOwned(this%c_ptr())
 end function
 
 function levels(this)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: levels
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  levels = atlas__fs__BStructuredColumns__levels(this%CPTR_PGIBUG_A)
+  levels = atlas__fs__BStructuredColumns__levels(this%c_ptr())
 end function
 
 function xy(this) result(field)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   type(atlas_Field) :: field
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  field = atlas_Field( atlas__fs__BStructuredColumns__xy(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__fs__BStructuredColumns__xy(this%c_ptr()) )
   call field%return()
 end function
 
@@ -494,7 +494,7 @@ function z(this) result(field)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   type(atlas_Field) :: field
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  field = atlas_Field( atlas__fs__BStructuredColumns__z(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__fs__BStructuredColumns__z(this%c_ptr()) )
   call field%return()
 end function
 
@@ -503,7 +503,7 @@ function partition(this) result(field)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   type(atlas_Field) :: field
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  field = atlas_Field( atlas__fs__BStructuredColumns__partition(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__fs__BStructuredColumns__partition(this%c_ptr()) )
   call field%return()
 end function
 
@@ -511,7 +511,7 @@ function global_index(this) result(field)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   type(atlas_Field) :: field
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  field = atlas_Field( atlas__fs__BStructuredColumns__global_index(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__fs__BStructuredColumns__global_index(this%c_ptr()) )
   call field%return()
 end function
 
@@ -519,7 +519,7 @@ function index_i(this) result(field)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   type(atlas_Field) :: field
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  field = atlas_Field( atlas__fs__BStructuredColumns__index_i(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__fs__BStructuredColumns__index_i(this%c_ptr()) )
   call field%return()
 end function
 
@@ -527,7 +527,7 @@ function index_j(this) result(field)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   type(atlas_Field) :: field
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  field = atlas_Field( atlas__fs__BStructuredColumns__index_j(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__fs__BStructuredColumns__index_j(this%c_ptr()) )
   call field%return()
 end function
 
@@ -535,7 +535,7 @@ function grid(this)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   type(atlas_Grid) :: grid
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  grid = atlas_Grid( atlas__fs__BStructuredColumns__grid(this%CPTR_PGIBUG_A) )
+  grid = atlas_Grid( atlas__fs__BStructuredColumns__grid(this%c_ptr()) )
   call grid%return()
 end function
 
@@ -544,7 +544,7 @@ function block_begin(this,j) result(i)
   integer(ATLAS_KIND_IDX) :: i
   integer(ATLAS_KIND_IDX), intent(in) :: j
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  i = atlas__fs__BStructuredColumns__block_begin(this%CPTR_PGIBUG_A,j-1) + 1
+  i = atlas__fs__BStructuredColumns__block_begin(this%c_ptr(),j-1) + 1
 end function
 
 function block_size(this,j) result(i)
@@ -552,21 +552,21 @@ function block_size(this,j) result(i)
   integer(ATLAS_KIND_IDX) :: i
   integer(ATLAS_KIND_IDX), intent(in) :: j
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  i = atlas__fs__BStructuredColumns__block_size(this%CPTR_PGIBUG_A,j-1)
+  i = atlas__fs__BStructuredColumns__block_size(this%c_ptr(),j-1)
 end function
 
 function nproma(this) result(i)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: i
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  i = atlas__fs__BStructuredColumns__nproma(this%CPTR_PGIBUG_A)
+  i = atlas__fs__BStructuredColumns__nproma(this%c_ptr())
 end function
 
 function nblks(this) result(i)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: i
   class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  i = atlas__fs__BStructuredColumns__nblks(this%CPTR_PGIBUG_A)
+  i = atlas__fs__BStructuredColumns__nblks(this%c_ptr())
 end function
 
 !-------------------------------------------------------------------------------

--- a/src/atlas_f/functionspace/atlas_functionspace_CellColumns_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_CellColumns_module.F90
@@ -118,7 +118,7 @@ function constructor(mesh,halo,levels) result(this)
   config = atlas_Config()
   if( present(halo) )   call config%set("halo",halo)
   if( present(levels) ) call config%set("levels",levels)
-  call this%reset_c_ptr( atlas__CellsFunctionSpace__new(mesh%CPTR_PGIBUG_A,config%CPTR_PGIBUG_B) )
+  call this%reset_c_ptr( atlas__CellsFunctionSpace__new(mesh%c_ptr(),config%c_ptr()) )
   call config%final()
   call this%return()
 end function
@@ -129,7 +129,7 @@ function nb_cells(this)
   use atlas_functionspace_CellColumns_c_binding
   integer :: nb_cells
   class(atlas_functionspace_CellColumns), intent(in) :: this
-  nb_cells = atlas__CellsFunctionSpace__nb_cells(this%CPTR_PGIBUG_A)
+  nb_cells = atlas__CellsFunctionSpace__nb_cells(this%c_ptr())
 end function
 
 !------------------------------------------------------------------------------
@@ -138,7 +138,7 @@ function mesh(this)
   use atlas_functionspace_CellColumns_c_binding
   type(atlas_Mesh) :: mesh
   class(atlas_functionspace_CellColumns), intent(in) :: this
-  call mesh%reset_c_ptr( atlas__CellsFunctionSpace__mesh(this%CPTR_PGIBUG_A) )
+  call mesh%reset_c_ptr( atlas__CellsFunctionSpace__mesh(this%c_ptr()) )
   call mesh%return()
 end function
 
@@ -148,7 +148,7 @@ function cells(this)
   use atlas_functionspace_CellColumns_c_binding
   type(atlas_mesh_Cells) :: cells
   class(atlas_functionspace_CellColumns), intent(in) :: this
-  call cells%reset_c_ptr( atlas__CellsFunctionSpace__cells(this%CPTR_PGIBUG_A) )
+  call cells%reset_c_ptr( atlas__CellsFunctionSpace__cells(this%c_ptr()) )
   call cells%return()
 end function
 
@@ -158,7 +158,7 @@ function get_gather(this) result(gather)
   use atlas_functionspace_CellColumns_c_binding
   type(atlas_GatherScatter) :: gather
   class(atlas_functionspace_CellColumns), intent(in) :: this
-  call gather%reset_c_ptr( atlas__CellsFunctioNSpace__get_gather(this%CPTR_PGIBUG_A) )
+  call gather%reset_c_ptr( atlas__CellsFunctioNSpace__get_gather(this%c_ptr()) )
 end function
 
 !------------------------------------------------------------------------------
@@ -167,7 +167,7 @@ function get_scatter(this) result(gather)
   use atlas_functionspace_CellColumns_c_binding
   type(atlas_GatherScatter) :: gather
   class(atlas_functionspace_CellColumns), intent(in) :: this
-  call gather%reset_c_ptr( atlas__CellsFunctioNSpace__get_scatter(this%CPTR_PGIBUG_A) )
+  call gather%reset_c_ptr( atlas__CellsFunctioNSpace__get_scatter(this%c_ptr()) )
 end function
 
 !------------------------------------------------------------------------------
@@ -177,7 +177,7 @@ subroutine gather_fieldset(this,local,global)
   class(atlas_functionspace_CellColumns), intent(in) :: this
   type(atlas_FieldSet), intent(in) :: local
   type(atlas_FieldSet), intent(inout) :: global
-  call atlas__CellsFunctionSpace__gather_fieldset(this%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A)
+  call atlas__CellsFunctionSpace__gather_fieldset(this%c_ptr(),local%c_ptr(),global%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -187,7 +187,7 @@ subroutine gather_field(this,local,global)
   class(atlas_functionspace_CellColumns), intent(in) :: this
   type(atlas_Field), intent(in) :: local
   type(atlas_Field), intent(inout) :: global
-  call atlas__CellsFunctionSpace__gather_field(this%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A)
+  call atlas__CellsFunctionSpace__gather_field(this%c_ptr(),local%c_ptr(),global%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -197,7 +197,7 @@ subroutine scatter_fieldset(this,global,local)
   class(atlas_functionspace_CellColumns), intent(in) :: this
   type(atlas_FieldSet), intent(in) :: global
   type(atlas_FieldSet), intent(inout) :: local
-  call atlas__CellsFunctionSpace__scatter_fieldset(this%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A)
+  call atlas__CellsFunctionSpace__scatter_fieldset(this%c_ptr(),global%c_ptr(),local%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -207,7 +207,7 @@ subroutine scatter_field(this,global,local)
   class(atlas_functionspace_CellColumns), intent(in) :: this
   type(atlas_Field), intent(in) :: global
   type(atlas_Field), intent(inout) :: local
-  call atlas__CellsFunctionSpace__scatter_field(this%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A)
+  call atlas__CellsFunctionSpace__scatter_field(this%c_ptr(),global%c_ptr(),local%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -216,7 +216,7 @@ function get_halo_exchange(this) result(halo_exchange)
   use atlas_functionspace_CellColumns_c_binding
   type(atlas_HaloExchange) :: halo_exchange
   class(atlas_functionspace_CellColumns), intent(in) :: this
-  call halo_exchange%reset_c_ptr( atlas__CellsFunctioNSpace__get_halo_exchange(this%CPTR_PGIBUG_A) )
+  call halo_exchange%reset_c_ptr( atlas__CellsFunctioNSpace__get_halo_exchange(this%c_ptr()) )
 end function
 
 !------------------------------------------------------------------------------
@@ -225,7 +225,7 @@ function get_checksum(this) result(checksum)
   use atlas_functionspace_CellColumns_c_binding
   type(atlas_Checksum) :: checksum
   class(atlas_functionspace_CellColumns), intent(in) :: this
-  call checksum%reset_c_ptr( atlas__CellsFunctioNSpace__get_checksum(this%CPTR_PGIBUG_A) )
+  call checksum%reset_c_ptr( atlas__CellsFunctioNSpace__get_checksum(this%c_ptr()) )
 end function
 
 !------------------------------------------------------------------------------
@@ -239,7 +239,7 @@ function checksum_fieldset(this,fieldset) result(checksum)
   type(c_ptr) :: checksum_cptr
   integer :: checksum_size, checksum_allocated
   call atlas__CellsFunctionSpace__checksum_fieldset( &
-    this%CPTR_PGIBUG_A,fieldset%CPTR_PGIBUG_A,checksum_cptr,checksum_size,checksum_allocated)
+    this%c_ptr(),fieldset%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
   allocate(character(len=checksum_size) :: checksum )
   checksum = c_ptr_to_string(checksum_cptr)
   if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
@@ -256,7 +256,7 @@ function checksum_field(this,field) result(checksum)
   type(c_ptr) :: checksum_cptr
   integer :: checksum_size, checksum_allocated
   call atlas__CellsFunctionSpace__checksum_field( &
-    this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,checksum_cptr,checksum_size,checksum_allocated)
+    this%c_ptr(),field%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
   allocate(character(len=checksum_size) :: checksum )
   checksum = c_ptr_to_string(checksum_cptr)
   if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)

--- a/src/atlas_f/functionspace/atlas_functionspace_EdgeColumns_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_EdgeColumns_module.F90
@@ -116,7 +116,7 @@ function constructor(mesh,halo,levels) result(this)
   if( present(halo) )   call config%set("halo",halo)
   if( present(levels) ) call config%set("levels",levels)
   call this%reset_c_ptr( atlas__fs__EdgeColumns__new( &
-    mesh%CPTR_PGIBUG_A,config%CPTR_PGIBUG_B) )
+    mesh%c_ptr(),config%c_ptr()) )
   call config%final()
   call this%return()
 end function
@@ -127,7 +127,7 @@ function nb_edges(this)
   use atlas_functionspace_EdgeColumns_c_binding
   integer :: nb_edges
   class(atlas_functionspace_EdgeColumns), intent(in) :: this
-  nb_edges = atlas__fs__EdgeColumns__nb_edges(this%CPTR_PGIBUG_A)
+  nb_edges = atlas__fs__EdgeColumns__nb_edges(this%c_ptr())
 end function
 
 !------------------------------------------------------------------------------
@@ -136,7 +136,7 @@ function mesh(this)
   use atlas_functionspace_EdgeColumns_c_binding
   type(atlas_Mesh) :: mesh
   class(atlas_functionspace_EdgeColumns), intent(in) :: this
-  call mesh%reset_c_ptr( atlas__fs__EdgeColumns__mesh(this%CPTR_PGIBUG_A) )
+  call mesh%reset_c_ptr( atlas__fs__EdgeColumns__mesh(this%c_ptr()) )
   call mesh%return()
 end function
 
@@ -146,7 +146,7 @@ function edges(this)
   use atlas_functionspace_EdgeColumns_c_binding
   type(atlas_mesh_Edges) :: edges
   class(atlas_functionspace_EdgeColumns), intent(in) :: this
-  call edges%reset_c_ptr( atlas__fs__EdgeColumns__edges(this%CPTR_PGIBUG_A) )
+  call edges%reset_c_ptr( atlas__fs__EdgeColumns__edges(this%c_ptr()) )
   call edges%return()
 end function
 
@@ -156,7 +156,7 @@ function get_gather(this) result(gather)
   use atlas_functionspace_EdgeColumns_c_binding
   type(atlas_GatherScatter) :: gather
   class(atlas_functionspace_EdgeColumns), intent(in) :: this
-  call gather%reset_c_ptr( atlas__fs__EdgeColumns__get_gather(this%CPTR_PGIBUG_A) )
+  call gather%reset_c_ptr( atlas__fs__EdgeColumns__get_gather(this%c_ptr()) )
 !   call gather%return()
 end function
 
@@ -166,7 +166,7 @@ function get_scatter(this) result(scatter)
   use atlas_functionspace_EdgeColumns_c_binding
   type(atlas_GatherScatter) :: scatter
   class(atlas_functionspace_EdgeColumns), intent(in) :: this
-  call scatter%reset_c_ptr( atlas__fs__EdgeColumns__get_scatter(this%CPTR_PGIBUG_A) )
+  call scatter%reset_c_ptr( atlas__fs__EdgeColumns__get_scatter(this%c_ptr()) )
 !   call scatter%return()
 end function
 
@@ -177,8 +177,8 @@ subroutine gather_fieldset(this,local,global)
   class(atlas_functionspace_EdgeColumns), intent(in) :: this
   type(atlas_FieldSet), intent(in) :: local
   type(atlas_FieldSet), intent(inout) :: global
-  call atlas__fs__EdgeColumns__gather_fieldset(this%CPTR_PGIBUG_A, &
-    local%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A)
+  call atlas__fs__EdgeColumns__gather_fieldset(this%c_ptr(), &
+    local%c_ptr(),global%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -188,7 +188,7 @@ subroutine gather_field(this,local,global)
   class(atlas_functionspace_EdgeColumns), intent(in) :: this
   type(atlas_Field), intent(in) :: local
   type(atlas_Field), intent(inout) :: global
-  call atlas__fs__EdgeColumns__gather_field(this%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A)
+  call atlas__fs__EdgeColumns__gather_field(this%c_ptr(),local%c_ptr(),global%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -198,8 +198,8 @@ subroutine scatter_fieldset(this,global,local)
   class(atlas_functionspace_EdgeColumns), intent(in) :: this
   type(atlas_FieldSet), intent(in) :: global
   type(atlas_FieldSet), intent(inout) :: local
-  call atlas__fs__EdgeColumns__scatter_fieldset(this%CPTR_PGIBUG_A, &
-    global%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A)
+  call atlas__fs__EdgeColumns__scatter_fieldset(this%c_ptr(), &
+    global%c_ptr(),local%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -209,8 +209,8 @@ subroutine scatter_field(this,global,local)
   class(atlas_functionspace_EdgeColumns), intent(in) :: this
   type(atlas_Field), intent(in) :: global
   type(atlas_Field), intent(inout) :: local
-  call atlas__fs__EdgeColumns__scatter_field(this%CPTR_PGIBUG_A, &
-    global%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A)
+  call atlas__fs__EdgeColumns__scatter_field(this%c_ptr(), &
+    global%c_ptr(),local%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -219,7 +219,7 @@ function get_halo_exchange(this) result(halo_exchange)
   use atlas_functionspace_EdgeColumns_c_binding
   type(atlas_HaloExchange) :: halo_exchange
   class(atlas_functionspace_EdgeColumns), intent(in) :: this
-  call halo_exchange%reset_c_ptr( atlas__fs__EdgeColumns__get_halo_exchange(this%CPTR_PGIBUG_A) )
+  call halo_exchange%reset_c_ptr( atlas__fs__EdgeColumns__get_halo_exchange(this%c_ptr()) )
 !   call halo_exchange%return()
 end function
 
@@ -229,7 +229,7 @@ function get_checksum(this) result(checksum)
   use atlas_functionspace_EdgeColumns_c_binding
   type(atlas_Checksum) :: checksum
   class(atlas_functionspace_EdgeColumns), intent(in) :: this
-  call checksum%reset_c_ptr( atlas__fs__EdgeColumns__get_checksum(this%CPTR_PGIBUG_A) )
+  call checksum%reset_c_ptr( atlas__fs__EdgeColumns__get_checksum(this%c_ptr()) )
 !   call checksum%return()
 end function
 
@@ -242,8 +242,8 @@ function checksum_fieldset(this,fieldset) result(checksum)
   type(atlas_FieldSet), intent(in) :: fieldset
   type(c_ptr) :: checksum_cptr
   integer :: checksum_size, checksum_allocated
-  call atlas__fs__EdgeColumns__checksum_fieldset(this%CPTR_PGIBUG_A, &
-    fieldset%CPTR_PGIBUG_A,checksum_cptr,checksum_size,checksum_allocated)
+  call atlas__fs__EdgeColumns__checksum_fieldset(this%c_ptr(), &
+    fieldset%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
   allocate(character(len=checksum_size) :: checksum )
   checksum = c_ptr_to_string(checksum_cptr)
   if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
@@ -258,8 +258,8 @@ function checksum_field(this,field) result(checksum)
   type(atlas_Field), intent(in) :: field
   type(c_ptr) :: checksum_cptr
   integer :: checksum_size, checksum_allocated
-  call atlas__fs__EdgeColumns__checksum_field(this%CPTR_PGIBUG_A, &
-    field%CPTR_PGIBUG_A,checksum_cptr,checksum_size,checksum_allocated)
+  call atlas__fs__EdgeColumns__checksum_field(this%c_ptr(), &
+    field%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
   allocate(character(len=checksum_size) :: checksum )
   checksum = c_ptr_to_string(checksum_cptr)
   if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)

--- a/src/atlas_f/functionspace/atlas_functionspace_NodeColumns_module.fypp
+++ b/src/atlas_f/functionspace/atlas_functionspace_NodeColumns_module.fypp
@@ -150,7 +150,7 @@ function constructor(mesh,halo,levels) result(this)
   config = atlas_Config()
   if( present(halo) )   call config%set("halo",halo)
   if( present(levels) ) call config%set("levels",levels)
-  call this%reset_c_ptr( atlas__NodesFunctionSpace__new(mesh%CPTR_PGIBUG_A,config%CPTR_PGIBUG_B) )
+  call this%reset_c_ptr( atlas__NodesFunctionSpace__new(mesh%c_ptr(),config%c_ptr()) )
   call config%final()
   call this%return()
 end function
@@ -161,7 +161,7 @@ function nb_nodes(this)
   use atlas_functionspace_NodeColumns_c_binding
   integer :: nb_nodes
   class(atlas_functionspace_NodeColumns), intent(in) :: this
-  nb_nodes = atlas__NodesFunctionSpace__nb_nodes(this%CPTR_PGIBUG_A)
+  nb_nodes = atlas__NodesFunctionSpace__nb_nodes(this%c_ptr())
 end function
 
 !------------------------------------------------------------------------------
@@ -170,7 +170,7 @@ function mesh(this)
   use atlas_functionspace_NodeColumns_c_binding
   type(atlas_Mesh) :: mesh
   class(atlas_functionspace_NodeColumns), intent(in) :: this
-  call mesh%reset_c_ptr( atlas__NodesFunctionSpace__mesh(this%CPTR_PGIBUG_A) )
+  call mesh%reset_c_ptr( atlas__NodesFunctionSpace__mesh(this%c_ptr()) )
   call mesh%return()
 end function
 
@@ -180,7 +180,7 @@ function nodes(this)
   use atlas_functionspace_NodeColumns_c_binding
   type(atlas_mesh_Nodes) :: nodes
   class(atlas_functionspace_NodeColumns), intent(in) :: this
-  call nodes%reset_c_ptr( atlas__NodesFunctionSpace__nodes(this%CPTR_PGIBUG_A) )
+  call nodes%reset_c_ptr( atlas__NodesFunctionSpace__nodes(this%c_ptr()) )
   call nodes%return()
 end function
 
@@ -190,7 +190,7 @@ function get_gather(this) result(gather)
   use atlas_functionspace_NodeColumns_c_binding
   type(atlas_GatherScatter) :: gather
   class(atlas_functionspace_NodeColumns), intent(in) :: this
-  call gather%reset_c_ptr( atlas__NodesFunctioNSpace__get_gather(this%CPTR_PGIBUG_A) )
+  call gather%reset_c_ptr( atlas__NodesFunctioNSpace__get_gather(this%c_ptr()) )
 end function
 
 !------------------------------------------------------------------------------
@@ -199,7 +199,7 @@ function get_scatter(this) result(gather)
   use atlas_functionspace_NodeColumns_c_binding
   type(atlas_GatherScatter) :: gather
   class(atlas_functionspace_NodeColumns), intent(in) :: this
-  call gather%reset_c_ptr( atlas__NodesFunctioNSpace__get_scatter(this%CPTR_PGIBUG_A) )
+  call gather%reset_c_ptr( atlas__NodesFunctioNSpace__get_scatter(this%c_ptr()) )
 end function
 
 !------------------------------------------------------------------------------
@@ -209,7 +209,7 @@ subroutine gather_fieldset(this,local,global)
   class(atlas_functionspace_NodeColumns), intent(in) :: this
   type(atlas_FieldSet), intent(in) :: local
   type(atlas_FieldSet), intent(inout) :: global
-  call atlas__NodesFunctionSpace__gather_fieldset(this%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A)
+  call atlas__NodesFunctionSpace__gather_fieldset(this%c_ptr(),local%c_ptr(),global%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -219,7 +219,7 @@ subroutine gather_field(this,local,global)
   class(atlas_functionspace_NodeColumns), intent(in) :: this
   type(atlas_Field), intent(in) :: local
   type(atlas_Field), intent(inout) :: global
-  call atlas__NodesFunctionSpace__gather_field(this%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A)
+  call atlas__NodesFunctionSpace__gather_field(this%c_ptr(),local%c_ptr(),global%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -229,7 +229,7 @@ subroutine scatter_fieldset(this,global,local)
   class(atlas_functionspace_NodeColumns), intent(in) :: this
   type(atlas_FieldSet), intent(in) :: global
   type(atlas_FieldSet), intent(inout) :: local
-  call atlas__NodesFunctionSpace__scatter_fieldset(this%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A)
+  call atlas__NodesFunctionSpace__scatter_fieldset(this%c_ptr(),global%c_ptr(),local%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -239,7 +239,7 @@ subroutine scatter_field(this,global,local)
   class(atlas_functionspace_NodeColumns), intent(in) :: this
   type(atlas_Field), intent(in) :: global
   type(atlas_Field), intent(inout) :: local
-  call atlas__NodesFunctionSpace__scatter_field(this%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A)
+  call atlas__NodesFunctionSpace__scatter_field(this%c_ptr(),global%c_ptr(),local%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -248,7 +248,7 @@ function get_halo_exchange(this) result(halo_exchange)
   use atlas_functionspace_NodeColumns_c_binding
   type(atlas_HaloExchange) :: halo_exchange
   class(atlas_functionspace_NodeColumns), intent(in) :: this
-  call halo_exchange%reset_c_ptr( atlas__NodesFunctioNSpace__get_halo_exchange(this%CPTR_PGIBUG_A) )
+  call halo_exchange%reset_c_ptr( atlas__NodesFunctioNSpace__get_halo_exchange(this%c_ptr()) )
 end function
 
 !------------------------------------------------------------------------------
@@ -257,7 +257,7 @@ function get_checksum(this) result(checksum)
   use atlas_functionspace_NodeColumns_c_binding
   type(atlas_Checksum) :: checksum
   class(atlas_functionspace_NodeColumns), intent(in) :: this
-  call checksum%reset_c_ptr( atlas__NodesFunctioNSpace__get_checksum(this%CPTR_PGIBUG_A) )
+  call checksum%reset_c_ptr( atlas__NodesFunctioNSpace__get_checksum(this%c_ptr()) )
 end function
 
 !------------------------------------------------------------------------------
@@ -271,7 +271,7 @@ function checksum_fieldset(this,fieldset) result(checksum)
   type(c_ptr) :: checksum_cptr
   integer :: checksum_size, checksum_allocated
   call atlas__NodesFunctionSpace__checksum_fieldset( &
-    this%CPTR_PGIBUG_A,fieldset%CPTR_PGIBUG_A,checksum_cptr,checksum_size,checksum_allocated)
+    this%c_ptr(),fieldset%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
   allocate(character(len=checksum_size) :: checksum )
   checksum = c_ptr_to_string(checksum_cptr)
   if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
@@ -288,7 +288,7 @@ function checksum_field(this,field) result(checksum)
   type(c_ptr) :: checksum_cptr
   integer :: checksum_size, checksum_allocated
   call atlas__NodesFunctionSpace__checksum_field( &
-    this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,checksum_cptr,checksum_size,checksum_allocated)
+    this%c_ptr(),field%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
   allocate(character(len=checksum_size) :: checksum )
   checksum = c_ptr_to_string(checksum_cptr)
   if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
@@ -303,7 +303,7 @@ subroutine minimum_${dtype}$_r0(this,field,minimum)
   class(atlas_functionspace_NodeColumns), intent(in) :: this
   type(atlas_Field) :: field
   ${ftype}$, intent(out) :: minimum
-  call atlas__NodesFunctionSpace__min_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,minimum)
+  call atlas__NodesFunctionSpace__min_${ctype}$(this%c_ptr(),field%c_ptr(),minimum)
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -317,7 +317,7 @@ subroutine minimum_${dtype}$_r1(this,field,minimum)
   type(c_ptr) :: min_cptr
   ${ftype}$, pointer :: min_fptr(:)
   integer :: min_size
-  call atlas__NodesFunctionSpace__min_arr_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,min_cptr,min_size)
+  call atlas__NodesFunctionSpace__min_arr_${ctype}$(this%c_ptr(),field%c_ptr(),min_cptr,min_size)
   call c_f_pointer(min_cptr,min_fptr,(/min_size/))
   allocate(minimum(min_size))
   minimum(:) = min_fptr(:)
@@ -332,7 +332,7 @@ subroutine maximum_${dtype}$_r0(this,field,maximum)
   class(atlas_functionspace_NodeColumns), intent(in) :: this
   type(atlas_Field) :: field
   ${ftype}$, intent(out) :: maximum
-  call atlas__NodesFunctionSpace__max_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,maximum)
+  call atlas__NodesFunctionSpace__max_${ctype}$(this%c_ptr(),field%c_ptr(),maximum)
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -346,7 +346,7 @@ subroutine maximum_${dtype}$_r1(this,field,maximum)
   type(c_ptr) :: max_cptr
   ${ftype}$, pointer :: max_fptr(:)
   integer :: max_size
-  call atlas__NodesFunctionSpace__max_arr_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,max_cptr,max_size)
+  call atlas__NodesFunctionSpace__max_arr_${ctype}$(this%c_ptr(),field%c_ptr(),max_cptr,max_size)
   call c_f_pointer(max_cptr,max_fptr,(/max_size/))
   allocate(maximum(max_size))
   maximum(:) = max_fptr(:)
@@ -363,7 +363,7 @@ subroutine minloc_${dtype}$_r0(this,field,minimum,location)
   ${ftype}$, intent(out) :: minimum
   integer(ATLAS_KIND_GIDX), intent(out) :: location
   integer(c_long) :: loc
-  call atlas__NodesFunctionSpace__minloc_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,minimum,loc)
+  call atlas__NodesFunctionSpace__minloc_${ctype}$(this%c_ptr(),field%c_ptr(),minimum,loc)
   location = loc
 end subroutine
 
@@ -377,7 +377,7 @@ subroutine maxloc_${dtype}$_r0(this,field,maximum,location)
   ${ftype}$, intent(out) :: maximum
   integer(ATLAS_KIND_GIDX), intent(out) :: location
   integer(c_long) :: loc
-  call atlas__NodesFunctionSpace__maxloc_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,maximum,loc)
+  call atlas__NodesFunctionSpace__maxloc_${ctype}$(this%c_ptr(),field%c_ptr(),maximum,loc)
   location = loc
 end subroutine
 
@@ -394,7 +394,7 @@ subroutine minloc_${dtype}$_r1(this,field,minimum,location)
   ${ftype}$, pointer :: min_fptr(:)
   integer(c_long),pointer :: loc_fptr(:)
   integer :: min_size
-  call atlas__NodesFunctionSpace__minloc_arr_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,min_cptr,loc_cptr,min_size)
+  call atlas__NodesFunctionSpace__minloc_arr_${ctype}$(this%c_ptr(),field%c_ptr(),min_cptr,loc_cptr,min_size)
   call c_f_pointer(min_cptr,min_fptr,(/min_size/))
   call c_f_pointer(loc_cptr,loc_fptr,(/min_size/))
   allocate(minimum(min_size))
@@ -418,7 +418,7 @@ subroutine maxloc_${dtype}$_r1(this,field,maximum,location)
   ${ftype}$, pointer :: max_fptr(:)
   integer(c_long),pointer :: loc_fptr(:)
   integer :: max_size
-  call atlas__NodesFunctionSpace__maxloc_arr_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,max_cptr,loc_cptr,max_size)
+  call atlas__NodesFunctionSpace__maxloc_arr_${ctype}$(this%c_ptr(),field%c_ptr(),max_cptr,loc_cptr,max_size)
   call c_f_pointer(max_cptr,max_fptr,(/max_size/))
   call c_f_pointer(loc_cptr,loc_fptr,(/max_size/))
   allocate(maximum(max_size))
@@ -439,7 +439,7 @@ subroutine sum_${dtype}$_r0(this,field,sum,N)
   ${ftype}$, intent(out) :: sum
   integer(c_int), intent(out), optional :: N
   integer(c_int) :: opt_N
-  call atlas__NodesFunctionSpace__sum_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,sum,opt_N)
+  call atlas__NodesFunctionSpace__sum_${ctype}$(this%c_ptr(),field%c_ptr(),sum,opt_N)
   if( present(N) ) N = opt_N
 end subroutine
 
@@ -457,7 +457,7 @@ subroutine sum_${dtype}$_r1(this,field,sum,N)
   ${ftype}$, pointer :: sum_fptr(:)
   integer :: sum_size
   integer(c_int) :: opt_N
-  call atlas__NodesFunctionSpace__sum_arr_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,sum_cptr,sum_size,opt_N)
+  call atlas__NodesFunctionSpace__sum_arr_${ctype}$(this%c_ptr(),field%c_ptr(),sum_cptr,sum_size,opt_N)
   call c_f_pointer(sum_cptr,sum_fptr,(/sum_size/))
   allocate(sum(sum_size))
   sum(:) = sum_fptr(:)
@@ -475,7 +475,7 @@ subroutine mean_${dtype}$_r0(this,field,mean,N)
   ${ftype}$, intent(out) :: mean
   integer(c_int), intent(out), optional :: N
   integer(c_int) :: opt_N
-  call atlas__NodesFunctionSpace__mean_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,mean,opt_N)
+  call atlas__NodesFunctionSpace__mean_${ctype}$(this%c_ptr(),field%c_ptr(),mean,opt_N)
   if( present(N) ) N = opt_N
 end subroutine
 
@@ -493,7 +493,7 @@ subroutine mean_${dtype}$_r1(this,field,mean,N)
   ${ftype}$, pointer :: mean_fptr(:)
   integer :: mean_size
   integer(c_int) :: opt_N
-  call atlas__NodesFunctionSpace__mean_arr_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,mean_cptr,mean_size,opt_N)
+  call atlas__NodesFunctionSpace__mean_arr_${ctype}$(this%c_ptr(),field%c_ptr(),mean_cptr,mean_size,opt_N)
   call c_f_pointer(mean_cptr,mean_fptr,(/mean_size/))
   allocate(mean(mean_size))
   mean(:) = mean_fptr(:)
@@ -513,7 +513,7 @@ subroutine mean_and_stddev_${dtype}$_r0(this,field,mean,stddev,N)
   integer(c_int), intent(out), optional :: N
   integer(c_int) :: opt_N
   call atlas__NodesFunctionSpace__mean_and_stddev_${ctype}$( &
-    this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,mean,stddev,opt_N)
+    this%c_ptr(),field%c_ptr(),mean,stddev,opt_N)
   if( present(N) ) N = opt_N
 end subroutine
 
@@ -533,7 +533,7 @@ subroutine mean_and_stddev_${dtype}$_r1(this,field,mean,stddev,N)
   integer :: varsize
   integer(c_int) :: opt_N
   call atlas__NodesFunctionSpace__mean_and_stddev_arr_${ctype}$( &
-    this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,mean_cptr,stddev_cptr,varsize,opt_N)
+    this%c_ptr(),field%c_ptr(),mean_cptr,stddev_cptr,varsize,opt_N)
   call c_f_pointer(mean_cptr,mean_fptr,(/varsize/))
   call c_f_pointer(stddev_cptr,stddev_fptr,(/varsize/))
   allocate(mean(varsize))
@@ -557,7 +557,7 @@ subroutine minloclev_${dtype}$_r0(this,field,minimum,location,level)
   integer(c_int), intent(out) :: level
   integer(c_long) :: loc
   integer(c_int) :: opt_lev
-  call atlas__NodesFunctionSpace__minloclev_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,minimum,loc,opt_lev)
+  call atlas__NodesFunctionSpace__minloclev_${ctype}$(this%c_ptr(),field%c_ptr(),minimum,loc,opt_lev)
   location = loc
   level = opt_lev
 end subroutine
@@ -574,7 +574,7 @@ subroutine maxloclev_${dtype}$_r0(this,field,maximum,location,level)
   integer(c_int), intent(out) :: level
   integer(c_long) :: loc
   integer(c_int) :: opt_lev
-  call atlas__NodesFunctionSpace__maxloclev_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,maximum,loc,opt_lev)
+  call atlas__NodesFunctionSpace__maxloclev_${ctype}$(this%c_ptr(),field%c_ptr(),maximum,loc,opt_lev)
   location = loc
   level = opt_lev
 end subroutine
@@ -594,7 +594,7 @@ subroutine minloclev_${dtype}$_r1(this,field,minimum,location,level)
   integer(c_long),pointer :: loc_fptr(:)
   integer(c_long),pointer :: lev_fptr(:)
   integer :: min_size, jlev
-  call atlas__NodesFunctionSpace__minloclev_arr_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,min_cptr,loc_cptr,lev_cptr,min_size)
+  call atlas__NodesFunctionSpace__minloclev_arr_${ctype}$(this%c_ptr(),field%c_ptr(),min_cptr,loc_cptr,lev_cptr,min_size)
   call c_f_pointer(min_cptr,min_fptr,(/min_size/))
   call c_f_pointer(loc_cptr,loc_fptr,(/min_size/))
   allocate(minimum(min_size))
@@ -626,7 +626,7 @@ subroutine maxloclev_${dtype}$_r1(this,field,maximum,location,level)
   integer(c_long),pointer :: loc_fptr(:)
   integer(c_long),pointer :: lev_fptr(:)
   integer :: max_size, jlev
-  call atlas__NodesFunctionSpace__maxloclev_arr_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,max_cptr,loc_cptr,lev_cptr,max_size)
+  call atlas__NodesFunctionSpace__maxloclev_arr_${ctype}$(this%c_ptr(),field%c_ptr(),max_cptr,loc_cptr,lev_cptr,max_size)
   call c_f_pointer(max_cptr,max_fptr,(/max_size/))
   call c_f_pointer(loc_cptr,loc_fptr,(/max_size/))
   allocate(maximum(max_size))
@@ -653,7 +653,7 @@ subroutine order_independent_sum_${dtype}$_r0(this,field,sum,N)
   ${ftype}$, intent(out) :: sum
   integer(c_int), intent(out), optional :: N
   integer(c_int) :: opt_N
-  call atlas__NodesFunctionSpace__oisum_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,sum,opt_N)
+  call atlas__NodesFunctionSpace__oisum_${ctype}$(this%c_ptr(),field%c_ptr(),sum,opt_N)
   if( present(N) ) N = opt_N
 end subroutine
 
@@ -671,7 +671,7 @@ subroutine order_independent_sum_${dtype}$_r1(this,field,sum,N)
   ${ftype}$, pointer :: sum_fptr(:)
   integer :: sum_size
   integer(c_int) :: opt_N
-  call atlas__NodesFunctionSpace__oisum_arr_${ctype}$(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,sum_cptr,sum_size,opt_N)
+  call atlas__NodesFunctionSpace__oisum_arr_${ctype}$(this%c_ptr(),field%c_ptr(),sum_cptr,sum_size,opt_N)
   call c_f_pointer(sum_cptr,sum_fptr,(/sum_size/))
   allocate(sum(sum_size))
   sum(:) = sum_fptr(:)
@@ -690,7 +690,7 @@ subroutine minloc_per_level(this,field,minimum,location)
   type(atlas_Field), intent(inout) :: minimum
   type(atlas_Field), intent(inout) :: location
   call atlas__NodesFunctionSpace__minloc_per_level( &
-    this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,minimum%CPTR_PGIBUG_A,location%CPTR_PGIBUG_A)
+    this%c_ptr(),field%c_ptr(),minimum%c_ptr(),location%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -702,7 +702,7 @@ subroutine maxloc_per_level(this,field,maximum,location)
   type(atlas_Field), intent(inout) :: maximum
   type(atlas_Field), intent(inout) :: location
   call atlas__NodesFunctionSpace__maxloc_per_level( &
-    this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,maximum%CPTR_PGIBUG_A,location%CPTR_PGIBUG_A)
+    this%c_ptr(),field%c_ptr(),maximum%c_ptr(),location%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -713,7 +713,7 @@ subroutine minimum_per_level(this,field,minimum)
   type(atlas_Field), intent(in) :: field
   type(atlas_Field), intent(inout) :: minimum
   call atlas__NodesFunctionSpace__min_per_level( &
-    this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,minimum%CPTR_PGIBUG_A)
+    this%c_ptr(),field%c_ptr(),minimum%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -724,7 +724,7 @@ subroutine maximum_per_level(this,field,maximum)
   type(atlas_Field), intent(in) :: field
   type(atlas_Field), intent(inout) :: maximum
   call atlas__NodesFunctionSpace__max_per_level( &
-    this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,maximum%CPTR_PGIBUG_A)
+    this%c_ptr(),field%c_ptr(),maximum%c_ptr())
 end subroutine
 
 !------------------------------------------------------------------------------
@@ -738,7 +738,7 @@ subroutine sum_per_level(this,field,sum,N)
   integer(c_int), intent(out), optional :: N
   integer(c_int) :: opt_N
   call atlas__NodesFunctionSpace__sum_per_level( &
-    this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,sum%CPTR_PGIBUG_A,opt_N)
+    this%c_ptr(),field%c_ptr(),sum%c_ptr(),opt_N)
   if( present(N) ) N = opt_N
 end subroutine
 
@@ -753,7 +753,7 @@ subroutine order_independent_sum_per_level(this,field,sum,N)
   integer(c_int), intent(out), optional :: N
   integer(c_int) :: opt_N
   call atlas__NodesFunctionSpace__oisum_per_level( &
-    this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,sum%CPTR_PGIBUG_A,opt_N)
+    this%c_ptr(),field%c_ptr(),sum%c_ptr(),opt_N)
   if( present(N) ) N = opt_N
 end subroutine
 
@@ -768,7 +768,7 @@ subroutine mean_per_level(this,field,mean,N)
   integer(c_int), intent(out), optional :: N
   integer(c_int) :: opt_N
   call atlas__NodesFunctionSpace__mean_per_level( &
-    this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,mean%CPTR_PGIBUG_A,opt_N)
+    this%c_ptr(),field%c_ptr(),mean%c_ptr(),opt_N)
   if( present(N) ) N = opt_N
 end subroutine
 
@@ -784,7 +784,7 @@ subroutine mean_and_stddev_per_level(this,field,mean,stddev,N)
   integer(c_int), intent(out), optional :: N
   integer(c_int) :: opt_N
   call atlas__NodesFunctionSpace__mean_and_stddev_per_level( &
-    & this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,mean%CPTR_PGIBUG_A,stddev%CPTR_PGIBUG_A,opt_N)
+    & this%c_ptr(),field%c_ptr(),mean%c_ptr(),stddev%c_ptr(),opt_N)
   if( present(N) ) N = opt_N
 end subroutine
 

--- a/src/atlas_f/functionspace/atlas_functionspace_PointCloud_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_PointCloud_module.F90
@@ -82,7 +82,7 @@ function ctor_lonlat(lonlat) result(this)
   use atlas_functionspace_PointCloud_c_binding
   type(atlas_functionspace_PointCloud) :: this
   class(atlas_Field), intent(in) :: lonlat
-  call this%reset_c_ptr( atlas__functionspace__PointCloud__new__lonlat( lonlat%CPTR_PGIBUG_A ) )
+  call this%reset_c_ptr( atlas__functionspace__PointCloud__new__lonlat( lonlat%c_ptr() ) )
   call this%return()
 end function
 
@@ -93,7 +93,7 @@ function ctor_lonlat_ghost(lonlat,ghost) result(this)
   type(atlas_functionspace_PointCloud) :: this
   class(atlas_Field), intent(in) :: lonlat
   class(atlas_Field), intent(in) :: ghost
-  call this%reset_c_ptr( atlas__functionspace__PointCloud__new__lonlat_ghost( lonlat%CPTR_PGIBUG_A, ghost%CPTR_PGIBUG_A  ) )
+  call this%reset_c_ptr( atlas__functionspace__PointCloud__new__lonlat_ghost( lonlat%c_ptr(), ghost%c_ptr()  ) )
   call this%return()
 end function
 
@@ -103,7 +103,7 @@ function ctor_fieldset(fset) result(this)
   use atlas_functionspace_PointCloud_c_binding
   type(atlas_functionspace_PointCloud) :: this
   class(atlas_FieldSet), intent(in) :: fset
-  call this%reset_c_ptr( atlas__functionspace__PointCloud__new__fieldset( fset%CPTR_PGIBUG_A  ) )
+  call this%reset_c_ptr( atlas__functionspace__PointCloud__new__fieldset( fset%c_ptr()  ) )
   call this%return()
 end function
 
@@ -113,7 +113,7 @@ function ctor_grid(grid) result(this)
   use atlas_functionspace_PointCloud_c_binding
   type(atlas_functionspace_PointCloud) :: this
   class(atlas_Grid), intent(in) :: grid
-  call this%reset_c_ptr( atlas__functionspace__PointCloud__new__grid( grid%CPTR_PGIBUG_A ) )
+  call this%reset_c_ptr( atlas__functionspace__PointCloud__new__grid( grid%c_ptr() ) )
   call this%return()
 end function
 
@@ -123,7 +123,7 @@ function size_(this)
   use atlas_functionspace_PointCloud_c_binding
   integer :: size_
   class(atlas_functionspace_PointCloud), intent(in) :: this
-  size_ = atlas__fs__PointCloud__size(this%CPTR_PGIBUG_A)
+  size_ = atlas__fs__PointCloud__size(this%c_ptr())
 end function
 
 !------------------------------------------------------------------------------
@@ -132,7 +132,7 @@ function lonlat(this) result(field)
   use atlas_functionspace_PointCloud_c_binding
   type(atlas_Field) :: field
   class(atlas_functionspace_PointCloud), intent(in) :: this
-  field = atlas_Field( atlas__fs__PointCloud__lonlat(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__fs__PointCloud__lonlat(this%c_ptr()) )
   call field%return()
 end function
 

--- a/src/atlas_f/functionspace/atlas_functionspace_Spectral_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_Spectral_module.F90
@@ -105,7 +105,7 @@ function atlas_functionspace_Spectral__config(truncation,levels) result(this)
   call options%set("truncation",truncation)
   if( present(levels) ) call options%set("levels",levels)
 
-  call this%reset_c_ptr( atlas__SpectralFunctionSpace__new__config(options%CPTR_PGIBUG_B) )
+  call this%reset_c_ptr( atlas__SpectralFunctionSpace__new__config(options%c_ptr()) )
   call options%final()
 
   call this%return()
@@ -116,7 +116,7 @@ subroutine gather_field(this,local,global)
   class(atlas_functionspace_Spectral), intent(in) :: this
   type(atlas_Field), intent(in) :: local
   type(atlas_Field), intent(inout) :: global
-  call atlas__SpectralFunctionSpace__gather(this%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A)
+  call atlas__SpectralFunctionSpace__gather(this%c_ptr(),local%c_ptr(),global%c_ptr())
 end subroutine
 
 subroutine scatter_field(this,global,local)
@@ -124,7 +124,7 @@ subroutine scatter_field(this,global,local)
   class(atlas_functionspace_Spectral), intent(in) :: this
   type(atlas_Field), intent(in) :: global
   type(atlas_Field), intent(inout) :: local
-  call atlas__SpectralFunctionSpace__scatter(this%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A)
+  call atlas__SpectralFunctionSpace__scatter(this%c_ptr(),global%c_ptr(),local%c_ptr())
 end subroutine
 
 subroutine gather_fieldset(this,local,global)
@@ -132,7 +132,7 @@ subroutine gather_fieldset(this,local,global)
   class(atlas_functionspace_Spectral), intent(in) :: this
   type(atlas_FieldSet), intent(in) :: local
   type(atlas_FieldSet), intent(inout) :: global
-  call atlas__SpectralFunctionSpace__gather_fieldset(this%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A)
+  call atlas__SpectralFunctionSpace__gather_fieldset(this%c_ptr(),local%c_ptr(),global%c_ptr())
 end subroutine
 
 subroutine scatter_fieldset(this,global,local)
@@ -140,7 +140,7 @@ subroutine scatter_fieldset(this,global,local)
   class(atlas_functionspace_Spectral), intent(in) :: this
   type(atlas_FieldSet), intent(in) :: global
   type(atlas_FieldSet), intent(inout) :: local
-  call atlas__SpectralFunctionSpace__scatter_fieldset(this%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A)
+  call atlas__SpectralFunctionSpace__scatter_fieldset(this%c_ptr(),global%c_ptr(),local%c_ptr())
 end subroutine
 
 subroutine norm_scalar(this,field,norm,rank)
@@ -154,7 +154,7 @@ subroutine norm_scalar(this,field,norm,rank)
   real(c_double) :: norm_array(1)
   opt_rank = 0
   if( present(rank) ) opt_rank = rank
-  call atlas__SpectralFunctionSpace__norm(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,norm_array,opt_rank)
+  call atlas__SpectralFunctionSpace__norm(this%c_ptr(),field%c_ptr(),norm_array,opt_rank)
   norm = norm_array(1)
 end subroutine
 
@@ -168,7 +168,7 @@ subroutine norm_array(this,field,norm,rank)
   integer :: opt_rank
   opt_rank = 0
   if( present(rank) ) opt_rank = rank
-  call atlas__SpectralFunctionSpace__norm(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,norm,opt_rank)
+  call atlas__SpectralFunctionSpace__norm(this%c_ptr(),field%c_ptr(),norm,opt_rank)
 end subroutine
 
 function levels( this )

--- a/src/atlas_f/functionspace/atlas_functionspace_StructuredColumns_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_StructuredColumns_module.F90
@@ -161,8 +161,8 @@ function ctor_grid(grid, halo, levels) result(this)
   config = empty_config() ! Due to PGI compiler bug, we have to do this instead of "config = atlas_Config()""
   if( present(halo) )   call config%set("halo",halo)
   if( present(levels) ) call config%set("levels",levels)
-  call this%reset_c_ptr( atlas__functionspace__StructuredColumns__new__grid( grid%CPTR_PGIBUG_A, &
-      & config%CPTR_PGIBUG_B ) )
+  call this%reset_c_ptr( atlas__functionspace__StructuredColumns__new__grid( grid%c_ptr(), &
+      & config%c_ptr() ) )
   call this%set_index()
   call config%final()
   call this%return()
@@ -180,7 +180,7 @@ function ctor_grid_dist(grid, distribution, halo, levels) result(this)
   if( present(halo) )   call config%set("halo",halo)
   if( present(levels) ) call config%set("levels",levels)
   call this%reset_c_ptr( atlas__functionspace__StructuredColumns__new__grid_dist( &
-      & grid%CPTR_PGIBUG_A, distribution%CPTR_PGIBUG_A, config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), distribution%c_ptr(), config%c_ptr() ) )
   call this%set_index()
   call config%final()
   call this%return()
@@ -200,8 +200,8 @@ function ctor_grid_dist_levels(grid, distribution, levels, halo) result(this)
   call config%set("levels",size(levels))
   vertical = atlas_Vertical(levels)
   call this%reset_c_ptr( atlas__functionspace__StructuredColumns__new__grid_dist_vert( &
-      & grid%CPTR_PGIBUG_A, distribution%CPTR_PGIBUG_A, vertical%CPTR_PGIBUG_B, &
-      & config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), distribution%c_ptr(), vertical%c_ptr(), &
+      & config%c_ptr() ) )
   call this%set_index()
   call config%final()
   call vertical%final()
@@ -220,8 +220,8 @@ function ctor_grid_dist_vertical(grid, distribution, vertical, halo) result(this
   if( present(halo) )   call config%set("halo",halo)
   call config%set("levels",vertical%size())
   call this%reset_c_ptr( atlas__functionspace__StructuredColumns__new__grid_dist_vert( &
-      & grid%CPTR_PGIBUG_A, distribution%CPTR_PGIBUG_A, vertical%CPTR_PGIBUG_B, &
-      & config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), distribution%c_ptr(), vertical%c_ptr(), &
+      & config%c_ptr() ) )
   call this%set_index()
   call config%final()
   call this%return()
@@ -234,8 +234,8 @@ function ctor_grid_dist_config(grid, distribution, config) result(this)
   type(atlas_griddistribution), intent(in) :: distribution
   type(atlas_Config), intent (in) :: config
   call this%reset_c_ptr(atlas__functionspace__StructuredColumns__new__grid_dist_config( &
-      & grid%CPTR_PGIBUG_A, distribution%CPTR_PGIBUG_A, &
-      & config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), distribution%c_ptr(), &
+      & config%c_ptr() ) )
   call this%set_index()
   call this%return()
 end function
@@ -253,7 +253,7 @@ function ctor_grid_part(grid, partitioner, halo, levels) result(this)
   if( present(halo) )   call config%set("halo",halo)
   if( present(levels) ) call config%set("levels",levels)
   call this%reset_c_ptr( atlas__functionspace__StructuredColumns__new__grid_part( &
-      & grid%CPTR_PGIBUG_A, partitioner%CPTR_PGIBUG_A, config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), partitioner%c_ptr(), config%c_ptr() ) )
   call this%set_index()
   call config%final()
   call this%return()
@@ -273,8 +273,8 @@ function ctor_grid_part_levels(grid, partitioner, levels, halo) result(this)
   call config%set("levels",size(levels))
   vertical = atlas_Vertical(levels)
   call this%reset_c_ptr( atlas__functionspace__StructuredColumns__new__grid_part_vert( &
-      & grid%CPTR_PGIBUG_A, partitioner%CPTR_PGIBUG_A, vertical%CPTR_PGIBUG_B, &
-      & config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), partitioner%c_ptr(), vertical%c_ptr(), &
+      & config%c_ptr() ) )
   call this%set_index()
   call config%final()
   call vertical%final()
@@ -293,8 +293,8 @@ function ctor_grid_part_vertical(grid, partitioner, vertical, halo) result(this)
   if( present(halo) )   call config%set("halo",halo)
   call config%set("levels",vertical%size())
   call this%reset_c_ptr( atlas__functionspace__StructuredColumns__new__grid_part_vert( &
-      & grid%CPTR_PGIBUG_A, partitioner%CPTR_PGIBUG_A, vertical%CPTR_PGIBUG_B, &
-      & config%CPTR_PGIBUG_B ) )
+      & grid%c_ptr(), partitioner%c_ptr(), vertical%c_ptr(), &
+      & config%c_ptr() ) )
   call this%set_index()
   call config%final()
   call this%return()
@@ -306,7 +306,7 @@ subroutine gather_field(this,local,global)
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
   type(atlas_Field), intent(in) :: local
   type(atlas_Field), intent(inout) :: global
-  call atlas__functionspace__StructuredColumns__gather_field(this%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A)
+  call atlas__functionspace__StructuredColumns__gather_field(this%c_ptr(),local%c_ptr(),global%c_ptr())
 end subroutine
 
 subroutine gather_fieldset(this,local,global)
@@ -314,7 +314,7 @@ subroutine gather_fieldset(this,local,global)
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
   type(atlas_FieldSet), intent(in) :: local
   type(atlas_FieldSet), intent(inout) :: global
-  call atlas__functionspace__StructuredColumns__gather_fieldset(this%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A)
+  call atlas__functionspace__StructuredColumns__gather_fieldset(this%c_ptr(),local%c_ptr(),global%c_ptr())
 end subroutine
 
 subroutine scatter_field(this,global,local)
@@ -322,7 +322,7 @@ subroutine scatter_field(this,global,local)
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
   type(atlas_Field), intent(in) :: global
   type(atlas_Field), intent(inout) :: local
-  call atlas__functionspace__StructuredColumns__scatter_field(this%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A)
+  call atlas__functionspace__StructuredColumns__scatter_field(this%c_ptr(),global%c_ptr(),local%c_ptr())
 end subroutine
 
 subroutine scatter_fieldset(this,global,local)
@@ -330,7 +330,7 @@ subroutine scatter_fieldset(this,global,local)
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
   type(atlas_FieldSet), intent(in) :: global
   type(atlas_FieldSet), intent(inout) :: local
-  call atlas__functionspace__StructuredColumns__scatter_fieldset(this%CPTR_PGIBUG_A,global%CPTR_PGIBUG_A,local%CPTR_PGIBUG_A)
+  call atlas__functionspace__StructuredColumns__scatter_fieldset(this%c_ptr(),global%c_ptr(),local%c_ptr())
 end subroutine
 
 function checksum_fieldset(this,fieldset) result(checksum)
@@ -343,7 +343,7 @@ function checksum_fieldset(this,fieldset) result(checksum)
   integer(ATLAS_KIND_IDX) :: checksum_size
   integer(c_int) :: checksum_allocated
   call atlas__fs__StructuredColumns__checksum_fieldset( &
-    & this%CPTR_PGIBUG_A,fieldset%CPTR_PGIBUG_A,checksum_cptr,checksum_size,checksum_allocated)
+    & this%c_ptr(),fieldset%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
   allocate(character(len=checksum_size) :: checksum )
   checksum = c_ptr_to_string(checksum_cptr)
   if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
@@ -360,7 +360,7 @@ function checksum_field(this,field) result(checksum)
   integer(ATLAS_KIND_IDX) :: checksum_size
   integer(c_int) :: checksum_allocated
   call atlas__fs__StructuredColumns__checksum_field( &
-      & this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,checksum_cptr,checksum_size,checksum_allocated)
+      & this%c_ptr(),field%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
   allocate(character(len=checksum_size) :: checksum )
   checksum = c_ptr_to_string(checksum_cptr)
   if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
@@ -374,7 +374,7 @@ subroutine set_index(this)
   integer(ATLAS_KIND_IDX), pointer :: index_fptr(:)
   integer(ATLAS_KIND_IDX) :: i_min, i_max, j_min, j_max
   integer(ATLAS_KIND_IDX) :: ni, nj
-  call atlas__fs__StructuredColumns__index_host( this%CPTR_PGIBUG_A, index_cptr, i_min, i_max, j_min, j_max )
+  call atlas__fs__StructuredColumns__index_host( this%c_ptr(), index_cptr, i_min, i_max, j_min, j_max )
   ni = i_max-i_min+1;
   nj = j_max-j_min+1;
   call c_f_pointer( index_cptr, index_fptr, (/ni*nj/) )
@@ -385,14 +385,14 @@ function j_begin(this) result(j)
   use atlas_functionspace_StructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: j
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  j = atlas__fs__StructuredColumns__j_begin(this%CPTR_PGIBUG_A)
+  j = atlas__fs__StructuredColumns__j_begin(this%c_ptr())
 end function
 
 function j_end(this) result(j)
   use atlas_functionspace_StructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: j
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  j = atlas__fs__StructuredColumns__j_end(this%CPTR_PGIBUG_A)
+  j = atlas__fs__StructuredColumns__j_end(this%c_ptr())
 end function
 
 function i_begin(this,j) result(i)
@@ -400,7 +400,7 @@ function i_begin(this,j) result(i)
   integer(ATLAS_KIND_IDX) :: i
   integer(ATLAS_KIND_IDX), intent(in) :: j
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  i = atlas__fs__StructuredColumns__i_begin(this%CPTR_PGIBUG_A,j)
+  i = atlas__fs__StructuredColumns__i_begin(this%c_ptr(),j)
 end function
 
 function i_end(this,j) result(i)
@@ -408,7 +408,7 @@ function i_end(this,j) result(i)
   integer(ATLAS_KIND_IDX) :: i
   integer(ATLAS_KIND_IDX), intent(in) :: j
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  i = atlas__fs__StructuredColumns__i_end(this%CPTR_PGIBUG_A,j)
+  i = atlas__fs__StructuredColumns__i_end(this%c_ptr(),j)
 end function
 
 
@@ -416,14 +416,14 @@ function j_begin_halo(this) result(j)
   use atlas_functionspace_StructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: j
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  j = atlas__fs__StructuredColumns__j_begin_halo(this%CPTR_PGIBUG_A)
+  j = atlas__fs__StructuredColumns__j_begin_halo(this%c_ptr())
 end function
 
 function j_end_halo(this) result(j)
   use atlas_functionspace_StructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: j
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  j = atlas__fs__StructuredColumns__j_end_halo(this%CPTR_PGIBUG_A)
+  j = atlas__fs__StructuredColumns__j_end_halo(this%c_ptr())
 end function
 
 function i_begin_halo(this,j) result(i)
@@ -431,7 +431,7 @@ function i_begin_halo(this,j) result(i)
   integer(ATLAS_KIND_IDX) :: i
   integer(ATLAS_KIND_IDX), intent(in) :: j
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  i = atlas__fs__StructuredColumns__i_begin_halo(this%CPTR_PGIBUG_A,j)
+  i = atlas__fs__StructuredColumns__i_begin_halo(this%c_ptr(),j)
 end function
 
 function i_end_halo(this,j) result(i)
@@ -439,35 +439,35 @@ function i_end_halo(this,j) result(i)
   integer(ATLAS_KIND_IDX) :: i
   integer(ATLAS_KIND_IDX), intent(in) :: j
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  i = atlas__fs__StructuredColumns__i_end_halo(this%CPTR_PGIBUG_A,j)
+  i = atlas__fs__StructuredColumns__i_end_halo(this%c_ptr(),j)
 end function
 
 function get_size(this) result(size)
   use atlas_functionspace_StructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: size
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  size = atlas__fs__StructuredColumns__size(this%CPTR_PGIBUG_A)
+  size = atlas__fs__StructuredColumns__size(this%c_ptr())
 end function
 
 function get_size_owned(this) result(size)
   use atlas_functionspace_StructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: size
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  size = atlas__fs__StructuredColumns__sizeOwned(this%CPTR_PGIBUG_A)
+  size = atlas__fs__StructuredColumns__sizeOwned(this%c_ptr())
 end function
 
 function levels(this)
   use atlas_functionspace_StructuredColumns_c_binding
   integer(ATLAS_KIND_IDX) :: levels
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  levels = atlas__fs__StructuredColumns__levels(this%CPTR_PGIBUG_A)
+  levels = atlas__fs__StructuredColumns__levels(this%c_ptr())
 end function
 
 function xy(this) result(field)
   use atlas_functionspace_StructuredColumns_c_binding
   type(atlas_Field) :: field
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  field = atlas_Field( atlas__fs__StructuredColumns__xy(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__fs__StructuredColumns__xy(this%c_ptr()) )
   call field%return()
 end function
 
@@ -475,7 +475,7 @@ function z(this) result(field)
   use atlas_functionspace_StructuredColumns_c_binding
   type(atlas_Field) :: field
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  field = atlas_Field( atlas__fs__StructuredColumns__z(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__fs__StructuredColumns__z(this%c_ptr()) )
   call field%return()
 end function
 
@@ -484,7 +484,7 @@ function partition(this) result(field)
   use atlas_functionspace_StructuredColumns_c_binding
   type(atlas_Field) :: field
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  field = atlas_Field( atlas__fs__StructuredColumns__partition(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__fs__StructuredColumns__partition(this%c_ptr()) )
   call field%return()
 end function
 
@@ -492,7 +492,7 @@ function global_index(this) result(field)
   use atlas_functionspace_StructuredColumns_c_binding
   type(atlas_Field) :: field
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  field = atlas_Field( atlas__fs__StructuredColumns__global_index(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__fs__StructuredColumns__global_index(this%c_ptr()) )
   call field%return()
 end function
 
@@ -500,7 +500,7 @@ function index_i(this) result(field)
   use atlas_functionspace_StructuredColumns_c_binding
   type(atlas_Field) :: field
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  field = atlas_Field( atlas__fs__StructuredColumns__index_i(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__fs__StructuredColumns__index_i(this%c_ptr()) )
   call field%return()
 end function
 
@@ -508,7 +508,7 @@ function index_j(this) result(field)
   use atlas_functionspace_StructuredColumns_c_binding
   type(atlas_Field) :: field
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  field = atlas_Field( atlas__fs__StructuredColumns__index_j(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__fs__StructuredColumns__index_j(this%c_ptr()) )
   call field%return()
 end function
 
@@ -516,7 +516,7 @@ function grid(this)
   use atlas_functionspace_StructuredColumns_c_binding
   type(atlas_Grid) :: grid
   class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  grid = atlas_Grid( atlas__fs__StructuredColumns__grid(this%CPTR_PGIBUG_A) )
+  grid = atlas_Grid( atlas__fs__StructuredColumns__grid(this%c_ptr()) )
   call grid%return()
 end function
 

--- a/src/atlas_f/grid/atlas_GridDistribution_module.F90
+++ b/src/atlas_f/grid/atlas_GridDistribution_module.F90
@@ -100,7 +100,7 @@ function atlas_GridDistribution__ctor_Grid_Config( grid, config ) result(this)
   type(atlas_GridDistribution) :: this
   class(atlas_Grid), intent (in) :: grid
   type(atlas_Config), intent(in) :: config
-  call this%reset_c_ptr( atlas__GridDistribution__new__Grid_Config(grid%CPTR_PGIBUG_A, config%CPTR_PGIBUG_B) )
+  call this%reset_c_ptr( atlas__GridDistribution__new__Grid_Config(grid%c_ptr(), config%c_ptr()) )
   call this%return()
 end function
 
@@ -111,7 +111,7 @@ function atlas_GridDistribution__ctor_Grid_Partitioner( grid, partitioner ) resu
   type(atlas_GridDistribution) :: this
   class(atlas_Grid), intent (in) :: grid
   class(fckit_owned_object), intent(in) :: partitioner ! cannot use atlas_Partitioner as it would cause cyclic module dependencies
-  call this%reset_c_ptr( atlas__GridDistribution__new__Grid_Partitioner(grid%CPTR_PGIBUG_A, partitioner%CPTR_PGIBUG_A) )
+  call this%reset_c_ptr( atlas__GridDistribution__new__Grid_Partitioner(grid%c_ptr(), partitioner%c_ptr()) )
   call this%return()
 end function
 
@@ -122,7 +122,7 @@ function partition_int32(this, i) result(partition)
   integer(c_int) :: partition
   class(atlas_GridDistribution), intent(in) :: this
   integer(c_int), intent(in) :: i
-  partition = atlas__GridDistribution__partition_int32(this%CPTR_PGIBUG_A, i-1)
+  partition = atlas__GridDistribution__partition_int32(this%c_ptr(), i-1)
 end function
 
 function partition_int64(this, i) result(partition)
@@ -131,7 +131,7 @@ function partition_int64(this, i) result(partition)
   integer(c_int) :: partition
   class(atlas_GridDistribution), intent(in) :: this
   integer(c_long), intent(in) :: i
-  partition = atlas__GridDistribution__partition_int64(this%CPTR_PGIBUG_A, i-1)
+  partition = atlas__GridDistribution__partition_int64(this%c_ptr(), i-1)
 end function
 
 
@@ -141,7 +141,7 @@ function atlas_GridDistribution__nb_pts(this) result(nb_pts)
   class(atlas_GridDistribution) :: this
   integer(kind=ATLAS_KIND_IDX), allocatable :: nb_pts(:)
   allocate (nb_pts (this%nb_partitions ()))
-  call atlas__GridDistribution__nb_pts(this%CPTR_PGIBUG_A, nb_pts)
+  call atlas__GridDistribution__nb_pts(this%c_ptr(), nb_pts)
 end function
 
 function atlas_GridDistribution__nb_partitions(this) result(nb_partitions)
@@ -149,7 +149,7 @@ function atlas_GridDistribution__nb_partitions(this) result(nb_partitions)
   use atlas_distribution_c_binding
   class(atlas_GridDistribution), intent(in) :: this
   integer(c_long) :: nb_partitions
-  nb_partitions = atlas__atlas__GridDistribution__nb_partitions(this%CPTR_PGIBUG_A)
+  nb_partitions = atlas__atlas__GridDistribution__nb_partitions(this%c_ptr())
 end function
 
 ! ----------------------------------------------------------------------------------------

--- a/src/atlas_f/grid/atlas_Grid_module.F90
+++ b/src/atlas_f/grid/atlas_Grid_module.F90
@@ -517,7 +517,7 @@ function atlas_Grid__ctor_config(config) result(this)
   use atlas_grid_Structured_c_binding
   type(atlas_Grid) :: this
   type(atlas_Config), intent(in) :: config
-  call this%reset_c_ptr( atlas__grid__Structured__config(config%CPTR_PGIBUG_B) )
+  call this%reset_c_ptr( atlas__grid__Structured__config(config%c_ptr()) )
   call this%return()
 end function
 
@@ -536,7 +536,7 @@ function atlas_UnstructuredGrid__ctor_config(config) result(this)
   use atlas_grid_unstructured_c_binding
   type(atlas_UnstructuredGrid) :: this
   type(atlas_Config), intent(in) :: config
-  call this%reset_c_ptr( atlas__grid__Unstructured__config(config%CPTR_PGIBUG_B) )
+  call this%reset_c_ptr( atlas__grid__Unstructured__config(config%c_ptr()) )
   call this%return()
 end function
 
@@ -581,7 +581,7 @@ function atlas_StructuredGrid__ctor_config(config) result(this)
   use atlas_grid_Structured_c_binding
   type(atlas_StructuredGrid) :: this
   type(atlas_Config), intent(in) :: config
-  call this%reset_c_ptr( atlas__grid__Structured__config(config%CPTR_PGIBUG_B) )
+  call this%reset_c_ptr( atlas__grid__Structured__config(config%c_ptr()) )
   call this%return()
 end function
 
@@ -654,7 +654,7 @@ function atlas_ReducedGaussianGrid__ctor_projection_int32(nx, projection) result
   integer(c_int), intent(in)  :: nx(:)
   type(atlas_Projection), intent(in) :: projection
   call this%reset_c_ptr( &
-    & atlas__grid__reduced__ReducedGaussian_int_projection( nx, int(size(nx),c_long), projection%CPTR_PGIBUG_A ) )
+    & atlas__grid__reduced__ReducedGaussian_int_projection( nx, int(size(nx),c_long), projection%c_ptr() ) )
    call this%return()
 end function
 
@@ -665,7 +665,7 @@ function atlas_ReducedGaussianGrid__ctor_projection_int64(nx, projection) result
   integer(c_long), intent(in)  :: nx(:)
   type(atlas_Projection), intent(in) :: projection
   call this%reset_c_ptr( &
-    & atlas__grid__reduced__ReducedGaussian_long_projection( nx, int(size(nx),c_long), projection%CPTR_PGIBUG_A ) )
+    & atlas__grid__reduced__ReducedGaussian_long_projection( nx, int(size(nx),c_long), projection%c_ptr() ) )
   call this%return()
 end function
 
@@ -760,7 +760,7 @@ function atlas_Grid__name(this) result(name)
   character(len=:), allocatable :: name
   type(c_ptr) :: name_c_str
   integer :: size
-  call atlas__grid__Grid__name(this%CPTR_PGIBUG_A, name_c_str, size )
+  call atlas__grid__Grid__name(this%c_ptr(), name_c_str, size )
   name = c_ptr_to_string(name_c_str)
   call c_ptr_free(name_c_str)
 end function
@@ -770,14 +770,14 @@ function atlas_Grid__size(this) result(npts)
   use atlas_grid_Grid_c_binding
   class(atlas_Grid), intent(in) :: this
   integer(ATLAS_KIND_IDX) :: npts
-  npts = int(atlas__grid__Grid__size(this%CPTR_PGIBUG_A),ATLAS_KIND_IDX)
+  npts = int(atlas__grid__Grid__size(this%c_ptr()),ATLAS_KIND_IDX)
 end function
 
 function atlas_Grid__spec(this) result(spec)
   use atlas_grid_Grid_c_binding
   class(atlas_Grid), intent(in) :: this
   type(atlas_Config) :: spec
-  spec = atlas_Config( atlas__grid__Grid__spec(this%CPTR_PGIBUG_A) )
+  spec = atlas_Config( atlas__grid__Grid__spec(this%c_ptr()) )
   call spec%return ()
 end function
 
@@ -789,7 +789,7 @@ function uid(this)
   character(len=:), allocatable :: uid
   type(c_ptr) :: uid_c_str
   integer :: size
-  call atlas__grid__Grid__uid(this%CPTR_PGIBUG_A, uid_c_str, size )
+  call atlas__grid__Grid__uid(this%c_ptr(), uid_c_str, size )
   uid = c_ptr_to_string(uid_c_str)
   call c_ptr_free(uid_c_str)
 end function
@@ -799,7 +799,7 @@ function lonlat_bounding_box (this) result (bb)
   use atlas_grid_Grid_c_binding
   class(atlas_Grid), intent(in) :: this
   type(atlas_LonLatRectangularDomain) :: bb
-  bb = atlas_LonLatRectangularDomain(atlas__grid__Grid__lonlat_bounding_box (this%CPTR_PGIBUG_A))
+  bb = atlas_LonLatRectangularDomain(atlas__grid__Grid__lonlat_bounding_box (this%c_ptr()))
   call bb%return()
 end function
 
@@ -809,7 +809,7 @@ function Gaussian__N(this) result(N)
   use atlas_grid_Structured_c_binding
   class(atlas_GaussianGrid), intent(in) :: this
   integer(c_long) :: N
-  N = atlas__grid__Gaussian__N(this%CPTR_PGIBUG_A)
+  N = atlas__grid__Gaussian__N(this%c_ptr())
 end function
 
 function ReducedGaussian__N(this) result(N)
@@ -817,7 +817,7 @@ function ReducedGaussian__N(this) result(N)
   use atlas_grid_Structured_c_binding
   class(atlas_ReducedGaussianGrid), intent(in) :: this
   integer(c_long) :: N
-  N = atlas__grid__Gaussian__N(this%CPTR_PGIBUG_A)
+  N = atlas__grid__Gaussian__N(this%c_ptr())
 end function
 
 function RegularGaussian__N(this) result(N)
@@ -825,7 +825,7 @@ function RegularGaussian__N(this) result(N)
   use atlas_grid_Structured_c_binding
   class(atlas_RegularGaussianGrid), intent(in) :: this
   integer(c_long) :: N
-  N = atlas__grid__Gaussian__N(this%CPTR_PGIBUG_A)
+  N = atlas__grid__Gaussian__N(this%c_ptr())
 end function
 
 function Structured__ny(this) result(ny)
@@ -833,7 +833,7 @@ function Structured__ny(this) result(ny)
   use atlas_grid_Structured_c_binding
   class(atlas_StructuredGrid), intent(in) :: this
   integer(ATLAS_KIND_IDX) :: ny
-  ny = atlas__grid__Structured__ny(this%CPTR_PGIBUG_A)
+  ny = atlas__grid__Structured__ny(this%c_ptr())
 end function
 
 subroutine Structured__index2ij_int32(this, gidx, i, j) 
@@ -842,7 +842,7 @@ subroutine Structured__index2ij_int32(this, gidx, i, j)
   integer(c_int32_t), intent (in) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(ATLAS_KIND_IDX), intent(out) :: i, j
-  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, c_gidx(gidx), i, j)
+  call atlas__grid__Structured__index2ij(this%c_ptr(), c_gidx(gidx), i, j)
   i = i + 1
   j = j + 1
 end subroutine
@@ -853,7 +853,7 @@ subroutine Structured__index2ij_int64(this, gidx, i, j)
   integer(c_int64_t), intent (in) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(ATLAS_KIND_IDX), intent(out) :: i, j
-  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, c_gidx(gidx), i, j)
+  call atlas__grid__Structured__index2ij(this%c_ptr(), c_gidx(gidx), i, j)
   i = i + 1
   j = j + 1
 end subroutine
@@ -864,7 +864,7 @@ function Structured__ij_int32(this, gidx) result(ij)
   integer(c_int), intent (in) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(ATLAS_KIND_IDX) :: ij (2)
-  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, c_gidx(gidx), ij(1), ij(2))
+  call atlas__grid__Structured__index2ij(this%c_ptr(), c_gidx(gidx), ij(1), ij(2))
   ij = ij + 1
 end function
 
@@ -874,7 +874,7 @@ function Structured__ij_int64(this, gidx) result(ij)
   integer(c_long), intent (in) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(ATLAS_KIND_IDX) :: ij (2)
-  call atlas__grid__Structured__index2ij(this%CPTR_PGIBUG_A, c_gidx(gidx), ij(1), ij(2))
+  call atlas__grid__Structured__index2ij(this%c_ptr(), c_gidx(gidx), ij(1), ij(2))
   ij = ij + 1
 end function
 
@@ -884,7 +884,7 @@ function Structured__index_int32(this, i, j) result(gidx)
   integer(ATLAS_KIND_IDX) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_int), intent(in) :: i, j
-  gidx = int(1 + atlas__grid__Structured__index(this%CPTR_PGIBUG_A, c_idx(i), c_idx(j) ), ATLAS_KIND_IDX )
+  gidx = int(1 + atlas__grid__Structured__index(this%c_ptr(), c_idx(i), c_idx(j) ), ATLAS_KIND_IDX )
 end function
 
 function Structured__index_int64(this, i, j) result(gidx)
@@ -893,7 +893,7 @@ function Structured__index_int64(this, i, j) result(gidx)
   integer(ATLAS_KIND_IDX) :: gidx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_long), intent(in) :: i, j
-  gidx = int( 1 + atlas__grid__Structured__index(this%CPTR_PGIBUG_A, c_idx(i), c_idx(j) ), ATLAS_KIND_IDX )
+  gidx = int( 1 + atlas__grid__Structured__index(this%c_ptr(), c_idx(i), c_idx(j) ), ATLAS_KIND_IDX )
 end function
 
 function Structured__nx_int32(this, j) result(nx)
@@ -902,7 +902,7 @@ function Structured__nx_int32(this, j) result(nx)
   integer(ATLAS_KIND_IDX) :: nx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_int), intent(in) :: j
-  nx = atlas__grid__Structured__nx(this%CPTR_PGIBUG_A, c_idx(j) )
+  nx = atlas__grid__Structured__nx(this%c_ptr(), c_idx(j) )
 end function
 
 function Structured__nx_int64(this, j) result(nx)
@@ -911,14 +911,14 @@ function Structured__nx_int64(this, j) result(nx)
   integer(ATLAS_KIND_IDX) :: nx
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_long), intent(in) :: j
-  nx = atlas__grid__Structured__nx(this%CPTR_PGIBUG_A, c_idx(j) )
+  nx = atlas__grid__Structured__nx(this%c_ptr(), c_idx(j) )
 end function
 
 function Structured__reduced(this) result(reduced)
   use atlas_grid_Structured_c_binding
   class(atlas_StructuredGrid), intent(in) :: this
   logical :: reduced
-  if( atlas__grid__Structured__reduced(this%CPTR_PGIBUG_A) == 1 ) then
+  if( atlas__grid__Structured__reduced(this%c_ptr()) == 1 ) then
     reduced = .true.
   else
     reduced = .false.
@@ -932,7 +932,7 @@ function Structured__nx_array(this) result(nx)
   integer(ATLAS_KIND_IDX), pointer        :: nx(:)
   type   (c_ptr)                          :: nx_c_ptr
   integer(ATLAS_KIND_IDX)                 :: nx_size
-  call atlas__grid__Structured__nx_array(this%CPTR_PGIBUG_A, nx_c_ptr, nx_size)
+  call atlas__grid__Structured__nx_array(this%c_ptr(), nx_c_ptr, nx_size)
   call c_f_pointer(nx_c_ptr , nx , (/nx_size/))
 end function
 
@@ -941,7 +941,7 @@ function Structured__nxmax(this) result(nxmax)
   use atlas_grid_Structured_c_binding
   class(atlas_StructuredGrid), intent(in)  :: this
   integer(c_long)                          :: nxmax
-  nxmax = atlas__grid__Structured__nxmax(this%CPTR_PGIBUG_A)
+  nxmax = atlas__grid__Structured__nxmax(this%c_ptr())
 end function
 
 function Structured__nxmin(this) result(nxmin)
@@ -949,7 +949,7 @@ function Structured__nxmin(this) result(nxmin)
   use atlas_grid_Structured_c_binding
   class(atlas_StructuredGrid), intent(in)  :: this
   integer(c_long)                          :: nxmin
-  nxmin = atlas__grid__Structured__nxmin(this%CPTR_PGIBUG_A)
+  nxmin = atlas__grid__Structured__nxmin(this%c_ptr())
 end function
 
 function Structured__y_32(this, j) result(y)
@@ -958,7 +958,7 @@ function Structured__y_32(this, j) result(y)
   real(c_double) :: y
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_int),              intent(in) :: j
-  y = atlas__grid__Structured__y(this%CPTR_PGIBUG_A, c_idx(j) )
+  y = atlas__grid__Structured__y(this%c_ptr(), c_idx(j) )
 end function
 
 function Structured__y_64(this, j) result(y)
@@ -967,7 +967,7 @@ function Structured__y_64(this, j) result(y)
   real(c_double) :: y
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_long),             intent(in) :: j
-  y = atlas__grid__Structured__y(this%CPTR_PGIBUG_A, c_idx(j) )
+  y = atlas__grid__Structured__y(this%c_ptr(), c_idx(j) )
 end function
 
 function Structured__y_array(this) result(y)
@@ -977,7 +977,7 @@ function Structured__y_array(this) result(y)
   real   (c_double)       , pointer    :: y(:)
   type   (c_ptr)                       :: y_c_ptr
   integer(ATLAS_KIND_IDX)              :: y_size
-  call atlas__grid__Structured__y_array(this%CPTR_PGIBUG_A, &
+  call atlas__grid__Structured__y_array(this%c_ptr(), &
       & y_c_ptr, y_size)
   call c_f_pointer (y_c_ptr, y, (/y_size/))
 end function
@@ -988,7 +988,7 @@ function Structured__x_32(this, i,j) result(x)
   class(atlas_StructuredGrid), intent(in)  :: this
   real(c_double) :: x
   integer(c_int) :: i,j
-  x = atlas__grid__Structured__x(this%CPTR_PGIBUG_A, c_idx(i), c_idx(j))
+  x = atlas__grid__Structured__x(this%c_ptr(), c_idx(i), c_idx(j))
 end function
 
 function Structured__x_64(this, i,j) result(x)
@@ -997,7 +997,7 @@ function Structured__x_64(this, i,j) result(x)
   class(atlas_StructuredGrid), intent(in)  :: this
   real(c_double) :: x
   integer(c_long) :: i,j
-  x = atlas__grid__Structured__x(this%CPTR_PGIBUG_A, c_idx(i), c_idx(j))
+  x = atlas__grid__Structured__x(this%c_ptr(), c_idx(i), c_idx(j))
 end function
 
 function Structured__xy_32(this, i,j) result(xy)
@@ -1006,7 +1006,7 @@ function Structured__xy_32(this, i,j) result(xy)
   real(c_double) :: xy(2)
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_int) , intent(in) :: i,j
-  call atlas__grid__Structured__xy(this%CPTR_PGIBUG_A, c_idx(i), c_idx(j), xy)
+  call atlas__grid__Structured__xy(this%c_ptr(), c_idx(i), c_idx(j), xy)
 end function
 
 function Structured__xy_64(this, i,j) result(xy)
@@ -1015,7 +1015,7 @@ function Structured__xy_64(this, i,j) result(xy)
   real(c_double) :: xy(2)
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_long) , intent(in) :: i,j
-  call atlas__grid__Structured__xy(this%CPTR_PGIBUG_A, c_idx(i), c_idx(j), xy)
+  call atlas__grid__Structured__xy(this%c_ptr(), c_idx(i), c_idx(j), xy)
 end function
 
 function Structured__lonlat_32(this, i,j) result(lonlat)
@@ -1024,7 +1024,7 @@ function Structured__lonlat_32(this, i,j) result(lonlat)
   real(c_double) :: lonlat(2)
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_int) , intent(in) :: i,j
-  call atlas__grid__Structured__lonlat(this%CPTR_PGIBUG_A, c_idx(i), c_idx(j), lonlat)
+  call atlas__grid__Structured__lonlat(this%c_ptr(), c_idx(i), c_idx(j), lonlat)
 end function
 
 function Structured__lonlat_64(this, i,j) result(lonlat)
@@ -1033,7 +1033,7 @@ function Structured__lonlat_64(this, i,j) result(lonlat)
   real(c_double) :: lonlat(2)
   class(atlas_StructuredGrid), intent(in) :: this
   integer(c_long) , intent(in) :: i,j
-  call atlas__grid__Structured__lonlat(this%CPTR_PGIBUG_A, c_idx(i), c_idx(j), lonlat)
+  call atlas__grid__Structured__lonlat(this%c_ptr(), c_idx(i), c_idx(j), lonlat)
 end function
 
 ! ----------------------------------------------------------------------------------------

--- a/src/atlas_f/grid/atlas_Partitioner_module.F90
+++ b/src/atlas_f/grid/atlas_Partitioner_module.F90
@@ -78,7 +78,7 @@ function atlas_Partitioner__ctor( config ) result(this)
   use atlas_partitioner_c_binding
   type(atlas_Partitioner) :: this
   type(atlas_Config) :: config
-  call this%reset_c_ptr( atlas__grid__Partitioner__new( config%CPTR_PGIBUG_B ) )
+  call this%reset_c_ptr( atlas__grid__Partitioner__new( config%c_ptr() ) )
   call this%return()
 end function
 
@@ -103,11 +103,11 @@ function atlas_MatchingMeshPartitioner__ctor( mesh, config ) result(this)
   type(atlas_Config) :: opt_config
   if( present(config) ) then
     call this%reset_c_ptr( atlas__grid__MatchingMeshPartitioner__new( &
-      mesh%CPTR_PGIBUG_A, config%CPTR_PGIBUG_B ) )
+      mesh%c_ptr(), config%c_ptr() ) )
   else
     opt_config = atlas_Config()
     call this%reset_c_ptr( atlas__grid__MatchingMeshPartitioner__new( &
-      mesh%CPTR_PGIBUG_A, opt_config%CPTR_PGIBUG_B ) )
+      mesh%c_ptr(), opt_config%c_ptr() ) )
     call opt_config%final()
   endif
   call this%return()
@@ -124,11 +124,11 @@ function atlas_MatchingFunctionSpacePartitioner__ctor( functionspace, config ) r
   type(atlas_Config) :: opt_config
   if( present(config) ) then
     call this%reset_c_ptr( atlas__grid__MatchingFunctionSpacePartitioner__new( &
-      functionspace%CPTR_PGIBUG_A, config%CPTR_PGIBUG_B ) )
+      functionspace%c_ptr(), config%c_ptr() ) )
   else
     opt_config = atlas_Config()
     call this%reset_c_ptr( atlas__grid__MatchingFunctionSpacePartitioner__new( &
-      functionspace%CPTR_PGIBUG_A, opt_config%CPTR_PGIBUG_B ) )
+      functionspace%c_ptr(), opt_config%c_ptr() ) )
     call opt_config%final()
   endif
   call this%return()
@@ -141,7 +141,7 @@ function partition(this,grid) result(distribution)
   type(atlas_GridDistribution) :: distribution
   class(atlas_Partitioner), intent(in) :: this
   class(atlas_Grid), intent(in) :: grid
-  distribution = atlas_GridDistribution( atlas__grid__Partitioner__partition( this%CPTR_PGIBUG_A, grid%CPTR_PGIBUG_A ) )
+  distribution = atlas_GridDistribution( atlas__grid__Partitioner__partition( this%c_ptr(), grid%c_ptr() ) )
   call distribution%return()
 end function
 

--- a/src/atlas_f/grid/atlas_StencilComputer_module.F90
+++ b/src/atlas_f/grid/atlas_StencilComputer_module.F90
@@ -176,7 +176,7 @@ function atlas_StructuredGrid_ComputeNorth__ctor(grid, halo) result(this)
   type(atlas_StructuredGrid_ComputeNorth) :: this
   class(atlas_StructuredGrid), intent(in) :: grid
   integer(c_int), intent(in) :: halo
-  call this%reset_c_ptr( atlas__grid__ComputeNorth__new(grid%CPTR_PGIBUG_B, halo), &
+  call this%reset_c_ptr( atlas__grid__ComputeNorth__new(grid%c_ptr(), halo), &
     & fckit_c_deleter(atlas__grid__ComputeNorth__delete) )
   call this%return()
 end function
@@ -190,7 +190,7 @@ function atlas_StructuredGrid_ComputeWest__ctor(grid, halo) result(this)
   type(atlas_StructuredGrid_ComputeWest) :: this
   class(atlas_StructuredGrid), intent(in) :: grid
   integer(c_int), intent(in) :: halo
-  call this%reset_c_ptr( atlas__grid__ComputeWest__new(grid%CPTR_PGIBUG_B, halo), &
+  call this%reset_c_ptr( atlas__grid__ComputeWest__new(grid%c_ptr(), halo), &
     & fckit_c_deleter(atlas__grid__ComputeWest__delete) )
   call this%return()
 end function
@@ -233,7 +233,7 @@ function atlas_StructuredGrid_ComputeNorth__execute_real32(this, y) result(index
   integer(ATLAS_KIND_IDX) :: index
   class(atlas_StructuredGrid_ComputeNorth), intent(in) :: this
   real(c_float), intent(in) :: y
-  index = atlas__grid__ComputeNorth__execute_real32(this%CPTR_PGIBUG_B, y) + 1
+  index = atlas__grid__ComputeNorth__execute_real32(this%c_ptr(), y) + 1
 end function
 
 function atlas_StructuredGrid_ComputeNorth__execute_real64(this, y) result(index)
@@ -243,7 +243,7 @@ function atlas_StructuredGrid_ComputeNorth__execute_real64(this, y) result(index
   integer(ATLAS_KIND_IDX) :: index
   class(atlas_StructuredGrid_ComputeNorth), intent(in) :: this
   real(c_double), intent(in) :: y
-  index = atlas__grid__ComputeNorth__execute_real64(this%CPTR_PGIBUG_B, y) + 1
+  index = atlas__grid__ComputeNorth__execute_real64(this%c_ptr(), y) + 1
 end function
 ! ----------------------------------------------------------------------------------------
 
@@ -255,7 +255,7 @@ function atlas_StructuredGrid_ComputeWest__execute_real32(this, x, j) result(ind
   class(atlas_StructuredGrid_ComputeWest), intent(in) :: this
   real(c_float), intent(in) :: x
   integer(ATLAS_KIND_IDX), intent(in) :: j
-  index = atlas__grid__ComputeWest__execute_real32(this%CPTR_PGIBUG_B, x, j-int(1,ATLAS_KIND_IDX)) + 1
+  index = atlas__grid__ComputeWest__execute_real32(this%c_ptr(), x, j-int(1,ATLAS_KIND_IDX)) + 1
 end function
 
 function atlas_StructuredGrid_ComputeWest__execute_real64(this, x, j) result(index)
@@ -266,7 +266,7 @@ function atlas_StructuredGrid_ComputeWest__execute_real64(this, x, j) result(ind
   class(atlas_StructuredGrid_ComputeWest), intent(in) :: this
   real(c_double), intent(in) :: x
   integer(ATLAS_KIND_IDX), intent(in) :: j
-  index = atlas__grid__ComputeWest__execute_real64(this%CPTR_PGIBUG_B, x, j-int(1,ATLAS_KIND_IDX)) + 1
+  index = atlas__grid__ComputeWest__execute_real64(this%c_ptr(), x, j-int(1,ATLAS_KIND_IDX)) + 1
 end function
 ! ----------------------------------------------------------------------------------------
 

--- a/src/atlas_f/grid/atlas_Vertical_module.F90
+++ b/src/atlas_f/grid/atlas_Vertical_module.F90
@@ -117,7 +117,7 @@ function z( this )
   use atlas_vertical_c_binding
   type(atlas_Field) :: z
   class(atlas_Vertical), intent(in) :: this
-  z = atlas_Field( atlas__Vertical__z( this%CPTR_PGIBUG_B ) )
+  z = atlas_Field( atlas__Vertical__z( this%c_ptr() ) )
   call z%return()
 end function
 
@@ -128,7 +128,7 @@ function vsize( this )
   use, intrinsic :: iso_c_binding, only : c_int
   integer(c_int) :: vsize
   class(atlas_Vertical), intent(in) :: this
-  vsize = atlas__Vertical__size( this%CPTR_PGIBUG_B )
+  vsize = atlas__Vertical__size( this%c_ptr() )
 end function
 
 ! ----------------------------------------------------------------------------------------

--- a/src/atlas_f/interpolation/atlas_Interpolation_module.F90
+++ b/src/atlas_f/interpolation/atlas_Interpolation_module.F90
@@ -76,8 +76,8 @@ function atlas_Interpolation__config_funcspace(config,source,target) result(this
   type(atlas_Config), intent(in) :: config
   class(atlas_FunctionSpace), intent(in) :: source
   class(atlas_FunctionSpace), intent(in) :: target
-  this = atlas_Interpolation__cptr(atlas__interpolation__new(config%CPTR_PGIBUG_B, &
-      source%CPTR_PGIBUG_A,target%CPTR_PGIBUG_A))
+  this = atlas_Interpolation__cptr(atlas__interpolation__new(config%c_ptr(), &
+      source%c_ptr(),target%c_ptr()))
   call this%return()
 end function
 
@@ -90,8 +90,8 @@ function atlas_Interpolation__config_funcspace_field(config,source,target) resul
   type(atlas_Config), intent(in) :: config
   class(atlas_FunctionSpace), intent(in) :: source
   class(atlas_Field), intent(in) :: target
-  this = atlas_Interpolation__cptr(atlas__interpolation__new_tgt_field(config%CPTR_PGIBUG_B, &
-      source%CPTR_PGIBUG_A,target%CPTR_PGIBUG_A))
+  this = atlas_Interpolation__cptr(atlas__interpolation__new_tgt_field(config%c_ptr(), &
+      source%c_ptr(),target%c_ptr()))
   call this%return()
 end function
 
@@ -104,8 +104,8 @@ function atlas_Interpolation__config_funcspace_fieldset(config,source,target) re
   type(atlas_Config), intent(in) :: config
   class(atlas_FunctionSpace), intent(in) :: source
   class(atlas_FieldSet), intent(in) :: target
-  this = atlas_Interpolation__cptr(atlas__interpolation__new_tgt_fieldset(config%CPTR_PGIBUG_B, &
-      source%CPTR_PGIBUG_A,target%CPTR_PGIBUG_A))
+  this = atlas_Interpolation__cptr(atlas__interpolation__new_tgt_fieldset(config%c_ptr(), &
+      source%c_ptr(),target%c_ptr()))
   call this%return()
 end function
 
@@ -115,7 +115,7 @@ subroutine execute_field(this,source,target)
   class(atlas_Interpolation), intent(in) :: this
   class(atlas_Field), intent(in) :: source
   class(atlas_Field), intent(inout) :: target
-  call atlas__Interpolation__execute_field(this%CPTR_PGIBUG_A,source%CPTR_PGIBUG_A,target%CPTR_PGIBUG_A)
+  call atlas__Interpolation__execute_field(this%c_ptr(),source%c_ptr(),target%c_ptr())
 end subroutine
 
 subroutine execute_fieldset(this,source,target)
@@ -124,7 +124,7 @@ subroutine execute_fieldset(this,source,target)
   class(atlas_Interpolation), intent(in) :: this
   class(atlas_FieldSet), intent(in) :: source
   class(atlas_FieldSet), intent(inout) :: target
-  call atlas__Interpolation__execute_fieldset(this%CPTR_PGIBUG_A,source%CPTR_PGIBUG_A,target%CPTR_PGIBUG_A)
+  call atlas__Interpolation__execute_fieldset(this%c_ptr(),source%c_ptr(),target%c_ptr())
 end subroutine
 
 subroutine execute_adjoint_field(this,source,target)
@@ -133,7 +133,7 @@ subroutine execute_adjoint_field(this,source,target)
   class(atlas_Interpolation), intent(in) :: this
   class(atlas_Field), intent(inout) :: source
   class(atlas_Field), intent(in) :: target
-  call atlas__Interpolation__execute_adjoint_field(this%CPTR_PGIBUG_A,source%CPTR_PGIBUG_A,target%CPTR_PGIBUG_A)
+  call atlas__Interpolation__execute_adjoint_field(this%c_ptr(),source%c_ptr(),target%c_ptr())
 end subroutine
 
 subroutine execute_adjoint_fieldset(this,source,target)
@@ -142,7 +142,7 @@ subroutine execute_adjoint_fieldset(this,source,target)
   class(atlas_Interpolation), intent(in) :: this
   class(atlas_FieldSet), intent(inout) :: source
   class(atlas_FieldSet), intent(in) :: target
-  call atlas__Interpolation__execute_adjoint_fieldset(this%CPTR_PGIBUG_A,source%CPTR_PGIBUG_A,target%CPTR_PGIBUG_A)
+  call atlas__Interpolation__execute_adjoint_fieldset(this%c_ptr(),source%c_ptr(),target%c_ptr())
 end subroutine
 
 

--- a/src/atlas_f/mesh/atlas_Connectivity_module.F90
+++ b/src/atlas_f/mesh/atlas_Connectivity_module.F90
@@ -219,7 +219,7 @@ function Connectivity_constructor(name) result(this)
   call this%reset_c_ptr( atlas__Connectivity__create() )
   call this%set_access()
   if( present(name) ) then
-    call atlas__Connectivity__rename(this%CPTR_PGIBUG_A,c_str(name))
+    call atlas__Connectivity__rename(this%c_ptr(),c_str(name))
   endif
   call this%return()
 end function
@@ -232,7 +232,7 @@ function atlas_Connectivity__name(this) result(name)
   class(atlas_Connectivity), intent(in) :: this
   character(len=:), allocatable :: name
   type(c_ptr) :: name_c_str
-  name_c_str = atlas__Connectivity__name(this%CPTR_PGIBUG_A)
+  name_c_str = atlas__Connectivity__name(this%c_ptr())
   name = c_ptr_to_string(name_c_str)
 end function
 
@@ -277,7 +277,7 @@ function atlas_Connectivity__missing_value(this) result(val)
   use atlas_connectivity_c_binding
   integer(ATLAS_KIND_IDX) :: val
   class(atlas_Connectivity), intent(in) :: this
-  val = atlas__Connectivity__missing_value(this%CPTR_PGIBUG_A)
+  val = atlas__Connectivity__missing_value(this%c_ptr())
 end function
 
 pure function atlas_Connectivity__cols(this,r) result(val)
@@ -401,7 +401,7 @@ subroutine atlas_Connectivity__add_values_args_long(this,rows,cols,values)
   integer(c_long), intent(in) :: rows
   integer(c_long), intent(in) :: cols
   integer(ATLAS_KIND_IDX) :: values(:)
-  call atlas__connectivity__add_values(this%CPTR_PGIBUG_A,int(rows,ATLAS_KIND_IDX),int(cols,ATLAS_KIND_IDX),values)
+  call atlas__connectivity__add_values(this%c_ptr(),int(rows,ATLAS_KIND_IDX),int(cols,ATLAS_KIND_IDX),values)
 end subroutine
 
 subroutine atlas_Connectivity__add_values_args_idx(this,rows,cols,values)
@@ -411,7 +411,7 @@ subroutine atlas_Connectivity__add_values_args_idx(this,rows,cols,values)
   integer(c_int), intent(in) :: rows
   integer(c_int), intent(in) :: cols
   integer(ATLAS_KIND_IDX), intent(in) :: values(:)
-  call atlas__connectivity__add_values(this%CPTR_PGIBUG_A,int(rows,ATLAS_KIND_IDX),int(cols,ATLAS_KIND_IDX),values)
+  call atlas__connectivity__add_values(this%c_ptr(),int(rows,ATLAS_KIND_IDX),int(cols,ATLAS_KIND_IDX),values)
 end subroutine
 
 #if ATLAS_BITS_LOCAL != 32
@@ -424,7 +424,7 @@ subroutine atlas_Connectivity__add_values_args_int32(this,rows,cols,values)
   integer(c_int), intent(in) :: values(:)
   integer(ATLAS_KIND_IDX) :: idx_values(rows*cols)
   idx_values(:) = values(:)
-  call atlas__connectivity__add_values(this%CPTR_PGIBUG_A,int(rows,ATLAS_KIND_IDX),int(cols,ATLAS_KIND_IDX),idx_values)
+  call atlas__connectivity__add_values(this%c_ptr(),int(rows,ATLAS_KIND_IDX),int(cols,ATLAS_KIND_IDX),idx_values)
 end subroutine
 #endif
 
@@ -435,7 +435,7 @@ subroutine atlas_Connectivity__add_missing_args_long(this,rows,cols)
   class(atlas_Connectivity), intent(in) :: this
   integer(c_long) :: rows
   integer(c_long) :: cols
-  call atlas__connectivity__add_missing(this%CPTR_PGIBUG_A,int(rows,ATLAS_KIND_IDX),int(cols,ATLAS_KIND_IDX))
+  call atlas__connectivity__add_missing(this%c_ptr(),int(rows,ATLAS_KIND_IDX),int(cols,ATLAS_KIND_IDX))
 end subroutine
 
 subroutine atlas_Connectivity__add_missing_args_int(this,rows,cols)
@@ -444,7 +444,7 @@ subroutine atlas_Connectivity__add_missing_args_int(this,rows,cols)
   class(atlas_Connectivity), intent(in) :: this
   integer(c_int) :: rows
   integer(c_int) :: cols
-  call atlas__connectivity__add_missing(this%CPTR_PGIBUG_A,int(rows,ATLAS_KIND_IDX),int(cols,ATLAS_KIND_IDX))
+  call atlas__connectivity__add_missing(this%c_ptr(),int(rows,ATLAS_KIND_IDX),int(cols,ATLAS_KIND_IDX))
 end subroutine
 
 !========================================================
@@ -467,7 +467,7 @@ function MultiBlockConnectivity_constructor(name) result(this)
   call this%reset_c_ptr( atlas__MultiBlockConnectivity__create() )
   call this%set_access()
   if( present(name) ) then
-    call atlas__Connectivity__rename(this%CPTR_PGIBUG_A,c_str(name))
+    call atlas__Connectivity__rename(this%c_ptr(),c_str(name))
   endif
   call this%return()
 end function
@@ -476,7 +476,7 @@ function atlas_MultiBlockConnectivity__blocks(this) result(val)
   use atlas_connectivity_c_binding
   integer(ATLAS_KIND_IDX) :: val
   class(atlas_MultiBlockConnectivity), intent(in) :: this
-  val = atlas__MultiBlockConnectivity__blocks(this%CPTR_PGIBUG_A)
+  val = atlas__MultiBlockConnectivity__blocks(this%c_ptr())
 end function
 
 function atlas_MultiBlockConnectivity__block(this,block_idx) result(block)
@@ -485,7 +485,7 @@ function atlas_MultiBlockConnectivity__block(this,block_idx) result(block)
   class(atlas_MultiBlockConnectivity), intent(in) :: this
   integer(ATLAS_KIND_IDX) :: block_idx
   call block%reset_c_ptr( atlas__MultiBlockConnectivity__block( &
-    this%CPTR_PGIBUG_A,int(block_idx-1_ATLAS_KIND_IDX,ATLAS_KIND_IDX) ) )
+    this%c_ptr(),int(block_idx-1_ATLAS_KIND_IDX,ATLAS_KIND_IDX) ) )
 end function
 
 !========================================================
@@ -506,7 +506,7 @@ subroutine atlas_BlockConnectivity__data(this,data)
   type(c_ptr) :: data_cptr
   integer(ATLAS_KIND_IDX) :: rows
   integer(ATLAS_KIND_IDX) :: cols
-  call atlas__BlockConnectivity__data(this%CPTR_PGIBUG_A,data_cptr,rows,cols)
+  call atlas__BlockConnectivity__data(this%c_ptr(),data_cptr,rows,cols)
   call c_f_pointer (data_cptr, data, [cols,rows])
 end subroutine
 
@@ -514,21 +514,21 @@ function atlas_BlockConnectivity__rows(this) result(val)
   use atlas_connectivity_c_binding
   integer(ATLAS_KIND_IDX) :: val
   class(atlas_BlockConnectivity), intent(in) :: this
-  val = atlas__BlockConnectivity__rows(this%CPTR_PGIBUG_A)
+  val = atlas__BlockConnectivity__rows(this%c_ptr())
 end function
 
 function atlas_BlockConnectivity__cols(this) result(val)
   use atlas_connectivity_c_binding
   integer(ATLAS_KIND_IDX) :: val
   class(atlas_BlockConnectivity), intent(in) :: this
-  val = atlas__BlockConnectivity__cols(this%CPTR_PGIBUG_A)
+  val = atlas__BlockConnectivity__cols(this%c_ptr())
 end function
 
 function atlas_BlockConnectivity__missing_value(this) result(val)
   use atlas_connectivity_c_binding
   integer(ATLAS_KIND_IDX) :: val
   class(atlas_BlockConnectivity), intent(in) :: this
-  val = atlas__BlockConnectivity__missing_value(this%CPTR_PGIBUG_A) + 1
+  val = atlas__BlockConnectivity__missing_value(this%c_ptr()) + 1
 end function
 
 !========================================================
@@ -538,16 +538,16 @@ subroutine set_access(this)
   class(atlas_Connectivity), intent(inout) :: this
   type(c_ptr) :: ctxt
   integer(c_int) :: have_ctxt
-  have_ctxt = atlas__connectivity__ctxt(this%CPTR_PGIBUG_A,ctxt)
+  have_ctxt = atlas__connectivity__ctxt(this%c_ptr(),ctxt)
   if( have_ctxt == 1 ) then
     call c_f_pointer(ctxt,this%access)
   else
     allocate( this%access )
-    call atlas__connectivity__register_ctxt  ( this%CPTR_PGIBUG_A, c_loc(this%access) )
-    call atlas__connectivity__register_update( this%CPTR_PGIBUG_A, c_funloc(update_access_c) )
-    call atlas__connectivity__register_delete( this%CPTR_PGIBUG_A, c_funloc(delete_access_c) )
+    call atlas__connectivity__register_ctxt  ( this%c_ptr(), c_loc(this%access) )
+    call atlas__connectivity__register_update( this%c_ptr(), c_funloc(update_access_c) )
+    call atlas__connectivity__register_delete( this%c_ptr(), c_funloc(delete_access_c) )
 
-    this%access%connectivity_ptr = this%CPTR_PGIBUG_A
+    this%access%connectivity_ptr = this%c_ptr()
     call update_access(this%access)
   endif
 end subroutine

--- a/src/atlas_f/mesh/atlas_ElementType_module.F90
+++ b/src/atlas_f/mesh/atlas_ElementType_module.F90
@@ -97,14 +97,14 @@ function nb_nodes(this)
   use atlas_elementtype_c_binding
   integer(ATLAS_KIND_IDX) :: nb_nodes
   class(atlas_ElementType), intent(in) :: this
-  nb_nodes = atlas__mesh__ElementType__nb_nodes(this%CPTR_PGIBUG_A)
+  nb_nodes = atlas__mesh__ElementType__nb_nodes(this%c_ptr())
 end function
 
 function nb_edges(this)
   use atlas_elementtype_c_binding
   integer(ATLAS_KIND_IDX) :: nb_edges
   class(atlas_ElementType), intent(in) :: this
-  nb_edges = atlas__mesh__ElementType__nb_edges(this%CPTR_PGIBUG_A)
+  nb_edges = atlas__mesh__ElementType__nb_edges(this%c_ptr())
 end function
 
 function name(this)
@@ -114,7 +114,7 @@ function name(this)
   character(len=:), allocatable :: name
   class(atlas_ElementType) :: this
   type(c_ptr) :: name_c_str
-  name_c_str = atlas__mesh__ElementType__name(this%CPTR_PGIBUG_A)
+  name_c_str = atlas__mesh__ElementType__name(this%c_ptr())
   name = c_ptr_to_string(name_c_str)
 end function
 
@@ -124,7 +124,7 @@ function parametric(this)
   logical :: parametric
   class(atlas_ElementType), intent(in) :: this
   integer(c_int) :: parametric_int
-  parametric_int = atlas__mesh__ElementType__parametric(this%CPTR_PGIBUG_A)
+  parametric_int = atlas__mesh__ElementType__parametric(this%c_ptr())
   if( parametric_int == 0 ) then
     parametric = .False.
   else

--- a/src/atlas_f/mesh/atlas_Elements_module.F90
+++ b/src/atlas_f/mesh/atlas_Elements_module.F90
@@ -81,7 +81,7 @@ function atlas_Elements__size(this) result(val)
   use atlas_elements_c_binding
   integer(ATLAS_KIND_IDX) :: val
   class(atlas_Elements), intent(in) :: this
-  val = atlas__mesh__Elements__size(this%CPTR_PGIBUG_A)
+  val = atlas__mesh__Elements__size(this%c_ptr())
 end function
 
 function node_connectivity(this) result(connectivity)
@@ -90,7 +90,7 @@ function node_connectivity(this) result(connectivity)
   class(atlas_Elements), intent(in) :: this
   type(atlas_BlockConnectivity) :: connectivity
   connectivity = atlas_BlockConnectivity( &
-      atlas__mesh__Elements__node_connectivity(this%CPTR_PGIBUG_A) )
+      atlas__mesh__Elements__node_connectivity(this%c_ptr()) )
   !call connectivity%return()
 end function
 
@@ -100,7 +100,7 @@ function edge_connectivity(this) result(connectivity)
   class(atlas_Elements), intent(in) :: this
   type(atlas_BlockConnectivity) :: connectivity
   connectivity = atlas_BlockConnectivity( &
-      atlas__mesh__Elements__edge_connectivity(this%CPTR_PGIBUG_A) )
+      atlas__mesh__Elements__edge_connectivity(this%c_ptr()) )
   !call connectivity%return()
 end function
 
@@ -110,7 +110,7 @@ function cell_connectivity(this) result(connectivity)
   class(atlas_Elements), intent(in) :: this
   type(atlas_BlockConnectivity) :: connectivity
   connectivity = atlas_BlockConnectivity( &
-      atlas__mesh__Elements__cell_connectivity(this%CPTR_PGIBUG_A) )
+      atlas__mesh__Elements__cell_connectivity(this%c_ptr()) )
   !call connectivity%return()
 end function
 
@@ -120,7 +120,7 @@ function element_type(this) result(etype)
   class(atlas_Elements), intent(in) :: this
   type(atlas_ElementType) :: etype
   etype = atlas_ElementType( &
-      atlas__mesh__Elements__element_type(this%CPTR_PGIBUG_A) )
+      atlas__mesh__Elements__element_type(this%c_ptr()) )
   call etype%return()
 end function
 
@@ -129,7 +129,7 @@ subroutine add_elements_long(this,nb_elements)
   use atlas_elements_c_binding
   class(atlas_Elements), intent(inout) :: this
   integer(c_long) :: nb_elements
-  call atlas__mesh__Elements__add(this%CPTR_PGIBUG_A,int(nb_elements,ATLAS_KIND_IDX))
+  call atlas__mesh__Elements__add(this%c_ptr(),int(nb_elements,ATLAS_KIND_IDX))
 end subroutine
 
 subroutine add_elements_int(this,nb_elements)
@@ -137,14 +137,14 @@ subroutine add_elements_int(this,nb_elements)
   use atlas_elements_c_binding
   class(atlas_Elements), intent(inout) :: this
   integer(c_int) :: nb_elements
-  call atlas__mesh__Elements__add(this%CPTR_PGIBUG_A,int(nb_elements,ATLAS_KIND_IDX))
+  call atlas__mesh__Elements__add(this%c_ptr(),int(nb_elements,ATLAS_KIND_IDX))
 end subroutine
 
 function nb_fields(this) result(val)
   use atlas_elements_c_binding
   integer(ATLAS_KIND_IDX) :: val
   class(atlas_Elements), intent(in) :: this
-  val = atlas__mesh__Elements__nb_fields(this%CPTR_PGIBUG_A)
+  val = atlas__mesh__Elements__nb_fields(this%c_ptr())
 end function
 
 function has_field(this,name) result(val)
@@ -153,7 +153,7 @@ function has_field(this,name) result(val)
   logical :: val
   class(atlas_Elements), intent(in) :: this
   character(len=*), intent(in) :: name
-  if( atlas__mesh__Elements__has_field(this%CPTR_PGIBUG_A,c_str(name)) == 0 ) then
+  if( atlas__mesh__Elements__has_field(this%c_ptr(),c_str(name)) == 0 ) then
     val = .False.
   else
     val = .True.
@@ -167,7 +167,7 @@ function field_by_name(this,name) result(field)
   type(atlas_Field) :: field
   class(atlas_Elements), intent(in) :: this
   character(len=*), intent(in) :: name
-  field = atlas_Field( atlas__mesh__Elements__field_by_name(this%CPTR_PGIBUG_A,c_str(name)) )
+  field = atlas_Field( atlas__mesh__Elements__field_by_name(this%c_ptr(),c_str(name)) )
   call field%return()
 end function
 
@@ -178,7 +178,7 @@ function field_by_idx_long(this,idx) result(field)
   type(atlas_Field) :: field
   class(atlas_Elements), intent(in) :: this
   integer(c_long), intent(in) :: idx
-  field = atlas_Field( atlas__mesh__Elements__field_by_idx(this%CPTR_PGIBUG_A,int(idx-1_c_long,ATLAS_KIND_IDX) ) )
+  field = atlas_Field( atlas__mesh__Elements__field_by_idx(this%c_ptr(),int(idx-1_c_long,ATLAS_KIND_IDX) ) )
   call field%return()
 end function
 
@@ -189,7 +189,7 @@ function field_by_idx_int(this,idx) result(field)
   type(atlas_Field) :: field
   class(atlas_Elements), intent(in) :: this
   integer(c_int), intent(in) :: idx
-  field = atlas_Field( atlas__mesh__Elements__field_by_idx(this%CPTR_PGIBUG_A,int(idx-1_c_int,ATLAS_KIND_IDX) ) )
+  field = atlas_Field( atlas__mesh__Elements__field_by_idx(this%c_ptr(),int(idx-1_c_int,ATLAS_KIND_IDX) ) )
   call field%return()
 end function
 
@@ -198,7 +198,7 @@ function global_index(this) result(field)
   use atlas_Field_module, only: atlas_Field
   type(atlas_Field) :: field
   class(atlas_Elements), intent(in) :: this
-  field = atlas_Field( atlas__mesh__Elements__global_index(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__mesh__Elements__global_index(this%c_ptr()) )
   call field%return()
 end function
 
@@ -207,7 +207,7 @@ function remote_index(this) result(field)
   use atlas_Field_module, only: atlas_Field
   type(atlas_Field) :: field
   class(atlas_Elements), intent(in) :: this
-  field = atlas_Field( atlas__mesh__Elements__remote_index(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__mesh__Elements__remote_index(this%c_ptr()) )
   call field%return()
 end function
 
@@ -216,7 +216,7 @@ function partition(this) result(field)
   use atlas_Field_module, only: atlas_Field
   type(atlas_Field) :: field
   class(atlas_Elements), intent(in) :: this
-  field = atlas_Field( atlas__mesh__Elements__partition(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__mesh__Elements__partition(this%c_ptr()) )
   call field%return()
 end function
 
@@ -225,7 +225,7 @@ function halo(this) result(field)
   use atlas_Field_module, only: atlas_Field
   type(atlas_Field) :: field
   class(atlas_Elements), intent(in) :: this
-  field = atlas_Field( atlas__mesh__Elements__halo(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__mesh__Elements__halo(this%c_ptr()) )
   call field%return()
 end function
 
@@ -233,14 +233,14 @@ function atlas_Elements__begin(this) result(val)
   use atlas_elements_c_binding
   integer(ATLAS_KIND_IDX) :: val
   class(atlas_Elements), intent(in) :: this
-  val = atlas__mesh__Elements__begin(this%CPTR_PGIBUG_A) + 1
+  val = atlas__mesh__Elements__begin(this%c_ptr()) + 1
 end function
 
 function atlas_Elements__end(this) result(val)
   use atlas_elements_c_binding
   integer(ATLAS_KIND_IDX) :: val
   class(atlas_Elements), intent(in) :: this
-  val = atlas__mesh__Elements__end(this%CPTR_PGIBUG_A)
+  val = atlas__mesh__Elements__end(this%c_ptr())
 end function
 
 !-------------------------------------------------------------------------------

--- a/src/atlas_f/mesh/atlas_HybridElements_module.F90
+++ b/src/atlas_f/mesh/atlas_HybridElements_module.F90
@@ -117,7 +117,7 @@ function atlas_HybridElements__size(this) result(val)
   use atlas_hybridelements_c_binding
   integer(ATLAS_KIND_IDX) :: val
   class(atlas_HybridElements), intent(in) :: this
-  val = atlas__mesh__HybridElements__size(this%CPTR_PGIBUG_A)
+  val = atlas__mesh__HybridElements__size(this%c_ptr())
 end function
 
 function node_connectivity(this) result(connectivity)
@@ -125,7 +125,7 @@ function node_connectivity(this) result(connectivity)
   class(atlas_HybridElements), intent(in) :: this
   type(atlas_MultiBlockConnectivity) :: connectivity
   connectivity = atlas_MultiBlockConnectivity( &
-      atlas__mesh__HybridElements__node_connectivity(this%CPTR_PGIBUG_A) )
+      atlas__mesh__HybridElements__node_connectivity(this%c_ptr()) )
   call connectivity%return()
 end function
 
@@ -134,7 +134,7 @@ function edge_connectivity(this) result(connectivity)
   class(atlas_HybridElements), intent(in) :: this
   type(atlas_MultiBlockConnectivity) :: connectivity
   connectivity = atlas_MultiBlockConnectivity( &
-      atlas__mesh__HybridElements__edge_connectivity(this%CPTR_PGIBUG_A) )
+      atlas__mesh__HybridElements__edge_connectivity(this%c_ptr()) )
   call connectivity%return()
 end function
 
@@ -143,7 +143,7 @@ function cell_connectivity(this) result(connectivity)
   class(atlas_HybridElements), intent(in) :: this
   type(atlas_MultiBlockConnectivity) :: connectivity
   connectivity = atlas_MultiBlockConnectivity( &
-      atlas__mesh__HybridElements__cell_connectivity(this%CPTR_PGIBUG_A) )
+      atlas__mesh__HybridElements__cell_connectivity(this%c_ptr()) )
   call connectivity%return()
 end function
 
@@ -153,7 +153,7 @@ subroutine add_elements_int(this,elementtype,nb_elements)
   class(atlas_HybridElements), intent(inout) :: this
   type(atlas_ElementType) :: elementtype
   integer(c_int) :: nb_elements
-  call atlas__mesh__HybridElements__add_elements(this%CPTR_PGIBUG_A,elementtype%CPTR_PGIBUG_A,int(nb_elements,ATLAS_KIND_IDX))
+  call atlas__mesh__HybridElements__add_elements(this%c_ptr(),elementtype%c_ptr(),int(nb_elements,ATLAS_KIND_IDX))
 end subroutine
 
 subroutine add_elements_long(this,elementtype,nb_elements)
@@ -162,7 +162,7 @@ subroutine add_elements_long(this,elementtype,nb_elements)
   class(atlas_HybridElements), intent(inout) :: this
   type(atlas_ElementType) :: elementtype
   integer(c_long) :: nb_elements
-  call atlas__mesh__HybridElements__add_elements(this%CPTR_PGIBUG_A,elementtype%CPTR_PGIBUG_A,int(nb_elements,ATLAS_KIND_IDX))
+  call atlas__mesh__HybridElements__add_elements(this%c_ptr(),elementtype%c_ptr(),int(nb_elements,ATLAS_KIND_IDX))
 end subroutine
 
 subroutine add_elements_with_nodes_int(this,elementtype,nb_elements,node_connectivity)
@@ -172,8 +172,8 @@ subroutine add_elements_with_nodes_int(this,elementtype,nb_elements,node_connect
   type(atlas_ElementType), intent(in) :: elementtype
   integer(c_int), intent(in) :: nb_elements
   integer(ATLAS_KIND_IDX), intent(in) :: node_connectivity(:)
-  call atlas__mesh__HybridElements__add_elements_with_nodes(this%CPTR_PGIBUG_A,&
-    & elementtype%CPTR_PGIBUG_A,int(nb_elements,ATLAS_KIND_IDX),node_connectivity,1)
+  call atlas__mesh__HybridElements__add_elements_with_nodes(this%c_ptr(),&
+    & elementtype%c_ptr(),int(nb_elements,ATLAS_KIND_IDX),node_connectivity,1)
 end subroutine
 
 subroutine add_elements_with_nodes_long(this,elementtype,nb_elements,node_connectivity)
@@ -183,8 +183,8 @@ subroutine add_elements_with_nodes_long(this,elementtype,nb_elements,node_connec
   type(atlas_ElementType), intent(in) :: elementtype
   integer(c_long), intent(in) :: nb_elements
   integer(ATLAS_KIND_IDX), intent(in) :: node_connectivity(:)
-  call atlas__mesh__HybridElements__add_elements_with_nodes(this%CPTR_PGIBUG_A,&
-    & elementtype%CPTR_PGIBUG_A,int(nb_elements,ATLAS_KIND_IDX),node_connectivity,1)
+  call atlas__mesh__HybridElements__add_elements_with_nodes(this%c_ptr(),&
+    & elementtype%c_ptr(),int(nb_elements,ATLAS_KIND_IDX),node_connectivity,1)
 end subroutine
 
 #if ATLAS_BITS_LOCAL != 32
@@ -198,8 +198,8 @@ subroutine add_elements_with_nodes_int_int32(this,elementtype,nb_elements,node_c
   integer(ATLAS_KIND_IDX), allocatable :: idx_node_connectivity(:)
   allocate( idx_node_connectivity( nb_elements * elementtype%nb_nodes() ) )
   idx_node_connectivity(:) = node_connectivity(:)
-  call atlas__mesh__HybridElements__add_elements_with_nodes(this%CPTR_PGIBUG_A,&
-    & elementtype%CPTR_PGIBUG_A,int(nb_elements,ATLAS_KIND_IDX),idx_node_connectivity,1)
+  call atlas__mesh__HybridElements__add_elements_with_nodes(this%c_ptr(),&
+    & elementtype%c_ptr(),int(nb_elements,ATLAS_KIND_IDX),idx_node_connectivity,1)
   deallocate( idx_node_connectivity )
 end subroutine
 
@@ -213,8 +213,8 @@ subroutine add_elements_with_nodes_long_int32(this,elementtype,nb_elements,node_
   integer(ATLAS_KIND_IDX), allocatable :: idx_node_connectivity(:)
   allocate( idx_node_connectivity( nb_elements * elementtype%nb_nodes() ) )
   idx_node_connectivity(:) = node_connectivity(:)
-  call atlas__mesh__HybridElements__add_elements_with_nodes(this%CPTR_PGIBUG_A,&
-    & elementtype%CPTR_PGIBUG_A,int(nb_elements,ATLAS_KIND_IDX),idx_node_connectivity,1)
+  call atlas__mesh__HybridElements__add_elements_with_nodes(this%c_ptr(),&
+    & elementtype%c_ptr(),int(nb_elements,ATLAS_KIND_IDX),idx_node_connectivity,1)
   deallocate( idx_node_connectivity )
 end subroutine
 #endif
@@ -223,7 +223,7 @@ subroutine add_field(this,field)
   use atlas_hybridelements_c_binding
   class(atlas_HybridElements), intent(inout) :: this
   type(atlas_Field), intent(in) :: field
-  call atlas__mesh__HybridElements__add_field(this%CPTR_PGIBUG_A, field%CPTR_PGIBUG_A)
+  call atlas__mesh__HybridElements__add_field(this%c_ptr(), field%c_ptr())
 end subroutine
 
 
@@ -231,14 +231,14 @@ function nb_types(this) result(val)
   use atlas_hybridelements_c_binding
   integer(ATLAS_KIND_IDX) :: val
   class(atlas_HybridElements), intent(in) :: this
-  val = atlas__mesh__HybridElements__nb_types(this%CPTR_PGIBUG_A)
+  val = atlas__mesh__HybridElements__nb_types(this%c_ptr())
 end function
 
 function nb_fields(this) result(val)
   use atlas_hybridelements_c_binding
   integer(ATLAS_KIND_IDX) :: val
   class(atlas_HybridElements), intent(in) :: this
-  val = atlas__mesh__HybridElements__nb_fields(this%CPTR_PGIBUG_A)
+  val = atlas__mesh__HybridElements__nb_fields(this%c_ptr())
 end function
 
 function has_field(this,name) result(val)
@@ -247,7 +247,7 @@ function has_field(this,name) result(val)
   logical :: val
   class(atlas_HybridElements), intent(in) :: this
   character(len=*), intent(in) :: name
-  if( atlas__mesh__HybridElements__has_field(this%CPTR_PGIBUG_A,c_str(name)) == 0 ) then
+  if( atlas__mesh__HybridElements__has_field(this%c_ptr(),c_str(name)) == 0 ) then
     val = .False.
   else
     val = .True.
@@ -260,7 +260,7 @@ function field_by_name(this,name) result(field)
   type(atlas_Field) :: field
   class(atlas_HybridElements), intent(in) :: this
   character(len=*), intent(in) :: name
-  field = atlas_Field( atlas__mesh__HybridElements__field_by_name(this%CPTR_PGIBUG_A,c_str(name)) )
+  field = atlas_Field( atlas__mesh__HybridElements__field_by_name(this%c_ptr(),c_str(name)) )
   call field%return()
 end function
 
@@ -270,7 +270,7 @@ function field_by_idx_long(this,idx) result(field)
   type(atlas_Field) :: field
   class(atlas_HybridElements), intent(in) :: this
   integer(c_long), intent(in) :: idx
-  field = atlas_Field( atlas__mesh__HybridElements__field_by_idx(this%CPTR_PGIBUG_A,int(idx-1_c_long,ATLAS_KIND_IDX) ) )
+  field = atlas_Field( atlas__mesh__HybridElements__field_by_idx(this%c_ptr(),int(idx-1_c_long,ATLAS_KIND_IDX) ) )
   call field%return()
 end function
 
@@ -280,7 +280,7 @@ function field_by_idx_int(this,idx) result(field)
   type(atlas_Field) :: field
   class(atlas_HybridElements), intent(in) :: this
   integer(c_int), intent(in) :: idx
-  field = atlas_Field( atlas__mesh__HybridElements__field_by_idx(this%CPTR_PGIBUG_A,int(idx-1_c_int,ATLAS_KIND_IDX) ) )
+  field = atlas_Field( atlas__mesh__HybridElements__field_by_idx(this%c_ptr(),int(idx-1_c_int,ATLAS_KIND_IDX) ) )
   call field%return()
 end function
 
@@ -288,7 +288,7 @@ function global_index(this) result(field)
   use atlas_hybridelements_c_binding
   type(atlas_Field) :: field
   class(atlas_HybridElements), intent(in) :: this
-  field = atlas_Field( atlas__mesh__HybridElements__global_index(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__mesh__HybridElements__global_index(this%c_ptr()) )
   call field%return()
 end function
 
@@ -296,7 +296,7 @@ function remote_index(this) result(field)
   use atlas_hybridelements_c_binding
   type(atlas_Field) :: field
   class(atlas_HybridElements), intent(in) :: this
-  field = atlas_Field( atlas__mesh__HybridElements__remote_index(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__mesh__HybridElements__remote_index(this%c_ptr()) )
   call field%return()
 end function
 
@@ -304,7 +304,7 @@ function partition(this) result(field)
   use atlas_hybridelements_c_binding
   type(atlas_Field) :: field
   class(atlas_HybridElements), intent(in) :: this
-  field = atlas_Field( atlas__mesh__HybridElements__partition(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__mesh__HybridElements__partition(this%c_ptr()) )
   call field%return()
 end function
 
@@ -312,7 +312,7 @@ function halo(this) result(field)
   use atlas_hybridelements_c_binding
   type(atlas_Field) :: field
   class(atlas_HybridElements), intent(in) :: this
-  field = atlas_Field( atlas__mesh__HybridElements__halo(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__mesh__HybridElements__halo(this%c_ptr()) )
   call field%return()
 end function
 
@@ -322,7 +322,7 @@ function elements_long(this,idx) result(elements)
   type(atlas_Elements) :: elements
   class(atlas_HybridElements), intent(in) :: this
   integer(c_long), intent(in) :: idx
-  elements = atlas_Elements( atlas__mesh__HybridElements__elements(this%CPTR_PGIBUG_A,int(idx-1_c_long,ATLAS_KIND_IDX) ) )
+  elements = atlas_Elements( atlas__mesh__HybridElements__elements(this%c_ptr(),int(idx-1_c_long,ATLAS_KIND_IDX) ) )
   call elements%return()
 end function
 
@@ -332,7 +332,7 @@ function elements_int(this,idx) result(elements)
   type(atlas_Elements) :: elements
   class(atlas_HybridElements), intent(in) :: this
   integer(c_int), intent(in) :: idx
-  elements = atlas_Elements( atlas__mesh__HybridElements__elements(this%CPTR_PGIBUG_A,int(idx-1_c_int,ATLAS_KIND_IDX) ) )
+  elements = atlas_Elements( atlas__mesh__HybridElements__elements(this%c_ptr(),int(idx-1_c_int,ATLAS_KIND_IDX) ) )
   call elements%return()
 end function
 

--- a/src/atlas_f/mesh/atlas_MeshBuilder_module.F90
+++ b/src/atlas_f/mesh/atlas_MeshBuilder_module.F90
@@ -104,7 +104,7 @@ function atlas_TriangularMeshBuilder__build(this, &
   view1d_triag_global_index => array_view1d(triag_global_index)
   view1d_triag_nodes => array_view1d(triag_nodes)
   call mesh%reset_c_ptr() ! Somehow needed with PGI/16.7 and build-type "bit"
-  mesh = atlas_Mesh( atlas__TriangularMeshBuilder__operator(this%CPTR_PGIBUG_A, &
+  mesh = atlas_Mesh( atlas__TriangularMeshBuilder__operator(this%c_ptr(), &
        & int(nb_nodes,c_size_t), node_global_index, &
        & view1d_x,   view1d_y,   int(array_stride(x,1),c_size_t),   int(array_stride(y,1),c_size_t),   &
        & view1d_lon, view1d_lat, int(array_stride(lon,1),c_size_t), int(array_stride(lat,1),c_size_t), &

--- a/src/atlas_f/mesh/atlas_MeshGenerator_module.F90
+++ b/src/atlas_f/mesh/atlas_MeshGenerator_module.F90
@@ -81,7 +81,7 @@ function atlas_MeshGenerator__config(config) result(this)
        meshgenerator_type='structured'
     endif
     call this%reset_c_ptr( atlas__MeshGenerator__create( &
-      c_str(meshgenerator_type),config%CPTR_PGIBUG_B) )
+      c_str(meshgenerator_type),config%c_ptr()) )
   else
     call this%reset_c_ptr( atlas__MeshGenerator__create_noconfig(c_str('structured')) )
   endif
@@ -100,10 +100,10 @@ function atlas_MeshGenerator__generate(this,grid,distribution) result(mesh)
    call mesh%reset_c_ptr() ! Somehow needed with PGI/16.7 and build-type "bit"
    if( present(distribution) ) then
      mesh = atlas_Mesh( atlas__MeshGenerator__generate__grid_griddist( &
-       this%CPTR_PGIBUG_A,grid%CPTR_PGIBUG_A,distribution%CPTR_PGIBUG_A) )
+       this%c_ptr(),grid%c_ptr(),distribution%c_ptr()) )
    else
      mesh = atlas_Mesh( atlas__MeshGenerator__generate__grid( &
-       this%CPTR_PGIBUG_A,grid%CPTR_PGIBUG_A) )
+       this%c_ptr(),grid%c_ptr()) )
    endif
    call mesh%return()
 end function
@@ -119,7 +119,7 @@ function atlas_MeshGenerator__generate_partitioner(this,grid,partitioner) result
    class(atlas_Partitioner), intent(in) :: partitioner
    call mesh%reset_c_ptr() ! Somehow needed with PGI/16.7 and build-type "bit"
    mesh = atlas_Mesh( atlas__MeshGenerator__generate__grid_partitioner( &
-       this%CPTR_PGIBUG_A,grid%CPTR_PGIBUG_A,partitioner%CPTR_PGIBUG_A) )
+       this%c_ptr(),grid%c_ptr(),partitioner%c_ptr()) )
    call mesh%return()
 end function
 

--- a/src/atlas_f/mesh/atlas_Mesh_module.F90
+++ b/src/atlas_f/mesh/atlas_Mesh_module.F90
@@ -95,7 +95,7 @@ function Mesh__nodes(this) result(nodes)
   use atlas_mesh_c_binding
   class(atlas_Mesh), intent(in) :: this
   type(atlas_mesh_Nodes) :: nodes
-  nodes = atlas_mesh_Nodes( atlas__Mesh__nodes(this%CPTR_PGIBUG_A) )
+  nodes = atlas_mesh_Nodes( atlas__Mesh__nodes(this%c_ptr()) )
   call nodes%return()
 end function
 
@@ -105,7 +105,7 @@ function Mesh__cells(this) result(cells)
   use atlas_mesh_c_binding
   class(atlas_Mesh), intent(in) :: this
   type(atlas_mesh_Cells) :: cells
-  cells = atlas_mesh_Cells( atlas__Mesh__cells(this%CPTR_PGIBUG_A) )
+  cells = atlas_mesh_Cells( atlas__Mesh__cells(this%c_ptr()) )
   call cells%return()
 end function
 
@@ -115,7 +115,7 @@ function Mesh__edges(this) result(edges)
   use atlas_mesh_c_binding
   class(atlas_Mesh), intent(in) :: this
   type(atlas_mesh_Edges) :: edges
-  edges = atlas_mesh_Edges( atlas__Mesh__Edges(this%CPTR_PGIBUG_A) )
+  edges = atlas_mesh_Edges( atlas__Mesh__Edges(this%c_ptr()) )
   call edges%return()
 end function
 
@@ -125,7 +125,7 @@ function footprint(this)
   use atlas_mesh_c_binding
   integer(c_size_t) :: footprint
   class(atlas_Mesh) :: this
-  footprint = atlas__Mesh__footprint(this%CPTR_PGIBUG_A)
+  footprint = atlas__Mesh__footprint(this%c_ptr())
 end function
 
 !-------------------------------------------------------------------------------
@@ -133,7 +133,7 @@ end function
 subroutine update_device(this)
   use atlas_mesh_c_binding
   class(atlas_Mesh), intent(inout) :: this
-  call atlas__Mesh__update_device(this%CPTR_PGIBUG_A)
+  call atlas__Mesh__update_device(this%c_ptr())
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -141,7 +141,7 @@ end subroutine
 subroutine update_host(this)
   use atlas_mesh_c_binding
   class(atlas_Mesh), intent(inout) :: this
-  call atlas__Mesh__update_host(this%CPTR_PGIBUG_A)
+  call atlas__Mesh__update_host(this%c_ptr())
 end subroutine
 
 ! ----------------------------------------------------------------------------------------
@@ -149,7 +149,7 @@ end subroutine
 subroutine sync_host_device(this)
   use atlas_mesh_c_binding
   class(atlas_Mesh), intent(inout) :: this
-  call atlas__Mesh__sync_host_device(this%CPTR_PGIBUG_A)
+  call atlas__Mesh__sync_host_device(this%c_ptr())
 end subroutine
 
 !-------------------------------------------------------------------------------

--- a/src/atlas_f/mesh/atlas_mesh_Nodes_module.F90
+++ b/src/atlas_f/mesh/atlas_mesh_Nodes_module.F90
@@ -100,7 +100,7 @@ function atlas_mesh_Nodes__size(this) result(val)
   use atlas_nodes_c_binding
   integer(ATLAS_KIND_IDX) :: val
   class(atlas_mesh_Nodes), intent(in) :: this
-  val = atlas__mesh__Nodes__size(this%CPTR_PGIBUG_A)
+  val = atlas__mesh__Nodes__size(this%c_ptr())
 end function
 
 function edge_connectivity(this) result(connectivity)
@@ -109,7 +109,7 @@ function edge_connectivity(this) result(connectivity)
   class(atlas_mesh_Nodes), intent(in) :: this
   type(atlas_Connectivity) :: connectivity
   connectivity = atlas_Connectivity( &
-      atlas__mesh__Nodes__edge_connectivity(this%CPTR_PGIBUG_A) )
+      atlas__mesh__Nodes__edge_connectivity(this%c_ptr()) )
   call connectivity%return()
 end function
 
@@ -118,7 +118,7 @@ function cell_connectivity(this) result(connectivity)
   class(atlas_mesh_Nodes), intent(in) :: this
   type(atlas_Connectivity) :: connectivity
   connectivity = atlas_Connectivity( &
-      atlas__mesh__Nodes__cell_connectivity(this%CPTR_PGIBUG_A) )
+      atlas__mesh__Nodes__cell_connectivity(this%c_ptr()) )
   call connectivity%return()
 end function
 
@@ -129,7 +129,7 @@ function connectivity(this,name)
   class(atlas_mesh_Nodes), intent(in) :: this
   character(len=*), intent(in) :: name
   connectivity = atlas_Connectivity( &
-      atlas__mesh__Nodes__connectivity(this%CPTR_PGIBUG_A,c_str(name)) )
+      atlas__mesh__Nodes__connectivity(this%c_ptr(),c_str(name)) )
   call connectivity%return()
 end function
 
@@ -137,7 +137,7 @@ subroutine add_connectivity(this,connectivity)
   use atlas_nodes_c_binding
   class(atlas_mesh_Nodes), intent(inout) :: this
   type(atlas_Connectivity), intent(in) :: connectivity
-  call atlas__mesh__Nodes__add_connectivity(this%CPTR_PGIBUG_A, connectivity%CPTR_PGIBUG_A)
+  call atlas__mesh__Nodes__add_connectivity(this%c_ptr(), connectivity%c_ptr())
 end subroutine
 
 
@@ -145,7 +145,7 @@ subroutine add_field(this,field)
   use atlas_nodes_c_binding
   class(atlas_mesh_Nodes), intent(inout) :: this
   type(atlas_Field), intent(in) :: field
-  call atlas__mesh__Nodes__add_field(this%CPTR_PGIBUG_A, field%CPTR_PGIBUG_A)
+  call atlas__mesh__Nodes__add_field(this%c_ptr(), field%c_ptr())
 end subroutine
 
 subroutine remove_field(this,name)
@@ -153,14 +153,14 @@ subroutine remove_field(this,name)
   use fckit_c_interop_module, only: c_str
   class(atlas_mesh_Nodes), intent(in) :: this
   character(len=*), intent(in) :: name
-  call atlas__mesh__Nodes__remove_field(this%CPTR_PGIBUG_A,c_str(name))
+  call atlas__mesh__Nodes__remove_field(this%c_ptr(),c_str(name))
 end subroutine
 
 function nb_fields(this) result(val)
   use atlas_nodes_c_binding
   integer(ATLAS_KIND_IDX) :: val
   class(atlas_mesh_Nodes), intent(in) :: this
-  val = atlas__mesh__Nodes__nb_fields(this%CPTR_PGIBUG_A)
+  val = atlas__mesh__Nodes__nb_fields(this%c_ptr())
 end function
 
 function has_field(this,name) result(val)
@@ -169,7 +169,7 @@ function has_field(this,name) result(val)
   logical :: val
   class(atlas_mesh_Nodes), intent(in) :: this
   character(len=*), intent(in) :: name
-  if( atlas__mesh__Nodes__has_field(this%CPTR_PGIBUG_A,c_str(name)) == 0 ) then
+  if( atlas__mesh__Nodes__has_field(this%c_ptr(),c_str(name)) == 0 ) then
     val = .False.
   else
     val = .True.
@@ -182,7 +182,7 @@ function field_by_name(this,name) result(field)
   type(atlas_Field) :: field
   class(atlas_mesh_Nodes), intent(in) :: this
   character(len=*), intent(in) :: name
-  field = atlas_Field( atlas__mesh__Nodes__field_by_name(this%CPTR_PGIBUG_A,c_str(name)) )
+  field = atlas_Field( atlas__mesh__Nodes__field_by_name(this%c_ptr(),c_str(name)) )
   call field%return()
 end function
 
@@ -192,7 +192,7 @@ function field_by_idx_long(this,idx) result(field)
   type(atlas_Field) :: field
   class(atlas_mesh_Nodes), intent(in) :: this
   integer(c_long), intent(in) :: idx
-  field = atlas_Field( atlas__mesh__Nodes__field_by_idx(this%CPTR_PGIBUG_A,int(idx-1_c_long,ATLAS_KIND_IDX) ) )
+  field = atlas_Field( atlas__mesh__Nodes__field_by_idx(this%c_ptr(),int(idx-1_c_long,ATLAS_KIND_IDX) ) )
   call field%return()
 end function
 
@@ -202,7 +202,7 @@ function field_by_idx_int(this,idx) result(field)
   type(atlas_Field) :: field
   class(atlas_mesh_Nodes), intent(in) :: this
   integer(c_int), intent(in) :: idx
-  field = atlas_Field( atlas__mesh__Nodes__field_by_idx(this%CPTR_PGIBUG_A,int(idx-1_c_long,ATLAS_KIND_IDX) ) )
+  field = atlas_Field( atlas__mesh__Nodes__field_by_idx(this%c_ptr(),int(idx-1_c_long,ATLAS_KIND_IDX) ) )
   call field%return()
 end function
 
@@ -210,7 +210,7 @@ function xy(this) result(field)
   use atlas_nodes_c_binding
   type(atlas_Field) :: field
   class(atlas_mesh_Nodes), intent(in) :: this
-  field = atlas_Field( atlas__mesh__Nodes__xy(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__mesh__Nodes__xy(this%c_ptr()) )
   call field%return()
 end function
 
@@ -218,7 +218,7 @@ function lonlat(this) result(field)
   use atlas_nodes_c_binding
   type(atlas_Field) :: field
   class(atlas_mesh_Nodes), intent(in) :: this
-  field = atlas_Field( atlas__mesh__Nodes__lonlat(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__mesh__Nodes__lonlat(this%c_ptr()) )
   call field%return()
 end function
 
@@ -226,7 +226,7 @@ function global_index(this) result(field)
   use atlas_nodes_c_binding
   type(atlas_Field) :: field
   class(atlas_mesh_Nodes), intent(in) :: this
-  field = atlas_Field( atlas__mesh__Nodes__global_index(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__mesh__Nodes__global_index(this%c_ptr()) )
   call field%return()
 end function
 
@@ -234,7 +234,7 @@ function remote_index(this) result(field)
   use atlas_nodes_c_binding
   type(atlas_Field) :: field
   class(atlas_mesh_Nodes), intent(in) :: this
-  field = atlas_Field( atlas__mesh__Nodes__remote_index(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__mesh__Nodes__remote_index(this%c_ptr()) )
   call field%return()
 end function
 
@@ -242,7 +242,7 @@ function partition(this) result(field)
   use atlas_nodes_c_binding
   type(atlas_Field) :: field
   class(atlas_mesh_Nodes), intent(in) :: this
-  field = atlas_Field( atlas__mesh__Nodes__partition(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__mesh__Nodes__partition(this%c_ptr()) )
   call field%return()
 end function
 
@@ -250,7 +250,7 @@ function ghost(this) result(field)
   use atlas_nodes_c_binding
   type(atlas_Field) :: field
   class(atlas_mesh_Nodes), intent(in) :: this
-  field = atlas_Field( atlas__mesh__Nodes__ghost(this%CPTR_PGIBUG_A) )
+  field = atlas_Field( atlas__mesh__Nodes__ghost(this%c_ptr()) )
   call field%return()
 end function
 
@@ -258,7 +258,7 @@ function metadata(this)
   use atlas_nodes_c_binding
   type(atlas_Metadata) :: metadata
   class(atlas_mesh_Nodes), intent(in) :: this
-  call metadata%reset_c_ptr( atlas__mesh__Nodes__metadata(this%CPTR_PGIBUG_A) )
+  call metadata%reset_c_ptr( atlas__mesh__Nodes__metadata(this%c_ptr()) )
 end function
 
 subroutine resize_int(this,size)
@@ -266,7 +266,7 @@ subroutine resize_int(this,size)
   use atlas_nodes_c_binding
   class(atlas_mesh_Nodes), intent(in) :: this
   integer(c_int), intent(in) :: size
-  call atlas__mesh__Nodes__resize(this%CPTR_PGIBUG_A,int(size,ATLAS_KIND_IDX))
+  call atlas__mesh__Nodes__resize(this%c_ptr(),int(size,ATLAS_KIND_IDX))
 end subroutine
 
 subroutine resize_long(this,size)
@@ -274,7 +274,7 @@ subroutine resize_long(this,size)
   use atlas_nodes_c_binding
   class(atlas_mesh_Nodes), intent(in) :: this
   integer(c_long), intent(in) :: size
-  call atlas__mesh__Nodes__resize(this%CPTR_PGIBUG_A,int(size,ATLAS_KIND_IDX))
+  call atlas__mesh__Nodes__resize(this%c_ptr(),int(size,ATLAS_KIND_IDX))
 end subroutine
 
 function str(this)
@@ -284,7 +284,7 @@ function str(this)
   class(atlas_mesh_Nodes), intent(in) :: this
   type(c_ptr) :: str_cptr
   integer(c_int) :: str_size
-  call atlas__mesh__Nodes__str(this%CPTR_PGIBUG_A,str_cptr,str_size)
+  call atlas__mesh__Nodes__str(this%c_ptr(),str_cptr,str_size)
   allocate(character(len=str_size) :: str )
   str = c_ptr_to_string(str_cptr)
   call c_ptr_free(str_cptr)

--- a/src/atlas_f/mesh/atlas_mesh_actions_module.F90
+++ b/src/atlas_f/mesh/atlas_mesh_actions_module.F90
@@ -32,35 +32,35 @@ subroutine atlas_build_parallel_fields(mesh)
   use atlas_BuildParallelFields_c_binding
   use atlas_Mesh_module, only: atlas_Mesh
   type(atlas_Mesh), intent(inout) :: mesh
-  call atlas__build_parallel_fields(mesh%CPTR_PGIBUG_A)
+  call atlas__build_parallel_fields(mesh%c_ptr())
 end subroutine atlas_build_parallel_fields
 
 subroutine atlas_build_nodes_parallel_fields(nodes)
   use atlas_BuildParallelFields_c_binding
   use atlas_mesh_Nodes_module, only: atlas_mesh_Nodes
   type(atlas_mesh_Nodes), intent(inout) :: nodes
-  call atlas__build_nodes_parallel_fields(nodes%CPTR_PGIBUG_A)
+  call atlas__build_nodes_parallel_fields(nodes%c_ptr())
 end subroutine atlas_build_nodes_parallel_fields
 
 subroutine atlas_renumber_nodes_glb_idx(nodes)
   use atlas_BuildParallelFields_c_binding
   use atlas_mesh_Nodes_module, only: atlas_mesh_Nodes
   type(atlas_mesh_Nodes), intent(inout) :: nodes
-  call atlas__renumber_nodes_glb_idx(nodes%CPTR_PGIBUG_A)
+  call atlas__renumber_nodes_glb_idx(nodes%c_ptr())
 end subroutine atlas_renumber_nodes_glb_idx
 
 subroutine atlas_build_edges_parallel_fields(mesh)
   use atlas_BuildParallelFields_c_binding
   use atlas_Mesh_module, only: atlas_Mesh
   type(atlas_Mesh), intent(inout) :: mesh
-  call atlas__build_edges_parallel_fields(mesh%CPTR_PGIBUG_A)
+  call atlas__build_edges_parallel_fields(mesh%c_ptr())
 end subroutine atlas_build_edges_parallel_fields
 
 subroutine atlas_build_periodic_boundaries(mesh)
   use atlas_BuildPeriodicBoundaries_c_binding
   use atlas_Mesh_module, only: atlas_Mesh
   type(atlas_Mesh), intent(inout) :: mesh
-  call atlas__build_periodic_boundaries(mesh%CPTR_PGIBUG_A)
+  call atlas__build_periodic_boundaries(mesh%c_ptr())
 end subroutine atlas_build_periodic_boundaries
 
 subroutine atlas_build_halo(mesh,nelems)
@@ -68,49 +68,49 @@ subroutine atlas_build_halo(mesh,nelems)
   use atlas_Mesh_module, only: atlas_Mesh
   type(atlas_Mesh), intent(inout) :: mesh
   integer, intent(in) :: nelems
-  call atlas__build_halo(mesh%CPTR_PGIBUG_A,nelems)
+  call atlas__build_halo(mesh%c_ptr(),nelems)
 end subroutine atlas_build_halo
 
 subroutine atlas_build_edges(mesh)
   use atlas_BuildEdges_c_binding
   use atlas_Mesh_module, only: atlas_Mesh
   type(atlas_Mesh), intent(inout) :: mesh
-  call atlas__build_edges(mesh%CPTR_PGIBUG_A)
+  call atlas__build_edges(mesh%c_ptr())
 end subroutine atlas_build_edges
 
 subroutine atlas_build_pole_edges(mesh)
   use atlas_BuildEdges_c_binding
   use atlas_Mesh_module, only: atlas_Mesh
   type(atlas_Mesh), intent(inout) :: mesh
-  call atlas__build_pole_edges(mesh%CPTR_PGIBUG_A)
+  call atlas__build_pole_edges(mesh%c_ptr())
 end subroutine atlas_build_pole_edges
 
 subroutine atlas_build_node_to_cell_connectivity(mesh)
   use atlas_BuildNode2CellConnectivity_c_binding
   use atlas_Mesh_module, only: atlas_Mesh
   type(atlas_Mesh), intent(inout) :: mesh
-  call atlas__build_node_to_cell_connectivity(mesh%CPTR_PGIBUG_A)
+  call atlas__build_node_to_cell_connectivity(mesh%c_ptr())
 end subroutine atlas_build_node_to_cell_connectivity
 
 subroutine atlas_build_node_to_edge_connectivity(mesh)
   use atlas_BuildEdges_c_binding
   use atlas_Mesh_module, only: atlas_Mesh
   type(atlas_Mesh), intent(inout) :: mesh
-  call atlas__build_node_to_edge_connectivity(mesh%CPTR_PGIBUG_A)
+  call atlas__build_node_to_edge_connectivity(mesh%c_ptr())
 end subroutine atlas_build_node_to_edge_connectivity
 
 subroutine atlas_build_median_dual_mesh(mesh)
   use atlas_BuildDualMesh_c_binding
   use atlas_Mesh_module, only: atlas_Mesh
   type(atlas_Mesh), intent(inout) :: mesh
-  call atlas__build_median_dual_mesh(mesh%CPTR_PGIBUG_A)
+  call atlas__build_median_dual_mesh(mesh%c_ptr())
 end subroutine atlas_build_median_dual_mesh
 
 subroutine atlas_build_centroid_dual_mesh(mesh)
   use atlas_BuildDualMesh_c_binding
   use atlas_Mesh_module, only: atlas_Mesh
   type(atlas_Mesh), intent(inout) :: mesh
-  call atlas__build_centroid_dual_mesh(mesh%CPTR_PGIBUG_A)
+  call atlas__build_centroid_dual_mesh(mesh%c_ptr())
 end subroutine atlas_build_centroid_dual_mesh
 
 subroutine atlas_write_load_balance_report(mesh,filename)
@@ -119,7 +119,7 @@ subroutine atlas_write_load_balance_report(mesh,filename)
   use atlas_Mesh_module, only: atlas_Mesh
   type(atlas_Mesh), intent(in) :: mesh
   character(len=*), intent(in) :: filename
-  call atlas__write_load_balance_report(mesh%CPTR_PGIBUG_A,c_str(filename))
+  call atlas__write_load_balance_report(mesh%c_ptr(),c_str(filename))
 end subroutine atlas_write_load_balance_report
 
 ! -----------------------------------------------------------------------------

--- a/src/atlas_f/numerics/atlas_Method_module.F90
+++ b/src/atlas_f/numerics/atlas_Method_module.F90
@@ -68,7 +68,7 @@ function atlas_Method__name(this) result(name)
   class(atlas_Method), intent(in) :: this
   character(len=:), allocatable :: name
   type(c_ptr) :: name_c_str
-  name_c_str = atlas__Method__name(this%CPTR_PGIBUG_A)
+  name_c_str = atlas__Method__name(this%c_ptr())
   name = c_ptr_to_string(name_c_str)
 end function
 

--- a/src/atlas_f/numerics/atlas_Nabla_module.F90
+++ b/src/atlas_f/numerics/atlas_Nabla_module.F90
@@ -74,10 +74,10 @@ function atlas_Nabla__method_config(method,config) result(this)
   type(atlas_Config), intent(in), optional :: config
   type(atlas_Config) :: opt_config
   if( present(config) ) then
-    call this%reset_c_ptr( atlas__Nabla__create(method%CPTR_PGIBUG_A,config%CPTR_PGIBUG_B) )
+    call this%reset_c_ptr( atlas__Nabla__create(method%c_ptr(),config%c_ptr()) )
   else
     opt_config = atlas_Config()
-    call this%reset_c_ptr( atlas__Nabla__create(method%CPTR_PGIBUG_A,opt_config%CPTR_PGIBUG_B) )
+    call this%reset_c_ptr( atlas__Nabla__create(method%c_ptr(),opt_config%c_ptr()) )
     call opt_config%final()
   endif
   call this%return()
@@ -89,7 +89,7 @@ subroutine atlas_Nabla__gradient(this,scalar,grad)
   class(atlas_Nabla), intent(in) :: this
   class(atlas_Field), intent(in) :: scalar
   class(atlas_Field), intent(inout) :: grad
-  call atlas__Nabla__gradient(this%CPTR_PGIBUG_A,scalar%CPTR_PGIBUG_A,grad%CPTR_PGIBUG_A)
+  call atlas__Nabla__gradient(this%c_ptr(),scalar%c_ptr(),grad%c_ptr())
 end subroutine
 
 
@@ -99,7 +99,7 @@ subroutine atlas_Nabla__divergence(this,vector,div)
   class(atlas_Nabla), intent(in) :: this
   class(atlas_Field), intent(in) :: vector
   class(atlas_Field), intent(inout) :: div
-  call atlas__Nabla__divergence(this%CPTR_PGIBUG_A,vector%CPTR_PGIBUG_A,div%CPTR_PGIBUG_A)
+  call atlas__Nabla__divergence(this%c_ptr(),vector%c_ptr(),div%c_ptr())
 end subroutine
 
 subroutine atlas_Nabla__curl(this,vector,curl)
@@ -108,7 +108,7 @@ subroutine atlas_Nabla__curl(this,vector,curl)
   class(atlas_Nabla), intent(in) :: this
   class(atlas_Field), intent(in) :: vector
   class(atlas_Field), intent(inout) :: curl
-  call atlas__Nabla__curl(this%CPTR_PGIBUG_A,vector%CPTR_PGIBUG_A,curl%CPTR_PGIBUG_A)
+  call atlas__Nabla__curl(this%c_ptr(),vector%c_ptr(),curl%c_ptr())
 end subroutine
 
 subroutine atlas_Nabla__laplacian(this,scalar,lapl)
@@ -117,7 +117,7 @@ subroutine atlas_Nabla__laplacian(this,scalar,lapl)
   class(atlas_Nabla), intent(in) :: this
   class(atlas_Field), intent(in) :: scalar
   class(atlas_Field), intent(inout) :: lapl
-  call atlas__Nabla__laplacian(this%CPTR_PGIBUG_A,scalar%CPTR_PGIBUG_A,lapl%CPTR_PGIBUG_A)
+  call atlas__Nabla__laplacian(this%c_ptr(),scalar%c_ptr(),lapl%c_ptr())
 end subroutine
 
 function atlas_Nabla__functionspace(this) result(functionspace)
@@ -125,7 +125,7 @@ function atlas_Nabla__functionspace(this) result(functionspace)
   use atlas_Functionspace_module, only : atlas_FunctionSpace
   type(atlas_FunctionSpace) :: functionspace
   class(atlas_Nabla), intent(in) :: this
-  call functionspace%reset_c_ptr( atlas__Nabla__functionspace(this%CPTR_PGIBUG_A) )
+  call functionspace%reset_c_ptr( atlas__Nabla__functionspace(this%c_ptr()) )
   call functionspace%return()
 end function
 

--- a/src/atlas_f/numerics/atlas_fvm_module.F90
+++ b/src/atlas_f/numerics/atlas_fvm_module.F90
@@ -75,12 +75,12 @@ function atlas_fvm_Method__mesh_config(mesh,config) result(this)
   type(atlas_Config), intent(in), optional :: config
   type(atlas_Config) :: opt_config
   if( present(config) ) then
-    call this%reset_c_ptr( atlas__numerics__fvm__Method__new(mesh%CPTR_PGIBUG_A, &
-      config%CPTR_PGIBUG_B) )
+    call this%reset_c_ptr( atlas__numerics__fvm__Method__new(mesh%c_ptr(), &
+      config%c_ptr()) )
   else
     opt_config = atlas_Config()
-    call this%reset_c_ptr( atlas__numerics__fvm__Method__new(mesh%CPTR_PGIBUG_A, &
-      opt_config%CPTR_PGIBUG_B) )
+    call this%reset_c_ptr( atlas__numerics__fvm__Method__new(mesh%c_ptr(), &
+      opt_config%c_ptr()) )
     call opt_config%final()
   endif
   call this%return()
@@ -92,7 +92,7 @@ function node_columns(this)
   type(atlas_functionspace_NodeColumns) :: node_columns
   class(atlas_fvm_Method) :: this
   node_columns = atlas_functionspace_NodeColumns( &
-    & atlas__numerics__fvm__Method__functionspace_nodes(this%CPTR_PGIBUG_A) )
+    & atlas__numerics__fvm__Method__functionspace_nodes(this%c_ptr()) )
   call node_columns%return()
 end function
 
@@ -102,7 +102,7 @@ function edge_columns(this)
   type(atlas_functionspace_EdgeColumns) :: edge_columns
   class(atlas_fvm_Method) :: this
   edge_columns = atlas_functionspace_EdgeColumns( &
-    & atlas__numerics__fvm__Method__functionspace_edges(this%CPTR_PGIBUG_A) )
+    & atlas__numerics__fvm__Method__functionspace_edges(this%c_ptr()) )
   call edge_columns%return()
 end function
 

--- a/src/atlas_f/output/atlas_output_module.F90
+++ b/src/atlas_f/output/atlas_output_module.F90
@@ -107,7 +107,7 @@ function atlas_output_Gmsh__pathname_mode(file,mode,coordinates,levels,gather,gh
   if( present(gather) )      call opt_config%set("gather",gather)
   if( present(ghost) )       call opt_config%set("ghost",ghost)
   call this%reset_c_ptr( atlas__output__Gmsh__create_pathname_mode_config(c_str(file),c_str(opt_mode),&
-     opt_config%CPTR_PGIBUG_B) )
+     opt_config%c_ptr()) )
   call this%return()
   call opt_config%final()
 end function
@@ -119,10 +119,10 @@ subroutine write_mesh(this,mesh,config)
   type(atlas_Config), intent(in), optional :: config
   type(atlas_Config) :: opt_config
   if( present(config) ) then
-    call atlas__output__write_mesh(this%CPTR_PGIBUG_A,mesh%CPTR_PGIBUG_A,config%CPTR_PGIBUG_B)
+    call atlas__output__write_mesh(this%c_ptr(),mesh%c_ptr(),config%c_ptr())
   else
     opt_config = atlas_Config()
-    call atlas__output__write_mesh(this%CPTR_PGIBUG_A,mesh%CPTR_PGIBUG_A,opt_config%CPTR_PGIBUG_B)
+    call atlas__output__write_mesh(this%c_ptr(),mesh%c_ptr(),opt_config%c_ptr())
     call opt_config%final()
   endif
 end subroutine
@@ -135,12 +135,12 @@ subroutine write_field_fs(this,field,functionspace,config)
   type(atlas_Config), intent(in), optional :: config
   type(atlas_Config) :: opt_config
   if( present(config) ) then
-    call atlas__output__write_field_fs(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,functionspace%CPTR_PGIBUG_A, &
-       config%CPTR_PGIBUG_B)
+    call atlas__output__write_field_fs(this%c_ptr(),field%c_ptr(),functionspace%c_ptr(), &
+       config%c_ptr())
   else
     opt_config = atlas_Config()
-    call atlas__output__write_field_fs(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A,functionspace%CPTR_PGIBUG_A, &
-      opt_config%CPTR_PGIBUG_B)
+    call atlas__output__write_field_fs(this%c_ptr(),field%c_ptr(),functionspace%c_ptr(), &
+      opt_config%c_ptr())
     call opt_config%final()
   endif
 end subroutine
@@ -153,12 +153,12 @@ subroutine write_fieldset_fs(this,fieldset,functionspace,config)
   type(atlas_Config), intent(in), optional :: config
   type(atlas_Config) :: opt_config
   if( present(config) ) then
-    call atlas__output__write_fieldset_fs(this%CPTR_PGIBUG_A,fieldset%CPTR_PGIBUG_A,functionspace%CPTR_PGIBUG_A, &
-      config%CPTR_PGIBUG_B)
+    call atlas__output__write_fieldset_fs(this%c_ptr(),fieldset%c_ptr(),functionspace%c_ptr(), &
+      config%c_ptr())
   else
     opt_config = atlas_Config()
-    call atlas__output__write_fieldset_fs(this%CPTR_PGIBUG_A,fieldset%CPTR_PGIBUG_A,functionspace%CPTR_PGIBUG_A, &
-      opt_config%CPTR_PGIBUG_B)
+    call atlas__output__write_fieldset_fs(this%c_ptr(),fieldset%c_ptr(),functionspace%c_ptr(), &
+      opt_config%c_ptr())
     call opt_config%final()
   endif
 end subroutine
@@ -171,12 +171,12 @@ subroutine write_field(this,field,config)
   type(atlas_Config), intent(in), optional :: config
   type(atlas_Config) :: opt_config
   if( present(config) ) then
-    call atlas__output__write_field(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A, &
-      config%CPTR_PGIBUG_B)
+    call atlas__output__write_field(this%c_ptr(),field%c_ptr(), &
+      config%c_ptr())
   else
     opt_config = atlas_Config()
-    call atlas__output__write_field(this%CPTR_PGIBUG_A,field%CPTR_PGIBUG_A, &
-      opt_config%CPTR_PGIBUG_B)
+    call atlas__output__write_field(this%c_ptr(),field%c_ptr(), &
+      opt_config%c_ptr())
     call opt_config%final()
   endif
 end subroutine
@@ -189,12 +189,12 @@ subroutine write_fieldset(this,fieldset,config)
   type(atlas_Config), intent(in), optional :: config
   type(atlas_Config) :: opt_config
   if( present(config) ) then
-    call atlas__output__write_fieldset(this%CPTR_PGIBUG_A,fieldset%CPTR_PGIBUG_A, &
-      config%CPTR_PGIBUG_B)
+    call atlas__output__write_fieldset(this%c_ptr(),fieldset%c_ptr(), &
+      config%c_ptr())
   else
     opt_config = atlas_Config()
-    call atlas__output__write_fieldset(this%CPTR_PGIBUG_A,fieldset%CPTR_PGIBUG_A, &
-      opt_config%CPTR_PGIBUG_B)
+    call atlas__output__write_fieldset(this%c_ptr(),fieldset%c_ptr(), &
+      opt_config%c_ptr())
     call opt_config%final()
   endif
 end subroutine

--- a/src/atlas_f/parallel/atlas_Checksum_module.fypp
+++ b/src/atlas_f/parallel/atlas_Checksum_module.fypp
@@ -88,7 +88,7 @@ subroutine atlas_Checksum__delete(this)
   use atlas_checksum_c_binding
   class(atlas_Checksum), intent(inout) :: this
   if ( .not. this%is_null() ) then
-    call atlas__Checksum__delete(this%CPTR_PGIBUG_A)
+    call atlas__Checksum__delete(this%c_ptr())
   end if
   call this%reset_c_ptr()
 end subroutine atlas_Checksum__delete
@@ -99,7 +99,7 @@ subroutine Checksum__setup32(this, part, remote_idx, glb_idx )
   integer(c_int), intent(in) :: part(:)
   integer(ATLAS_KIND_IDX), intent(in) :: remote_idx(:)
   integer(c_int), intent(in) :: glb_idx(:)
-  call atlas__Checksum__setup32( this%CPTR_PGIBUG_A, part, remote_idx, 1, &
+  call atlas__Checksum__setup32( this%c_ptr(), part, remote_idx, 1, &
     &                          glb_idx, size(part) )
 end subroutine Checksum__setup32
 
@@ -109,7 +109,7 @@ subroutine Checksum__setup64(this, part, remote_idx, glb_idx)
   integer(c_int), intent(in) :: part(:)
   integer(ATLAS_KIND_IDX), intent(in) :: remote_idx(:)
   integer(c_long), intent(in) :: glb_idx(:)
-  call atlas__Checksum__setup64( this%CPTR_PGIBUG_A, part, remote_idx, 1, &
+  call atlas__Checksum__setup64( this%c_ptr(), part, remote_idx, 1, &
     &                            glb_idx, size(part) )
 end subroutine Checksum__setup64
 
@@ -126,7 +126,7 @@ function execute_${dtype}$_r1(this, loc_field_data) result(checksum)
   lstrides = (/ array_stride(loc_field_data,1) /)
   lextents = (/ 1                        /)
   lview => array_view1d(loc_field_data)
-  call atlas__Checksum__execute_strided_${ctype}$( this%CPTR_PGIBUG_A, &
+  call atlas__Checksum__execute_strided_${ctype}$( this%c_ptr(), &
     &  lview, lstrides, lextents, lrank, checksum_c_str )
   checksum = c_str_to_string(checksum_c_str)
 end function
@@ -142,7 +142,7 @@ function execute_${dtype}$_r2(this, loc_field_data) result(checksum)
   lstrides = (/ array_stride(loc_field_data,2), array_stride(loc_field_data,1) /)
   lextents = (/ 1,                        size  (loc_field_data,1) /)
   lview => array_view1d(loc_field_data)
-  call atlas__Checksum__execute_strided_${ctype}$( this%CPTR_PGIBUG_A, &
+  call atlas__Checksum__execute_strided_${ctype}$( this%c_ptr(), &
     &  lview, lstrides, lextents, lrank, checksum_c_str )
   checksum = c_str_to_string(checksum_c_str)
 end function
@@ -158,7 +158,7 @@ function execute_${dtype}$_r3(this, loc_field_data) result(checksum)
   lstrides = (/ array_stride(loc_field_data,3), array_stride(loc_field_data,2) , array_stride(loc_field_data,1) /)
   lextents = (/ 1,                        size  (loc_field_data,2) , size  (loc_field_data,1) /)
   lview => array_view1d(loc_field_data)
-  call atlas__Checksum__execute_strided_${ctype}$( this%CPTR_PGIBUG_A, &
+  call atlas__Checksum__execute_strided_${ctype}$( this%c_ptr(), &
     &  lview, lstrides, lextents, lrank, checksum_c_str )
   checksum = c_str_to_string(checksum_c_str)
 end function

--- a/src/atlas_f/parallel/atlas_GatherScatter_module.fypp
+++ b/src/atlas_f/parallel/atlas_GatherScatter_module.fypp
@@ -91,7 +91,7 @@ subroutine atlas_GatherScatter__delete(this)
   use atlas_gatherscatter_c_binding
   class(atlas_GatherScatter), intent(inout) :: this
   if ( .not. this%is_null() ) then
-    call atlas__GatherScatter__delete(this%CPTR_PGIBUG_A)
+    call atlas__GatherScatter__delete(this%c_ptr())
   end if
   call this%reset_c_ptr()
 end subroutine atlas_GatherScatter__delete
@@ -103,7 +103,7 @@ subroutine GatherScatter__setup32(this, part, remote_idx, glb_idx)
   integer(c_int), intent(in) :: part(:)
   integer(ATLAS_KIND_IDX), intent(in) :: remote_idx(:)
   integer(c_int), intent(in) :: glb_idx(:)
-  call atlas__GatherScatter__setup32( this%CPTR_PGIBUG_A, part, remote_idx, 1, &
+  call atlas__GatherScatter__setup32( this%c_ptr(), part, remote_idx, 1, &
     &                        glb_idx, size(part) )
 end subroutine GatherScatter__setup32
 
@@ -113,7 +113,7 @@ subroutine GatherScatter__setup64(this, part, remote_idx, glb_idx )
   integer(c_int), intent(in) :: part(:)
   integer(ATLAS_KIND_IDX), intent(in) :: remote_idx(:)
   integer(c_long), intent(in) :: glb_idx(:)
-  call atlas__GatherScatter__setup64( this%CPTR_PGIBUG_A, part, remote_idx, 1, &
+  call atlas__GatherScatter__setup64( this%c_ptr(), part, remote_idx, 1, &
     &                        glb_idx, size(part) )
 end subroutine GatherScatter__setup64
 
@@ -121,7 +121,7 @@ function GatherScatter__glb_dof(this) result(glb_dof)
   use atlas_gatherscatter_c_binding
   class(atlas_GatherScatter), intent(in) :: this
   integer :: glb_dof
-  glb_dof = atlas__GatherScatter__glb_dof(this%CPTR_PGIBUG_A)
+  glb_dof = atlas__GatherScatter__glb_dof(this%c_ptr())
 end function GatherScatter__glb_dof
 
 ! -----------------------------------------------------------------------------
@@ -145,7 +145,7 @@ subroutine gather_${dtype}$_r1(this, loc_field_data, glb_field_data)
   if( size(gview) == 0 ) then
     allocate(gview(0))
   endif
-  call atlas__GatherScatter__gather_${ctype}$( this%CPTR_PGIBUG_A, &
+  call atlas__GatherScatter__gather_${ctype}$( this%c_ptr(), &
     &  lview, lstrides, lextents, lrank, &
     &  gview, gstrides, gextents, grank )
 end subroutine
@@ -167,7 +167,7 @@ subroutine gather_${dtype}$_r2(this, loc_field_data, glb_field_data)
   if( size(gview) == 0 ) then
     allocate(gview(0))
   endif
-  call atlas__GatherScatter__gather_${ctype}$( this%CPTR_PGIBUG_A, &
+  call atlas__GatherScatter__gather_${ctype}$( this%c_ptr(), &
     &  lview, lstrides, lextents, lrank, &
     &  gview, gstrides, gextents, grank )
 end subroutine 
@@ -189,7 +189,7 @@ subroutine gather_${dtype}$_r3(this, loc_field_data, glb_field_data)
   if( size(gview) == 0 ) then
     allocate(gview(0))
   endif
-  call atlas__GatherScatter__gather_${ctype}$( this%CPTR_PGIBUG_A, &
+  call atlas__GatherScatter__gather_${ctype}$( this%c_ptr(), &
     &  lview, lstrides, lextents, lrank, &
     &  gview, gstrides, gextents, grank )
 end subroutine
@@ -210,7 +210,7 @@ subroutine scatter_${dtype}$_r1(this, glb_field_data, loc_field_data)
   gstrides = (/ array_stride(glb_field_data,1) /)
   gextents = (/ 1                        /)
   gview => array_view1d(glb_field_data)
-  call atlas__GatherScatter__scatter_${ctype}$( this%CPTR_PGIBUG_A, &
+  call atlas__GatherScatter__scatter_${ctype}$( this%c_ptr(), &
     &  gview, gstrides, gextents, grank, &
     &  lview, lstrides, lextents, lrank )
 end subroutine
@@ -232,7 +232,7 @@ subroutine scatter_${dtype}$_r2(this, glb_field_data, loc_field_data)
   if( size(gview) == 0 ) then
     allocate(gview(0))
   endif
-  call atlas__GatherScatter__scatter_${ctype}$( this%CPTR_PGIBUG_A, &
+  call atlas__GatherScatter__scatter_${ctype}$( this%c_ptr(), &
     &  gview, gstrides, gextents, grank, &
     &  lview, lstrides, lextents, lrank )
 end subroutine
@@ -254,7 +254,7 @@ subroutine scatter_${dtype}$_r3(this, glb_field_data, loc_field_data)
   if( size(gview) == 0 ) then
     allocate(gview(0))
   endif
-  call atlas__GatherScatter__scatter_${ctype}$( this%CPTR_PGIBUG_A, &
+  call atlas__GatherScatter__scatter_${ctype}$( this%c_ptr(), &
     &  gview, gstrides, gextents, grank, &
     &  lview, lstrides, lextents, lrank )
 end subroutine

--- a/src/atlas_f/parallel/atlas_HaloExchange_module.fypp
+++ b/src/atlas_f/parallel/atlas_HaloExchange_module.fypp
@@ -80,7 +80,7 @@ subroutine atlas_HaloExchange__delete(this)
   use atlas_haloexchange_c_binding
   class(atlas_HaloExchange), intent(inout) :: this
   if ( .not. this%is_null() ) then
-    call atlas__HaloExchange__delete(this%CPTR_PGIBUG_A)
+    call atlas__HaloExchange__delete(this%c_ptr())
   end if
   call this%reset_c_ptr()
 end subroutine atlas_HaloExchange__delete
@@ -90,7 +90,7 @@ subroutine HaloExchange__setup(this, part, remote_idx)
   class(atlas_HaloExchange), intent(in) :: this
   integer(c_int), intent(in) :: part(:)
   integer(ATLAS_KIND_IDX), intent(in) :: remote_idx(:)
-  call atlas__HaloExchange__setup( this%CPTR_PGIBUG_A, part, remote_idx, 1, size(part) )
+  call atlas__HaloExchange__setup( this%c_ptr(), part, remote_idx, 1, size(part) )
 end subroutine HaloExchange__setup
 
 #:for dtype,ftype,ctype in types[:4]
@@ -102,7 +102,7 @@ subroutine HaloExchange__execute_${dtype}$_r1(this, field_data)
   integer :: strides(1), extents(1)
   strides = (/ array_stride(field_data,1) /)
   extents = (/ 1                    /)
-  call atlas__HaloExchange__execute_strided_${ctype}$( this%CPTR_PGIBUG_A, field_data, &
+  call atlas__HaloExchange__execute_strided_${ctype}$( this%c_ptr(), field_data, &
     & strides, extents, 1 )
 end subroutine
 
@@ -115,7 +115,7 @@ subroutine HaloExchange__execute_${dtype}$_r2(this, field_data)
   view => array_view1d(field_data)
   strides = (/ array_stride(field_data,2) , array_stride(field_data,1) /)
   extents = (/ 1                    , ubound(field_data,1) /)
-  call atlas__HaloExchange__execute_strided_${ctype}$( this%CPTR_PGIBUG_A, view, &
+  call atlas__HaloExchange__execute_strided_${ctype}$( this%c_ptr(), view, &
     & strides, extents, 2 )
 end subroutine 
 
@@ -128,7 +128,7 @@ subroutine HaloExchange__execute_${dtype}$_r3(this, field_data)
   view => array_view1d(field_data)
   strides = (/ array_stride(field_data,3), array_stride(field_data,2) , array_stride(field_data,1) /)
   extents = (/ 1,                    ubound(field_data,2) , ubound(field_data,1) /)
-  call atlas__HaloExchange__execute_strided_${ctype}$( this%CPTR_PGIBUG_A, view, &
+  call atlas__HaloExchange__execute_strided_${ctype}$( this%c_ptr(), view, &
     & strides, extents, 3 )
 end subroutine
 
@@ -142,7 +142,7 @@ subroutine HaloExchange__execute_${dtype}$_r4(this, field_data)
   strides = (/ array_stride(field_data,4), array_stride(field_data,3), array_stride(field_data,2) , &
                array_stride(field_data,1) /)
   extents = (/ 1, ubound(field_data,3) , ubound(field_data,2) , ubound(field_data,1) /)
-  call atlas__HaloExchange__execute_strided_${ctype}$( this%CPTR_PGIBUG_A, view, &
+  call atlas__HaloExchange__execute_strided_${ctype}$( this%c_ptr(), view, &
     & strides, extents, 4 )
 end subroutine
 

--- a/src/atlas_f/projection/atlas_Projection_module.F90
+++ b/src/atlas_f/projection/atlas_Projection_module.F90
@@ -88,7 +88,7 @@ function atlas_Projection__ctor_config(config) result(this)
   use, intrinsic :: iso_c_binding, only : c_ptr
   type(atlas_Projection) :: this
   type(atlas_Config) :: config
-  call this%reset_c_ptr( atlas__Projection__ctor_config(config%CPTR_PGIBUG_B) )
+  call this%reset_c_ptr( atlas__Projection__ctor_config(config%c_ptr()) )
   call this%return()
 end function
 
@@ -100,7 +100,7 @@ function atlas_Projection__type(this) result(type_)
   character(len=:), allocatable :: type_
   type(c_ptr) :: type_c_str
   integer :: size
-  call atlas__Projection__type(this%CPTR_PGIBUG_A, type_c_str, size )
+  call atlas__Projection__type(this%c_ptr(), type_c_str, size )
   type_ = c_ptr_to_string(type_c_str)
   call c_ptr_free(type_c_str)
 end function
@@ -113,7 +113,7 @@ function hash(this)
   character(len=:), allocatable :: hash
   type(c_ptr) :: hash_c_str
   integer :: size
-  call atlas__Projection__hash(this%CPTR_PGIBUG_A, hash_c_str, size )
+  call atlas__Projection__hash(this%c_ptr(), hash_c_str, size )
   hash = c_ptr_to_string(hash_c_str)
   call c_ptr_free(hash_c_str)
 end function
@@ -122,7 +122,7 @@ function spec(this)
   use atlas_projection_c_binding
   class(atlas_Projection), intent(in) :: this
   type(atlas_Config) :: spec
-  spec = atlas_Config( atlas__Projection__spec(this%CPTR_PGIBUG_A) )
+  spec = atlas_Config( atlas__Projection__spec(this%c_ptr()) )
   call spec%return()
 end function
 
@@ -134,7 +134,7 @@ subroutine xy2lonlat(this, x, y, lon, lat)
   real(c_double), intent(in) :: y
   real(c_double), intent(out) :: lon
   real(c_double), intent(out) :: lat
-  call atlas__Projection__xy2lonlat(this%CPTR_PGIBUG_A, x, y, lon, lat )
+  call atlas__Projection__xy2lonlat(this%c_ptr(), x, y, lon, lat )
 end subroutine
 
 subroutine lonlat2xy(this, lon, lat, x, y)
@@ -145,7 +145,7 @@ subroutine lonlat2xy(this, lon, lat, x, y)
   real(c_double), intent(in) :: lat
   real(c_double), intent(out) :: x
   real(c_double), intent(out) :: y
-  call atlas__Projection__lonlat2xy(this%CPTR_PGIBUG_A, lon, lat, x, y )
+  call atlas__Projection__lonlat2xy(this%c_ptr(), lon, lat, x, y )
 end subroutine
 
 !------------------------------------------------------------------------------

--- a/src/atlas_f/redistribution/atlas_Redistribution_module.F90
+++ b/src/atlas_f/redistribution/atlas_Redistribution_module.F90
@@ -86,7 +86,7 @@ function ctor_create(fspace1, fspace2, redist_name) result(this)
   type(atlas_Config) :: config
   config = empty_config()
   if (present(redist_name)) call config%set("type", redist_name)
-  call this%reset_c_ptr( atlas__Redistribution__new__config(fspace1%CPTR_PGIBUG_A, fspace2%CPTR_PGIBUG_A, config%CPTR_PGIBUG_B) )
+  call this%reset_c_ptr( atlas__Redistribution__new__config(fspace1%c_ptr(), fspace2%c_ptr(), config%c_ptr()) )
   call config%final()
   call this%return()
 end function
@@ -97,14 +97,14 @@ subroutine atlas_Redistribution__execute(this, field_1, field_2)
   class(atlas_Redistribution), intent(in) :: this
   class(atlas_Field), intent(in) :: field_1
   class(atlas_Field), intent(inout) :: field_2
-  call atlas__Redistribution__execute(this%CPTR_PGIBUG_A, field_1%CPTR_PGIBUG_A, field_2%CPTR_PGIBUG_A)
+  call atlas__Redistribution__execute(this%c_ptr(), field_1%c_ptr(), field_2%c_ptr())
 end subroutine
 
 function atlas_Redistribution__source(this) result(fspace)
   use atlas_redistribution_c_binding
   class(atlas_Redistribution), intent(in) :: this
   type(atlas_FunctionSpace) :: fspace
-  call fspace%reset_c_ptr(atlas__Redistribution__source(this%CPTR_PGIBUG_A))
+  call fspace%reset_c_ptr(atlas__Redistribution__source(this%c_ptr()))
   call fspace%return()
 end function
 
@@ -112,7 +112,7 @@ function atlas_Redistribution__target(this) result(fspace)
   use atlas_redistribution_c_binding
   class(atlas_Redistribution), intent(in) :: this
   type(atlas_FunctionSpace) :: fspace
-  call fspace%reset_c_ptr(atlas__Redistribution__target(this%CPTR_PGIBUG_A))
+  call fspace%reset_c_ptr(atlas__Redistribution__target(this%c_ptr()))
   call fspace%return()
 end function
 

--- a/src/atlas_f/runtime/atlas_Trace_module.F90
+++ b/src/atlas_f/runtime/atlas_Trace_module.F90
@@ -147,7 +147,7 @@ function running( this )
   use atlas_Trace_c_binding
   logical :: running
   class(atlas_Trace) :: this
-  if( atlas_Trace__running( this%CPTR_PGIBUG_B ) == 0 ) then
+  if( atlas_Trace__running( this%c_ptr() ) == 0 ) then
     running = .False.
   else
     running = .True.
@@ -161,7 +161,7 @@ function elapsed( this )
   use atlas_Trace_c_binding
   real(c_double) :: elapsed
   class(atlas_Trace) :: this
-  elapsed = atlas_Trace__elapsed( this%CPTR_PGIBUG_B )
+  elapsed = atlas_Trace__elapsed( this%c_ptr() )
 end function
 
 !-------------------------------------------------------------------------------
@@ -169,7 +169,7 @@ end function
 subroutine start( this )
   use atlas_Trace_c_binding
   class(atlas_Trace) :: this
-  call atlas_Trace__start( this%CPTR_PGIBUG_B )
+  call atlas_Trace__start( this%c_ptr() )
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -177,7 +177,7 @@ end subroutine
 subroutine stop( this )
   use atlas_Trace_c_binding
   class(atlas_Trace) :: this
-  call atlas_Trace__stop( this%CPTR_PGIBUG_B )
+  call atlas_Trace__stop( this%c_ptr() )
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -185,7 +185,7 @@ end subroutine
 subroutine pause( this )
   use atlas_Trace_c_binding
   class(atlas_Trace) :: this
-  call atlas_Trace__pause( this%CPTR_PGIBUG_B )
+  call atlas_Trace__pause( this%c_ptr() )
 end subroutine
 
 !-------------------------------------------------------------------------------
@@ -193,7 +193,7 @@ end subroutine
 subroutine resume( this )
   use atlas_Trace_c_binding
   class(atlas_Trace) :: this
-  call atlas_Trace__resume( this%CPTR_PGIBUG_B )
+  call atlas_Trace__resume( this%c_ptr() )
 end subroutine
 
 !-------------------------------------------------------------------------------

--- a/src/atlas_f/trans/atlas_Trans_module.F90
+++ b/src/atlas_f/trans/atlas_Trans_module.F90
@@ -162,15 +162,15 @@ function atlas_Trans__ctor( grid, nsmax, config ) result(this)
   type(atlas_Config), intent(in), optional :: config
   if( present( config ) ) then
     if( present(nsmax) ) then
-      call this%reset_c_ptr( atlas__Trans__new_config( grid%CPTR_PGIBUG_A, nsmax, config%CPTR_PGIBUG_B ) )
+      call this%reset_c_ptr( atlas__Trans__new_config( grid%c_ptr(), nsmax, config%c_ptr() ) )
     else
-      call this%reset_c_ptr( atlas__Trans__new_config( grid%CPTR_PGIBUG_A, 0, config%CPTR_PGIBUG_B ) )
+      call this%reset_c_ptr( atlas__Trans__new_config( grid%c_ptr(), 0, config%c_ptr() ) )
     endif
   else
     if( present(nsmax) ) then
-      call this%reset_c_ptr( atlas__Trans__new( grid%CPTR_PGIBUG_A, nsmax ) )
+      call this%reset_c_ptr( atlas__Trans__new( grid%c_ptr(), nsmax ) )
     else
-      call this%reset_c_ptr( atlas__Trans__new( grid%CPTR_PGIBUG_A, 0 ) )
+      call this%reset_c_ptr( atlas__Trans__new( grid%c_ptr(), 0 ) )
     endif
   endif
   call this%return()
@@ -180,21 +180,21 @@ function handle( this )
   use atlas_trans_c_binding
   integer :: handle
   class(atlas_Trans) :: this
-  handle = atlas__Trans__handle (this%CPTR_PGIBUG_A)
+  handle = atlas__Trans__handle (this%c_ptr())
 end function
 
 function truncation( this )
   use atlas_trans_c_binding
   integer :: truncation
   class(atlas_Trans) :: this
-  truncation = atlas__Trans__truncation (this%CPTR_PGIBUG_A)
+  truncation = atlas__Trans__truncation (this%c_ptr())
 end function
 
 function spectral( this )
   use atlas_trans_c_binding
   type(atlas_FunctionSpace) :: spectral
   class(atlas_Trans) :: this
-  spectral = atlas_FunctionSpace( atlas__Trans__spectral (this%CPTR_PGIBUG_A) )
+  spectral = atlas_FunctionSpace( atlas__Trans__spectral (this%c_ptr()) )
   call spectral%return()
 end function
 
@@ -203,7 +203,7 @@ function grid( this )
   use atlas_trans_c_binding
   class(atlas_Trans) :: this
   type(atlas_Grid) :: grid
-  grid = atlas_Grid( atlas__Trans__grid(this%CPTR_PGIBUG_A) )
+  grid = atlas_Grid( atlas__Trans__grid(this%c_ptr()) )
   call grid%return()
 end function
 
@@ -217,15 +217,15 @@ subroutine dirtrans_fieldset(this, gpfields, spfields, config)
   type(atlas_Config) :: p
 
   if( present(config) ) then
-    call p%reset_c_ptr( config%CPTR_PGIBUG_B )
+    call p%reset_c_ptr( config%c_ptr() )
   else
     p = atlas_Config()
   endif
 
-  call atlas__Trans__dirtrans_fieldset( this%CPTR_PGIBUG_A,     &
-    &                          gpfields%CPTR_PGIBUG_A, &
-    &                          spfields%CPTR_PGIBUG_A, &
-    &                          p%CPTR_PGIBUG_B )
+  call atlas__Trans__dirtrans_fieldset( this%c_ptr(),     &
+    &                          gpfields%c_ptr(), &
+    &                          spfields%c_ptr(), &
+    &                          p%c_ptr() )
 
   if( .not. present(config) ) then
     call p%final()
@@ -242,15 +242,15 @@ subroutine invtrans_fieldset(this, spfields, gpfields, config)
   type(atlas_Config) :: p
 
   if( present(config) ) then
-    call p%reset_c_ptr( config%CPTR_PGIBUG_B )
+    call p%reset_c_ptr( config%c_ptr() )
   else
     p = atlas_Config()
   endif
 
-  call atlas__Trans__invtrans_fieldset( this%CPTR_PGIBUG_A,     &
-    &                          spfields%CPTR_PGIBUG_A, &
-    &                          gpfields%CPTR_PGIBUG_A, &
-    &                          p%CPTR_PGIBUG_B )
+  call atlas__Trans__invtrans_fieldset( this%c_ptr(),     &
+    &                          spfields%c_ptr(), &
+    &                          gpfields%c_ptr(), &
+    &                          p%c_ptr() )
 
   if( .not. present(config) ) then
     call p%final()
@@ -266,15 +266,15 @@ subroutine dirtrans_field(this, gpfield, spfield, config)
   type(atlas_Config) :: p
 
   if( present(config) ) then
-    call p%reset_c_ptr( config%CPTR_PGIBUG_B )
+    call p%reset_c_ptr( config%c_ptr() )
   else
     p = atlas_Config()
   endif
 
-  call atlas__Trans__dirtrans_field( this%CPTR_PGIBUG_A, &
-    &                          gpfield%CPTR_PGIBUG_A, &
-    &                          spfield%CPTR_PGIBUG_A, &
-    &                          p%CPTR_PGIBUG_B )
+  call atlas__Trans__dirtrans_field( this%c_ptr(), &
+    &                          gpfield%c_ptr(), &
+    &                          spfield%c_ptr(), &
+    &                          p%c_ptr() )
 
   if( .not. present(config) ) then
     call p%final()
@@ -291,16 +291,16 @@ subroutine dirtrans_wind2vordiv_field(this, gpwind, spvor, spdiv, config)
   type(atlas_Config) :: p
 
   if( present(config) ) then
-    call p%reset_c_ptr( config%CPTR_PGIBUG_B )
+    call p%reset_c_ptr( config%c_ptr() )
   else
     p = atlas_Config()
   endif
 
-  call atlas__Trans__dirtrans_wind2vordiv_field( this%CPTR_PGIBUG_A, &
-    &                          gpwind%CPTR_PGIBUG_A, &
-    &                          spvor%CPTR_PGIBUG_A, &
-    &                          spdiv%CPTR_PGIBUG_A, &
-    &                          p%CPTR_PGIBUG_B )
+  call atlas__Trans__dirtrans_wind2vordiv_field( this%c_ptr(), &
+    &                          gpwind%c_ptr(), &
+    &                          spvor%c_ptr(), &
+    &                          spdiv%c_ptr(), &
+    &                          p%c_ptr() )
 
   if( .not. present(config) ) then
     call p%final()
@@ -318,15 +318,15 @@ subroutine invtrans_field(this, spfield, gpfield, config)
   type(atlas_Config) :: p
 
   if( present(config) ) then
-    call p%reset_c_ptr( config%CPTR_PGIBUG_B )
+    call p%reset_c_ptr( config%c_ptr() )
   else
     p = atlas_Config()
   endif
 
-  call atlas__Trans__invtrans_field( this%CPTR_PGIBUG_A, &
-    &                          spfield%CPTR_PGIBUG_A, &
-    &                          gpfield%CPTR_PGIBUG_A, &
-    &                          p%CPTR_PGIBUG_B )
+  call atlas__Trans__invtrans_field( this%c_ptr(), &
+    &                          spfield%c_ptr(), &
+    &                          gpfield%c_ptr(), &
+    &                          p%c_ptr() )
 
   if( .not. present(config) ) then
     call p%final()
@@ -344,16 +344,16 @@ subroutine invtrans_vordiv2wind_field(this, spvor, spdiv, gpwind, config)
   type(atlas_Config) :: p
 
   if( present(config) ) then
-    call p%reset_c_ptr( config%CPTR_PGIBUG_B )
+    call p%reset_c_ptr( config%c_ptr() )
   else
     p = atlas_Config()
   endif
 
-  call atlas__Trans__invtrans_vordiv2wind_field( this%CPTR_PGIBUG_A, &
-    &                          spvor%CPTR_PGIBUG_A, &
-    &                          spdiv%CPTR_PGIBUG_A, &
-    &                          gpwind%CPTR_PGIBUG_A, &
-    &                          p%CPTR_PGIBUG_B )
+  call atlas__Trans__invtrans_vordiv2wind_field( this%c_ptr(), &
+    &                          spvor%c_ptr(), &
+    &                          spdiv%c_ptr(), &
+    &                          gpwind%c_ptr(), &
+    &                          p%c_ptr() )
 
   if( .not. present(config) ) then
     call p%final()
@@ -369,10 +369,10 @@ subroutine invtrans_grad_field(this, spfield, gpfield)
   class(atlas_Field), intent(inout) :: gpfield
   type(atlas_Config) :: config
   config = atlas_Config()
-  call atlas__Trans__invtrans_grad_field( this%CPTR_PGIBUG_A, &
-    &                          spfield%CPTR_PGIBUG_A, &
-    &                          gpfield%CPTR_PGIBUG_A, &
-    &                          config%CPTR_PGIBUG_B)
+  call atlas__Trans__invtrans_grad_field( this%c_ptr(), &
+    &                          spfield%c_ptr(), &
+    &                          gpfield%c_ptr(), &
+    &                          config%c_ptr())
   call config%final()
 end subroutine invtrans_grad_field
 

--- a/src/atlas_f/util/atlas_Config_module.F90
+++ b/src/atlas_f/util/atlas_Config_module.F90
@@ -162,7 +162,7 @@ function atlas_Config__has(this, name) result(value)
   character(len=*), intent(in) :: name
   logical :: value
   integer :: value_int
-  value_int =  atlas__Config__has(this%CPTR_PGIBUG_B, c_str(name) )
+  value_int =  atlas__Config__has(this%c_ptr(), c_str(name) )
   if( value_int == 1 ) then
     value = .True.
   else
@@ -176,7 +176,7 @@ subroutine atlas_Config__set_config(this, name, value)
   class(atlas_Config), intent(inout) :: this
   character(len=*), intent(in) :: name
   class(atlas_Config), intent(in) :: value
-  call atlas__Config__set_config(this%CPTR_PGIBUG_B, c_str(name), value%CPTR_PGIBUG_B )
+  call atlas__Config__set_config(this%c_ptr(), c_str(name), value%c_ptr() )
 end subroutine atlas_Config__set_config
 
 subroutine atlas_Config__set_config_list(this, name, value)
@@ -190,9 +190,9 @@ subroutine atlas_Config__set_config_list(this, name, value)
   integer :: j
   if( size(value) > 0 ) then
     do j=1,size(value)
-      value_cptrs(j) = value(j)%CPTR_PGIBUG_B
+      value_cptrs(j) = value(j)%c_ptr()
     enddo
-    call atlas__Config__set_config_list(this%CPTR_PGIBUG_B, c_str(name), c_loc(value_cptrs(1)), size(value_cptrs) )
+    call atlas__Config__set_config_list(this%c_ptr(), c_str(name), c_loc(value_cptrs(1)), size(value_cptrs) )
   endif
 end subroutine atlas_Config__set_config_list
 
@@ -209,7 +209,7 @@ subroutine atlas_Config__set_logical(this, name, value)
   else
     value_int = 0
   end if
-  call atlas__Config__set_int(this%CPTR_PGIBUG_B, c_str(name), value_int )
+  call atlas__Config__set_int(this%c_ptr(), c_str(name), value_int )
 end subroutine atlas_Config__set_logical
 
 subroutine atlas_Config__set_int32(this, name, value)
@@ -219,7 +219,7 @@ subroutine atlas_Config__set_int32(this, name, value)
   class(atlas_Config), intent(inout) :: this
   character(len=*), intent(in) :: name
   integer(c_int), intent(in) :: value
-  call atlas__Config__set_int(this%CPTR_PGIBUG_B, c_str(name), value)
+  call atlas__Config__set_int(this%c_ptr(), c_str(name), value)
 end subroutine atlas_Config__set_int32
 
 subroutine atlas_Config__set_int64(this, name, value)
@@ -229,7 +229,7 @@ subroutine atlas_Config__set_int64(this, name, value)
   class(atlas_Config), intent(inout) :: this
   character(len=*), intent(in) :: name
   integer(c_long), intent(in) :: value
-  call atlas__Config__set_long(this%CPTR_PGIBUG_B, c_str(name), value)
+  call atlas__Config__set_long(this%c_ptr(), c_str(name), value)
 end subroutine atlas_Config__set_int64
 
 subroutine atlas_Config__set_real32(this, name, value)
@@ -239,7 +239,7 @@ subroutine atlas_Config__set_real32(this, name, value)
   class(atlas_Config), intent(inout) :: this
   character(len=*), intent(in) :: name
   real(c_float), intent(in) :: value
-  call atlas__Config__set_float(this%CPTR_PGIBUG_B, c_str(name) ,value)
+  call atlas__Config__set_float(this%c_ptr(), c_str(name) ,value)
 end subroutine atlas_Config__set_real32
 
 subroutine atlas_Config__set_real64(this, name, value)
@@ -249,7 +249,7 @@ subroutine atlas_Config__set_real64(this, name, value)
   class(atlas_Config), intent(inout) :: this
   character(len=*), intent(in) :: name
   real(c_double), intent(in) :: value
-  call atlas__Config__set_double(this%CPTR_PGIBUG_B, c_str(name) ,value)
+  call atlas__Config__set_double(this%c_ptr(), c_str(name) ,value)
 end subroutine atlas_Config__set_real64
 
 subroutine atlas_Config__set_string(this, name, value)
@@ -258,7 +258,7 @@ subroutine atlas_Config__set_string(this, name, value)
   class(atlas_Config), intent(inout) :: this
   character(len=*), intent(in) :: name
   character(len=*), intent(in) :: value
-  call atlas__Config__set_string(this%CPTR_PGIBUG_B, c_str(name) , c_str(value) )
+  call atlas__Config__set_string(this%c_ptr(), c_str(name) , c_str(value) )
 end subroutine atlas_Config__set_string
 
 function atlas_Config__get_config(this, name, value) result(found)
@@ -270,7 +270,7 @@ function atlas_Config__get_config(this, name, value) result(found)
   class(atlas_Config), intent(inout) :: value
   integer :: found_int
   value = atlas_Config()
-  found_int = atlas__Config__get_config( this%CPTR_PGIBUG_B, c_str(name), value%CPTR_PGIBUG_B )
+  found_int = atlas__Config__get_config( this%c_ptr(), c_str(name), value%c_ptr() )
   found = .False.
   if (found_int == 1) found = .True.
 end function atlas_Config__get_config
@@ -290,7 +290,7 @@ function atlas_Config__get_config_list(this, name, value) result(found)
   integer :: found_int
   integer :: j
   value_list_cptr = c_null_ptr
-  found_int = atlas__Config__get_config_list(this%CPTR_PGIBUG_B, c_str(name), &
+  found_int = atlas__Config__get_config_list(this%c_ptr(), c_str(name), &
     & value_list_cptr, value_list_size, value_list_allocated )
   if( found_int == 1 ) then
     call c_f_pointer(value_list_cptr,value_cptrs,(/value_list_size/))
@@ -314,7 +314,7 @@ function atlas_Config__get_logical(this, name, value) result(found)
   logical, intent(inout) :: value
   integer :: value_int
   integer :: found_int
-  found_int = atlas__Config__get_int(this%CPTR_PGIBUG_B,c_str(name), value_int )
+  found_int = atlas__Config__get_int(this%c_ptr(),c_str(name), value_int )
   found = .False.
   if (found_int == 1) found = .True.
   if (found) then
@@ -334,7 +334,7 @@ function atlas_Config__get_int32(this, name, value) result(found)
   character(len=*), intent(in) :: name
   integer, intent(inout) :: value
   integer :: found_int
-  found_int = atlas__Config__get_int(this%CPTR_PGIBUG_B, c_str(name), value )
+  found_int = atlas__Config__get_int(this%c_ptr(), c_str(name), value )
   found = .False.
   if (found_int == 1) found = .True.
 end function atlas_Config__get_int32
@@ -348,7 +348,7 @@ function atlas_Config__get_real32(this, name, value) result(found)
   character(len=*), intent(in) :: name
   real(c_float), intent(inout) :: value
   integer :: found_int
-  found_int = atlas__Config__get_float(this%CPTR_PGIBUG_B, c_str(name), value )
+  found_int = atlas__Config__get_float(this%c_ptr(), c_str(name), value )
   found = .False.
   if (found_int == 1) found = .True.
 end function atlas_Config__get_real32
@@ -362,7 +362,7 @@ function atlas_Config__get_real64(this, name, value) result(found)
   character(len=*), intent(in) :: name
   real(c_double), intent(inout) :: value
   integer :: found_int
-  found_int = atlas__Config__get_double(this%CPTR_PGIBUG_B, c_str(name), value )
+  found_int = atlas__Config__get_double(this%c_ptr(), c_str(name), value )
   found = .False.
   if (found_int == 1) found = .True.
 end function atlas_Config__get_real64
@@ -379,7 +379,7 @@ function atlas_Config__get_string(this, name, value) result(found)
   integer :: found_int
   integer(c_int) :: value_size
   integer(c_int) :: value_allocated
-  found_int = atlas__Config__get_string(this%CPTR_PGIBUG_B,c_str(name),value_cptr,value_size,value_allocated)
+  found_int = atlas__Config__get_string(this%c_ptr(),c_str(name),value_cptr,value_size,value_allocated)
   if( found_int == 1 ) then
     if( allocated(value) ) deallocate(value)
     allocate(character(len=value_size) :: value )
@@ -397,7 +397,7 @@ subroutine atlas_Config__set_array_int32(this, name, value)
   class(atlas_Config), intent(in) :: this
   character(len=*), intent(in) :: name
   integer(c_int), intent(in) :: value(:)
-  call atlas__Config__set_array_int(this%CPTR_PGIBUG_B, c_str(name), &
+  call atlas__Config__set_array_int(this%c_ptr(), c_str(name), &
     & value, size(value) )
 end subroutine atlas_Config__set_array_int32
 
@@ -408,7 +408,7 @@ subroutine atlas_Config__set_array_int64(this, name, value)
   class(atlas_Config), intent(in) :: this
   character(len=*), intent(in) :: name
   integer(c_long), intent(in) :: value(:)
-  call atlas__Config__set_array_long(this%CPTR_PGIBUG_B, c_str(name), &
+  call atlas__Config__set_array_long(this%c_ptr(), c_str(name), &
     & value, size(value) )
 end subroutine atlas_Config__set_array_int64
 
@@ -419,7 +419,7 @@ subroutine atlas_Config__set_array_real32(this, name, value)
   class(atlas_Config), intent(in) :: this
   character(len=*), intent(in) :: name
   real(c_float), intent(in) :: value(:)
-  call atlas__Config__set_array_float(this%CPTR_PGIBUG_B, c_str(name), &
+  call atlas__Config__set_array_float(this%c_ptr(), c_str(name), &
     & value, size(value) )
 end subroutine atlas_Config__set_array_real32
 
@@ -430,7 +430,7 @@ subroutine atlas_Config__set_array_real64(this, name, value)
   class(atlas_Config), intent(in) :: this
   character(len=*), intent(in) :: name
   real(c_double), intent(in) :: value(:)
-  call atlas__Config__set_array_double(this%CPTR_PGIBUG_B, c_str(name), &
+  call atlas__Config__set_array_double(this%c_ptr(), c_str(name), &
     & value, size(value) )
 end subroutine atlas_Config__set_array_real64
 
@@ -447,7 +447,7 @@ function atlas_Config__get_array_int32(this, name, value) result(found)
   integer :: value_size
   integer :: value_allocated
   integer :: found_int
-  found_int = atlas__Config__get_array_int(this%CPTR_PGIBUG_B, c_str(name), &
+  found_int = atlas__Config__get_array_int(this%c_ptr(), c_str(name), &
     & value_cptr, value_size, value_allocated )
   if (found_int ==1 ) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
@@ -473,7 +473,7 @@ function atlas_Config__get_array_int64(this, name, value) result(found)
   integer :: value_size
   integer :: value_allocated
   integer :: found_int
-  found_int = atlas__Config__get_array_long(this%CPTR_PGIBUG_B, c_str(name), &
+  found_int = atlas__Config__get_array_long(this%c_ptr(), c_str(name), &
     & value_cptr, value_size, value_allocated )
   if (found_int == 1) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
@@ -499,7 +499,7 @@ function atlas_Config__get_array_real32(this, name, value) result(found)
   integer :: value_size
   integer :: value_allocated
   integer :: found_int
-  found_int = atlas__Config__get_array_float(this%CPTR_PGIBUG_B, c_str(name), &
+  found_int = atlas__Config__get_array_float(this%c_ptr(), c_str(name), &
     & value_cptr, value_size, value_allocated )
   if (found_int == 1 ) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
@@ -525,7 +525,7 @@ function atlas_Config__get_array_real64(this, name, value) result(found)
   integer :: value_size
   integer :: value_allocated
   integer :: found_int
-  found_int = atlas__Config__get_array_double(this%CPTR_PGIBUG_B, c_str(name), &
+  found_int = atlas__Config__get_array_double(this%c_ptr(), c_str(name), &
     & value_cptr, value_size, value_allocated )
   if (found_int == 1) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
@@ -547,7 +547,7 @@ function atlas_Config__json(this) result(json)
   type(c_ptr) :: json_cptr
   integer(c_int) :: json_size
   integer(c_int) :: json_allocated
-  call atlas__Config__json(this%CPTR_PGIBUG_B,json_cptr,json_size,json_allocated)
+  call atlas__Config__json(this%c_ptr(),json_cptr,json_size,json_allocated)
   allocate(character(len=json_size) :: json )
   json = c_ptr_to_string(json_cptr)
   if( json_allocated == 1 ) call c_ptr_free(json_cptr)

--- a/src/atlas_f/util/atlas_Geometry_module.F90
+++ b/src/atlas_f/util/atlas_Geometry_module.F90
@@ -97,7 +97,7 @@ subroutine atlas_Geometry__delete(this)
   use atlas_Geometry_c_binding
   class(atlas_Geometry), intent(inout) :: this
   if ( .not. this%is_null() ) then
-    call atlas__Geometry__delete(this%CPTR_PGIBUG_A)
+    call atlas__Geometry__delete(this%c_ptr())
   end if
   call this%reset_c_ptr()
 end subroutine atlas_Geometry__delete
@@ -111,7 +111,7 @@ subroutine Geometry__xyz2lonlat_separate_coords(this, x, y, z, lon, lat)
   real(c_double), intent(in) :: z
   real(c_double), intent(out) :: lon
   real(c_double), intent(out) :: lat
-  call atlas__Geometry__xyz2lonlat(this%CPTR_PGIBUG_A, x, y, z, lon, lat)
+  call atlas__Geometry__xyz2lonlat(this%c_ptr(), x, y, z, lon, lat)
 end subroutine Geometry__xyz2lonlat_separate_coords
 
 subroutine Geometry__xyz2lonlat_vectorized_coords(this, xyz, lonlat)
@@ -120,7 +120,7 @@ subroutine Geometry__xyz2lonlat_vectorized_coords(this, xyz, lonlat)
   class(atlas_Geometry), intent(in) :: this
   real(c_double), intent(in) :: xyz(3)
   real(c_double), intent(out) :: lonlat(2)
-  call atlas__Geometry__xyz2lonlat(this%CPTR_PGIBUG_A, xyz(1), xyz(2), xyz(3), lonlat(1), lonlat(2))
+  call atlas__Geometry__xyz2lonlat(this%c_ptr(), xyz(1), xyz(2), xyz(3), lonlat(1), lonlat(2))
 end subroutine Geometry__xyz2lonlat_vectorized_coords
 
 subroutine Geometry__lonlat2xyz_separate_coords(this, lon, lat, x, y, z)
@@ -132,7 +132,7 @@ subroutine Geometry__lonlat2xyz_separate_coords(this, lon, lat, x, y, z)
   real(c_double), intent(out) :: x
   real(c_double), intent(out) :: y
   real(c_double), intent(out) :: z
-  call atlas__Geometry__lonlat2xyz(this%CPTR_PGIBUG_A, lon, lat, x, y, z)
+  call atlas__Geometry__lonlat2xyz(this%c_ptr(), lon, lat, x, y, z)
 end subroutine Geometry__lonlat2xyz_separate_coords
 
 subroutine Geometry__lonlat2xyz_vectorized_coords(this, lonlat, xyz)
@@ -141,7 +141,7 @@ subroutine Geometry__lonlat2xyz_vectorized_coords(this, lonlat, xyz)
   class(atlas_Geometry), intent(in) :: this
   real(c_double), intent(in) :: lonlat(2)
   real(c_double), intent(out) :: xyz(3)
-  call atlas__Geometry__lonlat2xyz(this%CPTR_PGIBUG_A, lonlat(1), lonlat(2), xyz(1), xyz(2), xyz(3))
+  call atlas__Geometry__lonlat2xyz(this%c_ptr(), lonlat(1), lonlat(2), xyz(1), xyz(2), xyz(3))
 end subroutine Geometry__lonlat2xyz_vectorized_coords
 
 function Geometry__distance_lonlat_separate_coords(this, lon1, lat1, lon2, lat2) result(distance_lonlat)
@@ -153,7 +153,7 @@ function Geometry__distance_lonlat_separate_coords(this, lon1, lat1, lon2, lat2)
   real(c_double), intent(in) :: lon2
   real(c_double), intent(in) :: lat2
   real(c_double) :: distance_lonlat
-  distance_lonlat = atlas__Geometry__distance_lonlat(this%CPTR_PGIBUG_A, lon1, lat1, lon2, lat2)
+  distance_lonlat = atlas__Geometry__distance_lonlat(this%c_ptr(), lon1, lat1, lon2, lat2)
 end function Geometry__distance_lonlat_separate_coords
 
 function Geometry__distance_xyz_separate_coords(this, x1, y1, z1, x2, y2, z2) result(distance_xyz)
@@ -167,7 +167,7 @@ function Geometry__distance_xyz_separate_coords(this, x1, y1, z1, x2, y2, z2) re
   real(c_double), intent(in) :: y2
   real(c_double), intent(in) :: z2
   real(c_double) :: distance_xyz
-  distance_xyz = atlas__Geometry__distance_xyz(this%CPTR_PGIBUG_A, x1, y1, z1, x2, y2, z2)
+  distance_xyz = atlas__Geometry__distance_xyz(this%c_ptr(), x1, y1, z1, x2, y2, z2)
 end function Geometry__distance_xyz_separate_coords
 
 function Geometry__distance_vectorized_coords(this, point1, point2) result(distance_point)
@@ -179,10 +179,10 @@ function Geometry__distance_vectorized_coords(this, point1, point2) result(dista
   real(c_double) :: distance_point
   if ((size(point1)==2).and.(size(point2)==2)) then
     ! Lon/lat distance
-    distance_point = atlas__Geometry__distance_lonlat(this%CPTR_PGIBUG_A, point1(1), point1(2), point2(1), point2(2))
+    distance_point = atlas__Geometry__distance_lonlat(this%c_ptr(), point1(1), point1(2), point2(1), point2(2))
   elseif ((size(point1)==3).and.(size(point2)==3)) then
     ! XYZ distance
-    distance_point = atlas__Geometry__distance_xyz(this%CPTR_PGIBUG_A, point1(1), point1(2), point1(3), point2(1), point2(2), &
+    distance_point = atlas__Geometry__distance_xyz(this%c_ptr(), point1(1), point1(2), point1(3), point2(1), point2(2), &
                  & point2(3))
   else
     ! Abort
@@ -195,7 +195,7 @@ function Geometry__radius(this) result(radius)
   use fckit_c_interop_module
   class(atlas_Geometry), intent(in) :: this
   real(c_double) :: radius
-  radius = atlas__Geometry__radius(this%CPTR_PGIBUG_A)
+  radius = atlas__Geometry__radius(this%c_ptr())
 end function Geometry__radius
 
 function Geometry__area(this) result(area)
@@ -203,7 +203,7 @@ function Geometry__area(this) result(area)
   use fckit_c_interop_module
   class(atlas_Geometry), intent(in) :: this
   real(c_double) :: area
-  area = atlas__Geometry__area(this%CPTR_PGIBUG_A)
+  area = atlas__Geometry__area(this%c_ptr())
 end function Geometry__area
 
 !-------------------------------------------------------------------------------

--- a/src/atlas_f/util/atlas_KDTree_module.F90
+++ b/src/atlas_f/util/atlas_KDTree_module.F90
@@ -96,7 +96,7 @@ function atlas_IndexKDTree__ctor_geometry(geometry) result(this)
   use fckit_c_interop_module
   type(atlas_Geometry), intent(in) :: geometry
   type(atlas_IndexKDTree) :: this
-  call this%reset_c_ptr( atlas__IndexKDTree__new_geometry( geometry%CPTR_PGIBUG_A ) )
+  call this%reset_c_ptr( atlas__IndexKDTree__new_geometry( geometry%c_ptr() ) )
   call this%return()
 end function atlas_IndexKDTree__ctor_geometry
 
@@ -104,7 +104,7 @@ subroutine atlas_IndexKDTree__delete(this)
   use atlas_KDTree_c_binding
   class(atlas_IndexKDTree), intent(inout) :: this
   if ( .not. this%is_null() ) then
-    call atlas__IndexKDTree__delete(this%CPTR_PGIBUG_A)
+    call atlas__IndexKDTree__delete(this%c_ptr())
   end if
   call this%reset_c_ptr()
 end subroutine atlas_IndexKDTree__delete
@@ -113,7 +113,7 @@ function atlas_IndexKDTree__empty(this) result(empty)
   use atlas_KDTree_c_binding
   logical :: empty
   class(atlas_IndexKDTree), intent(in) :: this
-  if( atlas__IndexKDTree__empty(this%CPTR_PGIBUG_A) == 0 ) then
+  if( atlas__IndexKDTree__empty(this%c_ptr()) == 0 ) then
     empty = .False.
   else
     empty = .True.
@@ -125,7 +125,7 @@ function atlas_IndexKDTree__size(this) result(size)
   use atlas_kinds_module
   integer(ATLAS_KIND_IDX) :: size
   class(atlas_IndexKDTree), intent(in) :: this
-  size = atlas__IndexKDTree__size(this%CPTR_PGIBUG_A)
+  size = atlas__IndexKDTree__size(this%c_ptr())
 endfunction
 
 subroutine IndexKDTree__reserve(this, size)
@@ -134,7 +134,7 @@ subroutine IndexKDTree__reserve(this, size)
   use atlas_kinds_module
   class(atlas_IndexKDTree), intent(in) :: this
   integer(ATLAS_KIND_IDX), intent(in) :: size
-  call atlas__IndexKDTree__reserve(this%CPTR_PGIBUG_A, size)
+  call atlas__IndexKDTree__reserve(this%c_ptr(), size)
 end subroutine IndexKDTree__reserve
 
 subroutine IndexKDTree__insert_separate_coords(this, lon, lat, index)
@@ -145,7 +145,7 @@ subroutine IndexKDTree__insert_separate_coords(this, lon, lat, index)
   real(c_double), intent(in) :: lon
   real(c_double), intent(in) :: lat
   integer(ATLAS_KIND_IDX), intent(in) :: index
-  call atlas__IndexKDTree__insert(this%CPTR_PGIBUG_A, lon, lat, index)
+  call atlas__IndexKDTree__insert(this%c_ptr(), lon, lat, index)
 end subroutine IndexKDTree__insert_separate_coords
 
 subroutine IndexKDTree__insert_vectorized_coords(this, lonlat, index)
@@ -155,14 +155,14 @@ subroutine IndexKDTree__insert_vectorized_coords(this, lonlat, index)
   class(atlas_IndexKDTree), intent(in) :: this
   real(c_double), intent(in) :: lonlat(2)
   integer(ATLAS_KIND_IDX), intent(in) :: index
-  call atlas__IndexKDTree__insert(this%CPTR_PGIBUG_A, lonlat(1), lonlat(2), index)
+  call atlas__IndexKDTree__insert(this%c_ptr(), lonlat(1), lonlat(2), index)
 end subroutine IndexKDTree__insert_vectorized_coords
 
 subroutine IndexKDTree__build_only(this)
   use atlas_KDTree_c_binding
   use fckit_c_interop_module
   class(atlas_IndexKDTree), intent(in) :: this
-  call atlas__IndexKDTree__build(this%CPTR_PGIBUG_A)
+  call atlas__IndexKDTree__build(this%c_ptr())
 end subroutine IndexKDTree__build_only
 
 subroutine IndexKDTree__build_list_separate_coords(this, n, lons, lats, indices)
@@ -229,7 +229,7 @@ subroutine IndexKDTree__closestPoints_separate_coords(this, plon, plat, k, indic
   real(c_double), pointer :: lons_fptr(:)
   real(c_double), pointer :: lats_fptr(:)
   if ( k > 0 ) then
-    call atlas__IndexKDTree__closestPoints(this%CPTR_PGIBUG_A, plon, plat, int(k, c_size_t), lons_cptr, lats_cptr, indices_cptr, &
+    call atlas__IndexKDTree__closestPoints(this%c_ptr(), plon, plat, int(k, c_size_t), lons_cptr, lats_cptr, indices_cptr, &
                                          & distances_cptr)
     call c_f_pointer(indices_cptr, indices_fptr, (/k/))
     indices(:) = indices_fptr(:)
@@ -272,7 +272,7 @@ subroutine IndexKDTree__closestPoints_vectorized_coords(this, point, k, indices,
   real(c_double), pointer :: lons_fptr(:)
   real(c_double), pointer :: lats_fptr(:)
   if ( k > 0 ) then
-    call atlas__IndexKDTree__closestPoints(this%CPTR_PGIBUG_A, point(1), point(2), int(k, c_size_t), lons_cptr, lats_cptr, &
+    call atlas__IndexKDTree__closestPoints(this%c_ptr(), point(1), point(2), int(k, c_size_t), lons_cptr, lats_cptr, &
                                          & indices_cptr, distances_cptr)
     call c_f_pointer(indices_cptr, indices_fptr, (/k/))
     indices(:) = indices_fptr(:)
@@ -305,7 +305,7 @@ subroutine IndexKDTree__closestPoint_separate_coords(this, plon, plat, index, di
   real(c_double), intent(out), optional :: lon
   real(c_double), intent(out), optional :: lat
   real(c_double) :: distance_tmp, lon_tmp, lat_tmp
-  call atlas__IndexKDTree__closestPoint(this%CPTR_PGIBUG_A, plon, plat, lon_tmp, lat_tmp, index, distance_tmp)
+  call atlas__IndexKDTree__closestPoint(this%c_ptr(), plon, plat, lon_tmp, lat_tmp, index, distance_tmp)
   if (present(distance)) distance = distance_tmp
   if (present(lon)) lon = lon_tmp
   if (present(lat)) lat = lat_tmp
@@ -321,7 +321,7 @@ subroutine IndexKDTree__closestPoint_vectorized_coords(this, point, index, dista
   real(c_double), intent(out), optional :: distance
   real(c_double), intent(out), optional :: lonlat(2)
   real(c_double) :: distance_tmp, lon_tmp, lat_tmp
-  call atlas__IndexKDTree__closestPoint(this%CPTR_PGIBUG_A, point(1), point(2), lon_tmp, lat_tmp, index, distance_tmp)
+  call atlas__IndexKDTree__closestPoint(this%c_ptr(), point(1), point(2), lon_tmp, lat_tmp, index, distance_tmp)
   if (present(distance)) distance = distance_tmp
   if (present(lonlat)) then
      lonlat(1) = lon_tmp
@@ -352,7 +352,7 @@ subroutine IndexKDTree__closestPointsWithinRadius_separate_coords(this, plon, pl
   real(c_double), pointer :: lats_fptr(:)
   integer(ATLAS_KIND_IDX), pointer :: indices_fptr(:)
   real(c_double), pointer :: distances_fptr(:)
-  call atlas__IndexKDTree__closestPointsWithinRadius(this%CPTR_PGIBUG_A, plon, plat, radius, &
+  call atlas__IndexKDTree__closestPointsWithinRadius(this%c_ptr(), plon, plat, radius, &
                                                    & k_tmp, lons_cptr, lats_cptr, indices_cptr, distances_cptr)
   k = int(k_tmp, c_int)
   if (present(indices)) then
@@ -416,7 +416,7 @@ subroutine IndexKDTree__closestPointsWithinRadius_vectorized_coords(this, point,
   real(c_double), pointer :: lats_fptr(:)
   integer(ATLAS_KIND_IDX), pointer :: indices_fptr(:)
   real(c_double), pointer :: distances_fptr(:)
-  call atlas__IndexKDTree__closestPointsWithinRadius(this%CPTR_PGIBUG_A, point(1), point(2), radius, &
+  call atlas__IndexKDTree__closestPointsWithinRadius(this%c_ptr(), point(1), point(2), radius, &
                                                    & k_tmp, lons_cptr, lats_cptr, indices_cptr, distances_cptr)
   k = int(k_tmp, c_int)
   if (present(indices)) then
@@ -458,7 +458,7 @@ function IndexKDTree__geometry(this) result(geometry)
   use fckit_c_interop_module
   class(atlas_IndexKDTree), intent(in) :: this
   type(atlas_Geometry) :: geometry
-  call geometry%reset_c_ptr( atlas__IndexKDTree__geometry( this%CPTR_PGIBUG_A ) )
+  call geometry%reset_c_ptr( atlas__IndexKDTree__geometry( this%c_ptr() ) )
   call geometry%return()
 end function IndexKDTree__geometry
 

--- a/src/atlas_f/util/atlas_Metadata_module.F90
+++ b/src/atlas_f/util/atlas_Metadata_module.F90
@@ -105,7 +105,7 @@ subroutine atlas_Metadata__delete(this)
   use atlas_metadata_c_binding
   class(atlas_Metadata), intent(inout) :: this
   if ( .not. this%is_null() ) then
-    call atlas__Metadata__delete(this%CPTR_PGIBUG_A)
+    call atlas__Metadata__delete(this%c_ptr())
   end if
   call this%reset_c_ptr()
 end subroutine atlas_Metadata__delete
@@ -117,7 +117,7 @@ function Metadata__has(this, name) result(value)
   character(len=*), intent(in) :: name
   logical :: value
   integer :: value_int
-  value_int =  atlas__Metadata__has(this%CPTR_PGIBUG_A, c_str(name) )
+  value_int =  atlas__Metadata__has(this%c_ptr(), c_str(name) )
   if( value_int == 1 ) then
     value = .True.
   else
@@ -137,7 +137,7 @@ subroutine Metadata__set_logical(this, name, value)
   else
     value_int = 0
   end if
-  call atlas__Metadata__set_int(this%CPTR_PGIBUG_A, c_str(name), value_int )
+  call atlas__Metadata__set_int(this%c_ptr(), c_str(name), value_int )
 end subroutine Metadata__set_logical
 
 subroutine Metadata__set_int32(this, name, value)
@@ -146,7 +146,7 @@ subroutine Metadata__set_int32(this, name, value)
   class(atlas_Metadata), intent(inout) :: this
   character(len=*), intent(in) :: name
   integer, intent(in) :: value
-  call atlas__Metadata__set_int(this%CPTR_PGIBUG_A, c_str(name), value)
+  call atlas__Metadata__set_int(this%c_ptr(), c_str(name), value)
 end subroutine Metadata__set_int32
 
 subroutine Metadata__set_real32(this, name, value)
@@ -156,7 +156,7 @@ subroutine Metadata__set_real32(this, name, value)
   class(atlas_Metadata), intent(inout) :: this
   character(len=*), intent(in) :: name
   real(c_float), intent(in) :: value
-  call atlas__Metadata__set_float(this%CPTR_PGIBUG_A, c_str(name) ,value)
+  call atlas__Metadata__set_float(this%c_ptr(), c_str(name) ,value)
 end subroutine Metadata__set_real32
 
 subroutine Metadata__set_real64(this, name, value)
@@ -166,7 +166,7 @@ subroutine Metadata__set_real64(this, name, value)
   class(atlas_Metadata), intent(inout) :: this
   character(len=*), intent(in) :: name
   real(c_double), intent(in) :: value
-  call atlas__Metadata__set_double(this%CPTR_PGIBUG_A, c_str(name) ,value)
+  call atlas__Metadata__set_double(this%c_ptr(), c_str(name) ,value)
 end subroutine Metadata__set_real64
 
 subroutine Metadata__set_string(this, name, value)
@@ -175,7 +175,7 @@ subroutine Metadata__set_string(this, name, value)
   class(atlas_Metadata), intent(inout) :: this
   character(len=*), intent(in) :: name
   character(len=*), intent(in) :: value
-  call atlas__Metadata__set_string(this%CPTR_PGIBUG_A, c_str(name) , c_str(value) )
+  call atlas__Metadata__set_string(this%c_ptr(), c_str(name) , c_str(value) )
 end subroutine Metadata__set_string
 
 subroutine Metadata__get_logical(this, name, value)
@@ -185,7 +185,7 @@ subroutine Metadata__get_logical(this, name, value)
   character(len=*), intent(in) :: name
   logical, intent(out) :: value
   integer :: value_int
-  value_int = atlas__Metadata__get_int(this%CPTR_PGIBUG_A,c_str(name) )
+  value_int = atlas__Metadata__get_int(this%c_ptr(),c_str(name) )
   if (value_int > 0) then
     value = .True.
   else
@@ -199,7 +199,7 @@ subroutine Metadata__get_int32(this, name, value)
   class(atlas_Metadata), intent(in) :: this
   character(len=*), intent(in) :: name
   integer, intent(out) :: value
-  value = atlas__Metadata__get_int(this%CPTR_PGIBUG_A, c_str(name) )
+  value = atlas__Metadata__get_int(this%c_ptr(), c_str(name) )
 end subroutine Metadata__get_int32
 
 subroutine Metadata__get_real32(this, name, value)
@@ -209,7 +209,7 @@ subroutine Metadata__get_real32(this, name, value)
   class(atlas_Metadata), intent(in) :: this
   character(len=*), intent(in) :: name
   real(c_float), intent(out) :: value
-  value = atlas__Metadata__get_float(this%CPTR_PGIBUG_A, c_str(name) )
+  value = atlas__Metadata__get_float(this%c_ptr(), c_str(name) )
 end subroutine Metadata__get_real32
 
 subroutine Metadata__get_real64(this, name, value)
@@ -219,7 +219,7 @@ subroutine Metadata__get_real64(this, name, value)
   class(atlas_Metadata), intent(in) :: this
   character(len=*), intent(in) :: name
   real(c_double), intent(out) :: value
-  value = atlas__Metadata__get_double(this%CPTR_PGIBUG_A, c_str(name) )
+  value = atlas__Metadata__get_double(this%c_ptr(), c_str(name) )
 end subroutine Metadata__get_real64
 
 subroutine Metadata__get_string(this, name, value)
@@ -229,7 +229,7 @@ subroutine Metadata__get_string(this, name, value)
   character(len=*), intent(in) :: name
   character(len=:), allocatable, intent(out) :: value
   character(len=MAX_STR_LEN) :: value_cstr
-  call atlas__Metadata__get_string(this%CPTR_PGIBUG_A, c_str(name), value_cstr, MAX_STR_LEN )
+  call atlas__Metadata__get_string(this%c_ptr(), c_str(name), value_cstr, MAX_STR_LEN )
   value = c_str_to_string(value_cstr)
 end subroutine Metadata__get_string
 
@@ -240,7 +240,7 @@ subroutine Metadata__set_array_int32(this, name, value)
   class(atlas_Metadata), intent(in) :: this
   character(len=*), intent(in) :: name
   integer(c_int), intent(in) :: value(:)
-  call atlas__Metadata__set_array_int(this%CPTR_PGIBUG_A, c_str(name), &
+  call atlas__Metadata__set_array_int(this%c_ptr(), c_str(name), &
     & value, size(value) )
 end subroutine Metadata__set_array_int32
 
@@ -251,7 +251,7 @@ subroutine Metadata__set_array_int64(this, name, value)
   class(atlas_Metadata), intent(in) :: this
   character(len=*), intent(in) :: name
   integer(c_long), intent(in) :: value(:)
-  call atlas__Metadata__set_array_long(this%CPTR_PGIBUG_A, c_str(name), &
+  call atlas__Metadata__set_array_long(this%c_ptr(), c_str(name), &
     & value, size(value) )
 end subroutine Metadata__set_array_int64
 
@@ -262,7 +262,7 @@ subroutine Metadata__set_array_real32(this, name, value)
   class(atlas_Metadata), intent(in) :: this
   character(len=*), intent(in) :: name
   real(c_float), intent(in) :: value(:)
-  call atlas__Metadata__set_array_float(this%CPTR_PGIBUG_A, c_str(name), &
+  call atlas__Metadata__set_array_float(this%c_ptr(), c_str(name), &
     & value, size(value) )
 end subroutine Metadata__set_array_real32
 
@@ -273,7 +273,7 @@ subroutine Metadata__set_array_real64(this, name, value)
   class(atlas_Metadata), intent(in) :: this
   character(len=*), intent(in) :: name
   real(c_double), intent(in) :: value(:)
-  call atlas__Metadata__set_array_double(this%CPTR_PGIBUG_A, c_str(name), &
+  call atlas__Metadata__set_array_double(this%c_ptr(), c_str(name), &
     & value, size(value) )
 end subroutine Metadata__set_array_real64
 
@@ -288,7 +288,7 @@ subroutine Metadata__get_array_int32(this, name, value)
   integer(c_int), pointer :: value_fptr(:)
   integer :: value_size
   integer :: value_allocated
-  call atlas__Metadata__get_array_int(this%CPTR_PGIBUG_A, c_str(name), &
+  call atlas__Metadata__get_array_int(this%c_ptr(), c_str(name), &
     & value_cptr, value_size, value_allocated )
   call c_f_pointer(value_cptr,value_fptr,[value_size])
   allocate(value(value_size))
@@ -307,7 +307,7 @@ subroutine Metadata__get_array_int64(this, name, value)
   integer(c_long), pointer :: value_fptr(:)
   integer :: value_size
   integer :: value_allocated
-  call atlas__Metadata__get_array_long(this%CPTR_PGIBUG_A, c_str(name), &
+  call atlas__Metadata__get_array_long(this%c_ptr(), c_str(name), &
     & value_cptr, value_size, value_allocated )
   call c_f_pointer(value_cptr,value_fptr,(/value_size/))
   allocate(value(value_size))
@@ -326,7 +326,7 @@ subroutine Metadata__get_array_real32(this, name, value)
   real(c_float), pointer :: value_fptr(:)
   integer :: value_size
   integer :: value_allocated
-  call atlas__Metadata__get_array_float(this%CPTR_PGIBUG_A, c_str(name), &
+  call atlas__Metadata__get_array_float(this%c_ptr(), c_str(name), &
     & value_cptr, value_size, value_allocated )
   call c_f_pointer(value_cptr,value_fptr,(/value_size/))
   allocate(value(value_size))
@@ -345,7 +345,7 @@ subroutine Metadata__get_array_real64(this, name, value)
   real(c_double), pointer :: value_fptr(:)
   integer :: value_size
   integer :: value_allocated
-  call atlas__Metadata__get_array_double(this%CPTR_PGIBUG_A, c_str(name), &
+  call atlas__Metadata__get_array_double(this%c_ptr(), c_str(name), &
     & value_cptr, value_size, value_allocated )
   call c_f_pointer(value_cptr,value_fptr,(/value_size/))
   allocate(value(value_size))
@@ -358,7 +358,7 @@ subroutine MetaData__print(this,channel)
   use fckit_log_module, only : fckit_logchannel
   class(atlas_Metadata), intent(in) :: this
   type(fckit_logchannel), intent(in) :: channel
-  call atlas__Metadata__print(this%CPTR_PGIBUG_A,channel%CPTR_PGIBUG_A)
+  call atlas__Metadata__print(this%c_ptr(),channel%c_ptr())
 end subroutine Metadata__print
 
 function Metadata__json(this) result(json)
@@ -370,7 +370,7 @@ function Metadata__json(this) result(json)
   type(c_ptr) :: json_cptr
   integer(c_int) :: json_size
   integer(c_int) :: json_allocated
-  call atlas__Metadata__json(this%CPTR_PGIBUG_A,json_cptr,json_size,json_allocated)
+  call atlas__Metadata__json(this%c_ptr(),json_cptr,json_size,json_allocated)
   allocate(character(len=json_size) :: json )
   json = c_ptr_to_string(json_cptr)
   if( json_allocated == 1 ) call c_ptr_free(json_cptr)

--- a/src/tests/util/fctest_geometry.F90
+++ b/src/tests/util/fctest_geometry.F90
@@ -53,7 +53,7 @@ implicit none
 
   ! Check constructor
   geometry = atlas_Geometry("UnitSphere")
-  write(0,*) "geometry%c_ptr() = ", c_ptr_to_loc(geometry%CPTR_PGIBUG_A)
+  write(0,*) "geometry%c_ptr() = ", c_ptr_to_loc(geometry%c_ptr())
 
   ! Define points
   lonlat1 = (/-71.6_c_double, -33._c_double/)
@@ -102,7 +102,7 @@ implicit none
 
   ! Check constructor for Earth
   geometry = atlas_Geometry("Earth")
-  write(0,*) "geometry%c_ptr() = ", c_ptr_to_loc(geometry%CPTR_PGIBUG_A)
+  write(0,*) "geometry%c_ptr() = ", c_ptr_to_loc(geometry%c_ptr())
 
   ! Define points
   lonlat1 = (/-71.6_c_double, -33._c_double/)
@@ -151,7 +151,7 @@ implicit none
 
   ! Check constructor for another planet (Mars here)
   geometry = atlas_Geometry( 3389500.0_c_double )
-  write(0,*) "geometry%c_ptr() = ", c_ptr_to_loc(geometry%CPTR_PGIBUG_A)
+  write(0,*) "geometry%c_ptr() = ", c_ptr_to_loc(geometry%c_ptr())
 
   ! Define points
   lonlat1 = (/-71.6_c_double, -33._c_double/)

--- a/src/tests/util/fctest_kdtree.F90
+++ b/src/tests/util/fctest_kdtree.F90
@@ -108,7 +108,7 @@ implicit none
 
   ! Check constructor with specific geometry
   kdtree = atlas_IndexKDTree(geometry)
-  write(0,*) "kdtree%c_ptr() = ", c_ptr_to_loc(kdtree%CPTR_PGIBUG_A)
+  write(0,*) "kdtree%c_ptr() = ", c_ptr_to_loc(kdtree%c_ptr())
 
   ! Check reserve
   call kdtree%reserve(n)
@@ -155,7 +155,7 @@ implicit none
 
   ! Check constructor with specific geometry
   kdtree = atlas_IndexKDTree(geometry)
-  write(0,*) "kdtree%c_ptr() = ", c_ptr_to_loc(kdtree%CPTR_PGIBUG_A)
+  write(0,*) "kdtree%c_ptr() = ", c_ptr_to_loc(kdtree%c_ptr())
 
   ! Check reserve
   call kdtree%reserve(n)
@@ -200,7 +200,7 @@ implicit none
 
   ! Check constructor without geometry (Earth)
   kdtree = atlas_IndexKDTree()
-  write(0,*) "kdtree%c_ptr() = ", c_ptr_to_loc(kdtree%CPTR_PGIBUG_A)
+  write(0,*) "kdtree%c_ptr() = ", c_ptr_to_loc(kdtree%c_ptr())
 
   ! Check geometry accessor
   geometry = kdtree%geometry()
@@ -259,7 +259,7 @@ implicit none
 
   ! Check constructor without geometry (Earth)
   kdtree = atlas_IndexKDTree()
-  write(0,*) "kdtree%c_ptr() = ", c_ptr_to_loc(kdtree%CPTR_PGIBUG_A)
+  write(0,*) "kdtree%c_ptr() = ", c_ptr_to_loc(kdtree%c_ptr())
 
   ! Check build with list
   call kdtree%build(n, tree_lonlats, tree_indices)

--- a/src/tests/util/fctest_metadata.F90
+++ b/src/tests/util/fctest_metadata.F90
@@ -58,7 +58,7 @@ implicit none
 
   metadata = atlas_Metadata()
 
-  write(0,*) "metadata%c_ptr() = ", c_ptr_to_loc(metadata%CPTR_PGIBUG_A)
+  write(0,*) "metadata%c_ptr() = ", c_ptr_to_loc(metadata%c_ptr())
 
   call metadata%set("true",.True.)
   call metadata%set("false",.False.)


### PR DESCRIPTION
## Summary
Remove the long-standing `CPTR_PGIBUG_A,B` workaround across the Fortran bindings.

## Why
This is a broad mechanical cleanup of the Fortran interface layer, and it is stacked on the FieldSet fast-path work because both series touch overlapping binding files.

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-377
<!-- STATIC-ANALYSIS_END -->