### PR TITLE
Update github-hosted CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,8 @@ jobs:
           - linux gnu-14
           - linux clang-13
           - linux clang-18
-          - linux intel
-          - linux intel-classic
+          - linux intel-2025.3
+          - linux intel-classic-2021.10
           - linux nvhpc-26.1
           - macos
 
@@ -88,18 +88,18 @@ jobs:
             caching: true
             coverage: false
 
-          - name : linux intel
+          - name: linux intel-2025.3
             os: ubuntu-24.04
-            compiler: intel
+            compiler: intel-2025.3
             compiler_cc: icx
             compiler_cxx: icpx
             compiler_fc: ifx
             caching: true
             coverage: false
 
-          - name : linux intel-classic
+          - name: linux intel-classic-2021.10
             os: ubuntu-22.04
-            compiler: intel-classic
+            compiler: intel-classic-2021.10
             compiler_cc: icc
             compiler_cxx: icpc
             compiler_fc: ifort
@@ -226,9 +226,30 @@ jobs:
     - name: Install Intel oneAPI compiler
       if: contains( matrix.compiler, 'intel' )
       run: |
-        ${ATLAS_TOOLS}/install-intel-oneapi.sh
-        source /opt/intel/oneapi/setvars.sh
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
+        sudo apt-get update
+        if [[ "${{matrix.compiler}}" == "intel-classic-2021.10" ]]; then
+          version=2023.2.0 # latest oneapi version containing classic compiler (2021.10)
+          sudo apt-get install \
+            intel-oneapi-compiler-fortran-$version \
+            intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-$version \
+            intel-oneapi-mkl-$version
+          source /opt/intel/oneapi/setvars.sh
+          unset I_MPI_ROOT # We don't want to use the MPI from this compiler. It shows problems
+        else
+          #sudo apt-get install intel-oneapi-toolkit # since 2026 but MKL is too new for eckit 2.0.6
+          version=2025.3
+          sudo apt-get install \
+            intel-oneapi-base-toolkit-$version \
+            intel-oneapi-hpc-toolkit-$version \
+            intel-oneapi-compiler-fortran-$version
+          source /opt/intel/oneapi/setvars.sh
+        fi
         printenv >> $GITHUB_ENV
+        [ -z ${I_MPI_ROOT+x} ] || echo "MPI_HOME=${I_MPI_ROOT}" >> $GITHUB_ENV
         echo "CACHE_SUFFIX=$CC-$($CC -dumpversion)" >> $GITHUB_ENV
 
     - name: Install MPI
@@ -237,9 +258,11 @@ jobs:
         FCFLAGS=-fPIC CFLAGS=-fPIC FFLAGS=-fPIC ${ATLAS_TOOLS}/install-mpi.sh --mpi openmpi --prefix  ${DEPS_DIR}/openmpi
         [ -f ${DEPS_DIR}/openmpi/env.sh ] && source ${DEPS_DIR}/openmpi/env.sh
         [ -z ${MPI_HOME+x} ] || echo "MPI_HOME=${MPI_HOME}" >> $GITHUB_ENV
-        echo "CACHE_SUFFIX=${CACHE_SUFFIX}-mpi_$(${MPI_HOME}/bin/mpirun --version | head -1 | awk '{print $4}')" >> $GITHUB_ENV
+        echo "CACHE_SUFFIX=${CACHE_SUFFIX}-mpi_$(mpirun --version | head -1 | awk '{print $4}')" >> $GITHUB_ENV
 
     - name: Install FFTW
+      if: "!contains( matrix.compiler, 'intel' )"
+      # Use Intel MKL FFT functions instead of FFTW for intel compilers
       shell: bash -eux {0}
       run: |
         ${ATLAS_TOOLS}/install-fftw.sh --version 3.3.10 --prefix ${DEPS_DIR}/fftw

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ on:
 env:
   ATLAS_TOOLS: ${{ github.workspace }}/tools
   CTEST_PARALLEL_LEVEL: 1
