### PR TITLE
Fix bug in ATLAS_TRACE related to CallStack

### DIFF
--- a/src/atlas/runtime/trace/CallStack.cc
+++ b/src/atlas/runtime/trace/CallStack.cc
@@ -37,18 +37,26 @@ static size_t hash_codelocation( const CodeLocation& loc ) {
 }
 
 void CallStack::push(const CodeLocation& loc, const std::string& id) {
-    if (stack_.size() == size_) {
-        stack_.resize(2 * size_);
-    }
     auto hash = hash_codelocation(loc);
     if( ! id.empty() ) {
       hash = hash_combine( hash, std::hash<std::string>{}(id) );
     }
-    stack_[size_++] = hash;
+    if (stack_.size() == size_) {
+        if (stack_.capacity() == size_) {
+            stack_.reserve(std::max<size_t>(2 * size_, 64));
+        }
+        stack_.push_back(hash);
+    }
+    else {
+        stack_[size_] = hash;
+    }
+    ++size_;
+    hash_ = 0;
 }
 
 void CallStack::pop() {
     --size_;
+    hash_ = 0;
 }
 
 size_t CallStack::hash() const {

--- a/src/atlas/runtime/trace/CallStack.h
+++ b/src/atlas/runtime/trace/CallStack.h
@@ -41,10 +41,10 @@ public:
     operator bool() const { return size_ > 0; }
 
 public:
-    CallStack(): stack_(64){};
-    CallStack(const CallStack& other): stack_(other.stack_), size_(other.size_) {}
+    CallStack() { stack_.reserve(64); }
+    CallStack(const CallStack& other): stack_(other.begin(), other.end()), size_(other.size_) {}
     CallStack& operator=(const CallStack& other) {
-        stack_ = other.stack_;
+        stack_.assign(other.begin(), other.end());
         size_  = other.size_;
         hash_  = 0;
         return *this;

--- a/src/atlas/runtime/trace/Timings.cc
+++ b/src/atlas/runtime/trace/Timings.cc
@@ -53,8 +53,9 @@ private:
 
 public:
     static TimingsRegistry& instance() {
-        static TimingsRegistry registry;
-        return registry;
+        // Leaking this singleton as it is used in static destructors and we don't want to rely on the order of destruction of static objects
+        static TimingsRegistry* registry = new TimingsRegistry();
+        return *registry;
     }
 
     size_t add(const CodeLocation&, const CallStack& stack, const std::string& title, const Timings::Labels&);


### PR DESCRIPTION
This PR fixes a bug in `ATLAS_TRACE`.
There was an issue on a container overflow within `CallStack`.

This pull request refactors the `CallStack` and `TimingsRegistry` classes to improve memory management, efficiency, and robustness, particularly around stack resizing, copy semantics, and singleton lifetime. The changes ensure that the call stack grows efficiently and that the timings registry singleton remains valid throughout the program's lifetime, even during static destruction.

**CallStack improvements:**

* Changed internal stack resizing logic in `CallStack::push` to use `reserve` and `push_back` for efficient growth, and to avoid unnecessary resizing. Also, reset the cached hash after push/pop operations.
* Updated the `CallStack` constructor and copy operations to use `reserve` and `assign`, ensuring efficient memory allocation and correct copying of stack contents.

**TimingsRegistry singleton robustness:**

* Modified the `TimingsRegistry::instance` method to leak the singleton intentionally, avoiding issues with static object destruction order by allocating it on the heap.


<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-379
<!-- STATIC-ANALYSIS_END -->