-  CACHE_SUFFIX: v1
+  CACHE_SUFFIX: v2
 
 jobs:
   ci:
@@ -129,12 +129,22 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
+    - name: System info
+      shell: bash -eux {0}
+      run: |
+        if [[ "${{ matrix.os }}" =~ macos ]]; then
+          system_profiler SPHardwareDataType -detailLevel mini
+          sysctl machdep.cpu
+        else
+          sed '/^$/q' /proc/cpuinfo
+        fi
+
     - name: Checkout Repository
       uses: actions/checkout@v2
 
     - name: Set up Homebrew
       id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@master
+      uses: Homebrew/actions/setup-homebrew@main
 
     - name: Environment
       run:  |
@@ -142,6 +152,7 @@ jobs:
         echo "CC=${{ matrix.compiler_cc }}"     >> $GITHUB_ENV
         echo "CXX=${{ matrix.compiler_cxx }}"   >> $GITHUB_ENV
         echo "FC=${{ matrix.compiler_fc }}"     >> $GITHUB_ENV
+        echo "F77=${{ matrix.compiler_fc }}"    >> $GITHUB_ENV
 
         if [[ "${{ matrix.os }}" =~ macos ]]; then
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
@@ -198,6 +209,20 @@ jobs:
         echo "${NVHPC_DIR}/compilers/bin"                   >> $GITHUB_PATH
         [ -z ${MPI_HOME+x} ] || echo "MPI_HOME=${MPI_HOME}" >> $GITHUB_ENV
 
+        # Add a -tp=haswell flag, which is needed to avoid nvhpc errors of "Error during math dispatching processing..."
+        # It seems the compiler detects an incompatible target processor on some of the runners,
+        # in particular -tp=znver4 seems incompatible with "AMD EPYC 9V74 80-Core Processor" as shown by /proc/cpuinfo
+        NVHPC_TARGET_FLAG="-tp=haswell"
+        CFLAGS="${CFLAGS:+$CFLAGS }${NVHPC_TARGET_FLAG}"
+        CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }${NVHPC_TARGET_FLAG}"
+        FFLAGS="${FFLAGS:+$FFLAGS }${NVHPC_TARGET_FLAG}"
+        FCFLAGS="${FCFLAGS:+$FCFLAGS }${NVHPC_TARGET_FLAG}"
+
+        [ -z ${CFLAGS+x}   ] || echo "CFLAGS=${CFLAGS}"     >> $GITHUB_ENV
+        [ -z ${CXXFLAGS+x} ] || echo "CXXFLAGS=${CXXFLAGS}" >> $GITHUB_ENV
+        [ -z ${FFLAGS+x}   ] || echo "FFLAGS=${FFLAGS}"     >> $GITHUB_ENV
+        [ -z ${FCFLAGS+x}  ] || echo "FCFLAGS=${FCFLAGS}"   >> $GITHUB_ENV
+
     - name: Install Intel oneAPI compiler
       if: contains( matrix.compiler, 'intel' )
       run: |
@@ -252,7 +277,6 @@ jobs:
 
     - name: Set Build & Test Environment
       run: |
-
         # Only add --oversubscribe arg for openmpi
         [ -z ${I_MPI_ROOT+x} ] && echo "ATLAS_RUN_MPI_ARGS=--oversubscribe" >> $GITHUB_ENV
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
         fi
 
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     - name: Set up Homebrew
       id: set-up-homebrew
@@ -195,7 +195,7 @@ jobs:
     - name: Retrieve cached dependencies
       if: matrix.caching
       id: deps-restore-cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.DEPS_DIR }}
         key: deps-${{ matrix.os }}-${{ matrix.compiler }}-${{ env.CACHE_SUFFIX }}
@@ -291,7 +291,7 @@ jobs:
       # There seems to be a problem with cached NVHPC dependencies, leading to SIGILL perhaps due to slightly different architectures
       if: matrix.caching && matrix.build_type == 'Debug' && github.ref_name == github.event.repository.default_branch
       id: deps-save-cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ env.DEPS_DIR }}
         key: ${{ steps.deps-restore-cache.outputs.cache-primary-key }}
@@ -336,6 +336,6 @@ jobs:
 
     - name: Codecov Upload
       if: steps.build-test.outputs.coverage_file
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v7
       with:
         files: ${{ steps.build-test.outputs.coverage_file }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ on:
 env:
   ATLAS_TOOLS: ${{ github.workspace }}/tools
   CTEST_PARALLEL_LEVEL: 1
-  CACHE_SUFFIX: v2
+  CACHE_SUFFIX: v3
 
 jobs:
   ci:
@@ -235,11 +235,9 @@ jobs:
       shell: bash -eux {0}
       run: |
         FCFLAGS=-fPIC CFLAGS=-fPIC FFLAGS=-fPIC ${ATLAS_TOOLS}/install-mpi.sh --mpi openmpi --prefix  ${DEPS_DIR}/openmpi
-        if [[ "${{ matrix.os }}" =~ macos ]]; then
-           echo "CACHE_SUFFIX=${CACHE_SUFFIX}-mpi_$(mpirun --version | head -1 | awk '{print $4}')" >> $GITHUB_ENV
-        fi
         [ -f ${DEPS_DIR}/openmpi/env.sh ] && source ${DEPS_DIR}/openmpi/env.sh
         [ -z ${MPI_HOME+x} ] || echo "MPI_HOME=${MPI_HOME}" >> $GITHUB_ENV
+        echo "CACHE_SUFFIX=${CACHE_SUFFIX}-mpi_$(${MPI_HOME}/bin/mpirun --version | head -1 | awk '{print $4}')" >> $GITHUB_ENV
 
     - name: Install FFTW
       shell: bash -eux {0}

--- a/cmake/atlas_compile_flags.cmake
+++ b/cmake/atlas_compile_flags.cmake
@@ -69,6 +69,18 @@ endif()
 if( CMAKE_CXX_COMPILER_ID MATCHES IntelLLVM )
   # Turn off -ffinite-math-only which gets included by some optimisation levels which assumes values can never be NaN.
   # Then results in std::isnan(value) always return false.
-  ecbuild_add_cxx_flags("-fno-finite-math-only")
+  # First we had following implementation:
+  #     ecbuild_add_cxx_flags("-fno-finite-math-only")
+  # However this gets also added to link flags and icpcx warns on unused link flag.
+  # Following prevents the flag from being added to link steps.
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.27")
+    # For CMake 3.27+: Fully immune to both regular link steps AND Link-Time Optimization (LTO) steps
+    # COMPILE_ONLY is only available for CMake 3.27+
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<COMPILE_ONLY:-fno-finite-math-only>>)
+  else()
+    # For CMake 3.3 to 3.26: Limits flag to C++ files (will be safe for regular link steps,
+    # but could warning-leak if you manually use LTO/IPO flags elsewhere)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-finite-math-only>)
+  endif()
 endif()
 

--- a/cmake/atlas_export.cmake
+++ b/cmake/atlas_export.cmake
@@ -58,7 +58,14 @@ if( target_build_type STREQUAL STATIC_LIBRARY )
   set( atlas_REQUIRES_PRIVATE_DEPENDENCIES TRUE )
 endif()
 
-include( atlas_ecbuild2_compatibility )
+# make a backup because atlas_ecbuild2_compatibility will reset FFTW_LIBRARIES and FFTW_INCLUDE_DIRS
+# todo: remove atlas_ecbuild2_compatibility and the need for this backup
+set( FFTW_LIBRARIES_backup ${FFTW_LIBRARIES} )
+set( FFTW_INCLUDE_DIRS_backup ${FFTW_INCLUDE_DIRS} )
 
+include( atlas_ecbuild2_compatibility )
 ecbuild_install_project( NAME Atlas )
 
+# Restore from backup, so it can be printed in the summary further
+set( FFTW_LIBRARIES ${FFTW_LIBRARIES_backup} )
+set( FFTW_INCLUDE_DIRS ${FFTW_INCLUDE_DIRS_backup} )

--- a/cmake/project_summary.cmake
+++ b/cmake/project_summary.cmake
@@ -30,6 +30,14 @@ if( CGAL_FOUND )
 
 endif()
 
+if( atlas_HAVE_FFTW )
+
+    ecbuild_info( "FFTW" )
+    ecbuild_info( "    FFTW_INCLUDE_DIRS   : [${FFTW_INCLUDE_DIRS}]" )
+    ecbuild_info( "    FFTW_LIBRARIES      : [${FFTW_LIBRARIES}]" )
+
+endif()
+
 if( atlas_HAVE_CUDA )
 
     ecbuild_info( "CUDA (${CUDA_VERSION})" )

--- a/tools/install-intel-oneapi.sh
+++ b/tools/install-intel-oneapi.sh
@@ -10,5 +10,6 @@ sudo apt-get update
 sudo apt-get install \
     intel-oneapi-compiler-fortran-$version \
     intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-$version \
-    intel-oneapi-mpi-devel-2021.10.0 \
     intel-oneapi-mkl-$version
+
+# removed for now: intel-oneapi-mpi-devel-2021.10.0 \

--- a/tools/install-mpi.sh
+++ b/tools/install-mpi.sh
@@ -39,12 +39,12 @@ OMPIVER=5.0.10
 MPICHVER=3.4.2
 
 if [ ! -z ${mpi_version+x} ]; then
-  if [[ "${MPI}" =~ [Oo][Pp][Ee][Nn]\-?[Mm][Pp][Ii] ]]; then
-    OMPIVER=${mpi_version}
-  fi
-  if [[ "${MPI}" =~ [Mm][Pp][Ii][Cc][Hh] ]]; then
-    MPICHVER=${mpi_version}
-  fi
+    if [[ "${MPI}" =~ [Oo][Pp][Ee][Nn]\-?[Mm][Pp][Ii] ]]; then
+        OMPIVER=${mpi_version}
+    fi
+    if [[ "${MPI}" =~ [Mm][Pp][Ii][Cc][Hh] ]]; then
+        MPICHVER=${mpi_version}
+    fi
 fi
 
 
@@ -54,14 +54,17 @@ MPI_INSTALLED=false
 MPI_ROOT=
 
 export_env() {
-  if [ -z "${MPI_HOME+x}" ]; then
-    export MPI_HOME=${MPI_ROOT}
-  fi
+    if [ -z "${MPI_HOME+x}" ]; then
+        export MPI_HOME=${MPI_ROOT}
+    fi
 
-  case ":${PATH}:" in
-    *":${MPI_HOME}/bin:"*) ;;
-    *) export PATH=${MPI_HOME}/bin:${PATH} ;;
-  esac
+    case ":${PATH}:" in
+        *":${MPI_HOME}/bin:"*)
+            ;;
+        *)
+            export PATH=${MPI_HOME}/bin:${PATH}
+            ;;
+    esac
 }
 
 write_env() {
@@ -102,65 +105,70 @@ case "$os" in
 
     Linux)
         if [ -n "${MPI_HOME}" ]; then
-          echo "MPI is already installed at MPI_HOME=${MPI_HOME}."
-          echo "Not taking any action."
-          exit 0
+            echo "MPI is already installed at MPI_HOME=${MPI_HOME}."
+            echo "Not taking any action."
+            exit 0
+        fi
+        if [ -n "${I_MPI_ROOT}" ]; then
+            echo "MPI is already installed at I_MPI_ROOT=${I_MPI_ROOT}."
+            echo "Not taking any action."
+            exit 0
         fi
         MPI_ROOT=${PREFIX}
         case "$MPI" in
             mpich)
                 if [ -f ${PREFIX}/include/mpi.h ]; then
-                  echo "${PREFIX}/include/mpi.h found"
+                    echo "${PREFIX}/include/mpi.h found"
                 fi
                 if [ -f ${PREFIX}/lib/libmpich.so ]; then
-                  echo "${PREFIX}/lib/libmpich.so found -- nothing to build."
+                    echo "${PREFIX}/lib/libmpich.so found -- nothing to build."
                 else
-                  echo "Downloading mpich source..."
-                  wget http://www.mpich.org/static/downloads/${MPICHVER}/mpich-${MPICHVER}.tar.gz
-                  tar xfz mpich-${MPICHVER}.tar.gz
-                  rm mpich-${MPICHVER}.tar.gz
-                  echo "Configuring and building mpich..."
-                  cd mpich-${MPICHVER}
-                  unset F90
-                  unset F90FLAGS
-                  ${SCRIPTDIR}/reduce-output.sh ./configure \
-                          --prefix=${PREFIX} \
-                          --enable-static=false \
-                          --enable-alloca=true \
-                          --enable-threads=single \
-                          --enable-fortran=yes \
-                          --enable-fast=all \
-                          --enable-g=none \
-                          --enable-timing=none
-                  ${SCRIPTDIR}/reduce-output.sh make -j48
-                  ${SCRIPTDIR}/reduce-output.sh make install
-                  MPI_INSTALLED=true
-                  cd -
-                  rm -rf mpich-${MPICHVER}
+                    echo "Downloading mpich source..."
+                    wget http://www.mpich.org/static/downloads/${MPICHVER}/mpich-${MPICHVER}.tar.gz
+                    tar xfz mpich-${MPICHVER}.tar.gz
+                    rm mpich-${MPICHVER}.tar.gz
+                    echo "Configuring and building mpich..."
+                    cd mpich-${MPICHVER}
+                    unset F90
+                    unset F90FLAGS
+                    ${SCRIPTDIR}/reduce-output.sh ./configure \
+                            --prefix=${PREFIX} \
+                            --enable-static=false \
+                            --enable-alloca=true \
+                            --enable-threads=single \
+                            --enable-fortran=yes \
+                            --enable-fast=all \
+                            --enable-g=none \
+                            --enable-timing=none
+                    ${SCRIPTDIR}/reduce-output.sh make -j48
+                    ${SCRIPTDIR}/reduce-output.sh make install
+                    MPI_INSTALLED=true
+                    cd -
+                    rm -rf mpich-${MPICHVER}
                 fi
                 ;;
             openmpi)
                 if [ -f ${PREFIX}/include/mpi.h ]; then
-                  echo "openmpi/include/mpi.h found."
+                    echo "openmpi/include/mpi.h found."
                 fi
                 if [ -f ${PREFIX}/lib/libmpi.so ] || [ -f ${PREFIX}/lib64/libmpi.so ]; then
-                  echo "libmpi.so found -- nothing to build."
+                    echo "libmpi.so found -- nothing to build."
                 else
-                  echo "Downloading openmpi source..."
-                  OMPI_MAJOR_MINOR=$(echo $OMPIVER | sed 's/\([0-9]*\.[0-9]*\).*/\1/')
-                  wget --no-check-certificate https://www.open-mpi.org/software/ompi/v${OMPI_MAJOR_MINOR}/downloads/openmpi-$OMPIVER.tar.gz
-                  tar -zxf openmpi-$OMPIVER.tar.gz
-                  rm openmpi-$OMPIVER.tar.gz
-                  echo "Configuring and building openmpi..."
-                  cd openmpi-$OMPIVER
-                  ${SCRIPTDIR}/reduce-output.sh ./configure --prefix=${PREFIX}
-                  ${SCRIPTDIR}/reduce-output.sh make -j4
-                  ${SCRIPTDIR}/reduce-output.sh make install
-                  MPI_INSTALLED=true
-                  echo "localhost slots=72" >> ${PREFIX}/etc/openmpi-default-hostfile
-                  echo "rmaps_default_mapping_policy=:oversubscribe" >> ${PREFIX}/etc/prte-mca-params.conf
-                  cd -
-                  rm -rf openmpi-$OMPIVER
+                    echo "Downloading openmpi source..."
+                    OMPI_MAJOR_MINOR=$(echo $OMPIVER | sed 's/\([0-9]*\.[0-9]*\).*/\1/')
+                    wget --no-check-certificate https://www.open-mpi.org/software/ompi/v${OMPI_MAJOR_MINOR}/downloads/openmpi-$OMPIVER.tar.gz
+                    tar -zxf openmpi-$OMPIVER.tar.gz
+                    rm openmpi-$OMPIVER.tar.gz
+                    echo "Configuring and building openmpi..."
+                    cd openmpi-$OMPIVER
+                    ${SCRIPTDIR}/reduce-output.sh ./configure --prefix=${PREFIX}
+                    ${SCRIPTDIR}/reduce-output.sh make -j4
+                    ${SCRIPTDIR}/reduce-output.sh make install
+                    MPI_INSTALLED=true
+                    echo "localhost slots=72" >> ${PREFIX}/etc/openmpi-default-hostfile
+                    echo "rmaps_default_mapping_policy=:oversubscribe" >> ${PREFIX}/etc/prte-mca-params.conf
+                    cd -
+                    rm -rf openmpi-$OMPIVER
                 fi
                 ;;
             *)
@@ -169,7 +177,6 @@ case "$os" in
                 ;;
         esac
         ;;
-
     *)
         echo "Unknown operating system: $os"
         exit 1
@@ -178,8 +185,8 @@ esac
 
 
 if [ -n "${MPI_ROOT}" ]; then
-  write_env
-  echo "Please source ${PREFIX}/env.sh, containing:"
-  cat ${PREFIX}/env.sh
-  export_env
+    write_env
+    echo "Please source ${PREFIX}/env.sh, containing:"
+    cat ${PREFIX}/env.sh
+    export_env
 fi

--- a/tools/install-mpi.sh
+++ b/tools/install-mpi.sh
@@ -35,7 +35,7 @@ while [ $# != 0 ]; do
 done
 
 os=$(uname)
-OMPIVER=4.1.1
+OMPIVER=5.0.10
 MPICHVER=3.4.2
 
 if [ ! -z ${mpi_version+x} ]; then
@@ -49,20 +49,41 @@ fi
 
 
 mkdir -p ${PREFIX}
-touch ${PREFIX}/env.sh
 
 MPI_INSTALLED=false
+MPI_ROOT=
+
+export_env() {
+  if [ -z "${MPI_HOME+x}" ]; then
+    export MPI_HOME=${MPI_ROOT}
+  fi
+
+  case ":${PATH}:" in
+    *":${MPI_HOME}/bin:"*) ;;
+    *) export PATH=${MPI_HOME}/bin:${PATH} ;;
+  esac
+}
+
+write_env() {
+cat > ${PREFIX}/env.sh << EOF
+export MPI_HOME=${MPI_ROOT}
+export PATH=\${MPI_HOME}/bin:\${PATH}
+EOF
+}
 
 case "$os" in
     Darwin)
         case "$MPI" in
             mpich)
                 brew ls --versions mpich || brew install mpich
+                MPI_ROOT=$(brew --prefix mpich)
                 ;;
             openmpi)
-                brew ls --versions open-mpi || brew install open-mpi
+                brew ls --versions openmpi || brew install openmpi
+                MPI_ROOT=$(brew --prefix openmpi)
                 echo "localhost slots=72" >> $(brew --prefix)/etc/openmpi-default-hostfile
                 echo "localhost slots=72" >> $(brew --prefix)/etc/prte-default-hostfile
+                echo "rmaps_default_mapping_policy=:oversubscribe" >> $(brew --prefix)/etc/prte-mca-params.conf
 
                 # workaround for open-mpi/omp#7516
                 echo "setting the mca gds to hash..."
@@ -85,11 +106,7 @@ case "$os" in
           echo "Not taking any action."
           exit 0
         fi
-        if [ -n "${I_MPI_ROOT}" ]; then
-          echo "MPI is already installed at I_MPI_ROOT=${I_MPI_ROOT}."
-          echo "Not taking any action."
-          exit 0
-        fi
+        MPI_ROOT=${PREFIX}
         case "$MPI" in
             mpich)
                 if [ -f ${PREFIX}/include/mpi.h ]; then
@@ -130,7 +147,8 @@ case "$os" in
                   echo "libmpi.so found -- nothing to build."
                 else
                   echo "Downloading openmpi source..."
-                  wget --no-check-certificate https://www.open-mpi.org/software/ompi/v4.1/downloads/openmpi-$OMPIVER.tar.gz
+                  OMPI_MAJOR_MINOR=$(echo $OMPIVER | sed 's/\([0-9]*\.[0-9]*\).*/\1/')
+                  wget --no-check-certificate https://www.open-mpi.org/software/ompi/v${OMPI_MAJOR_MINOR}/downloads/openmpi-$OMPIVER.tar.gz
                   tar -zxf openmpi-$OMPIVER.tar.gz
                   rm openmpi-$OMPIVER.tar.gz
                   echo "Configuring and building openmpi..."
@@ -140,6 +158,7 @@ case "$os" in
                   ${SCRIPTDIR}/reduce-output.sh make install
                   MPI_INSTALLED=true
                   echo "localhost slots=72" >> ${PREFIX}/etc/openmpi-default-hostfile
+                  echo "rmaps_default_mapping_policy=:oversubscribe" >> ${PREFIX}/etc/prte-mca-params.conf
                   cd -
                   rm -rf openmpi-$OMPIVER
                 fi
@@ -158,11 +177,9 @@ case "$os" in
 esac
 
 
-if ${MPI_INSTALLED} ; then
-cat > ${PREFIX}/env.sh << EOF
-export MPI_HOME=${PREFIX}
-export PATH=\${MPI_HOME}/bin:\${PATH}
-EOF
-echo "Please source ${PREFIX}/env.sh, containing:"
-cat ${PREFIX}/env.sh
+if [ -n "${MPI_ROOT}" ]; then
+  write_env
+  echo "Please source ${PREFIX}/env.sh, containing:"
+  cat ${PREFIX}/env.sh
+  export_env
 fi

--- a/tools/install-nvhpc.sh
+++ b/tools/install-nvhpc.sh
@@ -16,7 +16,7 @@ set -e
 set -u
 set -o pipefail
 
-version=25.1
+version=26.1
 
 TEMPORARY_FILES="${TMPDIR:-/tmp}"
 export NVHPC_INSTALL_DIR=$(pwd)/nvhpc-install
@@ -53,10 +53,10 @@ case "$(uname -m)" in
 esac
 
 if [ -d "${NVHPC_INSTALL_DIR}" ]; then
-    #if [[ $(find "${NVHPC_INSTALL_DIR}" -name "nvc" | wc -l) == 1 ]]; then
+    if [[ $(find "${NVHPC_INSTALL_DIR}" -name "nvc" | wc -l) == 1 ]]; then
       echo "NVHPC already installed at ${NVHPC_INSTALL_DIR}"
       exit
-    #fi
+    fi
 fi
 
 
@@ -94,13 +94,29 @@ echo "+ ${TEMPORARY_FILES}/${FOLDER}/install"
 #rm -rf "${TEMPORARY_FILES}/${FOLDER}"
 
 NVHPC_VERSION=$(basename "${NVHPC_INSTALL_DIR}"/Linux_$(uname -m)/*.*/)
+NVHPC_DIR=${NVHPC_INSTALL_DIR}/Linux_$(uname -m)/${NVHPC_VERSION}
 
 # Use gcc which is available in PATH
-${NVHPC_INSTALL_DIR}/Linux_$(uname -m)/${NVHPC_VERSION}/compilers/bin/makelocalrc \
-  -x ${NVHPC_INSTALL_DIR}/Linux_$(uname -m)/${NVHPC_VERSION}/compilers/bin \
+${NVHPC_DIR}/compilers/bin/makelocalrc \
+  -x ${NVHPC_DIR}/compilers/bin \
   -gcc $(which gcc) \
   -gpp $(which g++) \
   -g77 $(which gfortran)
+
+# Locate the bundled OpenMPI prefix. From 25.x the comm_libs/mpi symlink points
+# at hpcx (a bin-only directory), so we derive the real prefix from the location
+# of openmpi-default-hostfile and fall back to comm_libs/mpi for older releases.
+MPI_HOME=$(dirname $(dirname $(find ${NVHPC_DIR}/comm_libs -name openmpi-default-hostfile -path '*/etc/*' 2>/dev/null | head -1)))
+if [ -z "${MPI_HOME}" ] || [ ! -d "${MPI_HOME}" ]; then
+    MPI_HOME=${NVHPC_DIR}/comm_libs/mpi
+fi
+
+# Allow for oversubscription. For open-mpi >= v5.0
+echo "rmaps_default_mapping_policy=:oversubscribe" >> ${MPI_HOME}/etc/prte-mca-params.conf
+
+# Allow for oversubscription. For open-mpi < v5.0 only (older nvhpc versions)
+echo "localhost slots=72" >> ${MPI_HOME}/etc/openmpi-default-hostfile
+echo "hwloc_base_binding_policy = core:overload-allowed" >> ${MPI_HOME}/etc/openmpi-mca-params.conf
 
 cat > ${NVHPC_INSTALL_DIR}/env.sh << EOF
 ### Variables
@@ -114,7 +130,7 @@ export NVHPC_LIBRARY_PATH=\${NVHPC_DIR}/compilers/lib
 export LD_LIBRARY_PATH=\${NVHPC_LIBRARY_PATH}
 
 ### MPI
-export MPI_HOME=\${NVHPC_DIR}/comm_libs/mpi
+export MPI_HOME=${MPI_HOME}
 export PATH=\${MPI_HOME}/bin:\${PATH}
 EOF
 


### PR DESCRIPTION
This pull request updates the build and toolchain setup for CI, focusing on improving compatibility and reliability with MPI and NVHPC, as well as enhancing system introspection and cache management. The most significant changes include updating MPI and NVHPC versions, improving environment handling and configuration for MPI installations, and adding system information reporting in CI workflows.

**CI Workflow and Environment Improvements:**

* Added a system information step to the CI workflow to collect hardware and CPU details for better debugging and reproducibility. (.github/workflows/build.yml)
* Improved the way MPI version is incorporated into the cache key, ensuring more accurate caching based on MPI version.
* Added export of the `F77` environment variable and improved the logic for setting MPI run arguments. 

**MPI Installation and Configuration:**

* Updated the default OpenMPI version to 5.0.10 and improved the installation script to handle environment setup more robustly, including writing and exporting `MPI_HOME` and updating the `PATH`.
* Enhanced OpenMPI installation logic to correctly fetch sources based on major/minor version and to set oversubscription policies for both macOS and Linux.

**NVHPC Installation and Compatibility:**

* Improved detection of existing installations. 
* Improved NVHPC environment setup: now locates the correct bundled OpenMPI prefix, sets oversubscription policies for both new and old OpenMPI versions, and exports the correct `MPI_HOME`.
* Added logic in the CI workflow to set a specific NVHPC target flag (`-tp=haswell`) to avoid processor compatibility errors on certain runners. This follows similar procedure as in ecmwf-ifs/ectrans#400 .

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-378
<!-- STATIC-ANALYSIS_END -->