### PR TITLE
Abstract FunctionSpace::checksum functions

### DIFF
--- a/src/atlas/functionspace/BlockStructuredColumns.cc
+++ b/src/atlas/functionspace/BlockStructuredColumns.cc
@@ -49,14 +49,6 @@ BlockStructuredColumns::BlockStructuredColumns(const Grid& grid, const grid::Dis
     FunctionSpace(new detail::BlockStructuredColumns(grid, distribution, vertical, config)),
     functionspace_(dynamic_cast<const detail::BlockStructuredColumns*>(get())) {}
 
-std::string BlockStructuredColumns::checksum(const FieldSet& fieldset) const {
-    return functionspace_->checksum(fieldset);
-}
-
-std::string BlockStructuredColumns::checksum(const Field& field) const {
-    return functionspace_->checksum(field);
-}
-
 // ----------------------------------------------------------------------------
 
 }  // namespace functionspace

--- a/src/atlas/functionspace/BlockStructuredColumns.h
+++ b/src/atlas/functionspace/BlockStructuredColumns.h
@@ -48,8 +48,8 @@ public:
 
     const StructuredGrid& grid() const { return functionspace_->grid(); }
 
-    std::string checksum(const FieldSet&) const;
-    std::string checksum(const Field&) const;
+    std::string checksum(const FieldSet& fieldset) const { return functionspace_->checksum(fieldset); }
+    std::string checksum(const Field& field) const { return functionspace_->checksum(field); }
 
     idx_t index(idx_t blk, idx_t rof) const { return functionspace_->index(blk, rof); }
     idx_t k_begin() const { return functionspace_->k_begin(); }

--- a/src/atlas/functionspace/CellColumns.cc
+++ b/src/atlas/functionspace/CellColumns.cc
@@ -851,29 +851,6 @@ const parallel::Checksum* atlas__fs__CellColumns__get_checksum(const CellColumns
 
 // -----------------------------------------------------------------------------------
 
-void atlas__fs__CellColumns__checksum_fieldset(const CellColumns* This, const field::FieldSetImpl* fieldset,
-                                               char*& checksum, int& size, int& allocated) {
-    ATLAS_ASSERT(This);
-    ATLAS_ASSERT(fieldset);
-    std::string checksum_str(This->checksum(fieldset));
-    size      = static_cast<int>(checksum_str.size());
-    checksum  = new char[size + 1];
-    allocated = true;
-    std::strncpy(checksum, checksum_str.c_str(), size + 1);
-}
-
-// -----------------------------------------------------------------------------------
-
-void atlas__fs__CellColumns__checksum_field(const CellColumns* This, const field::FieldImpl* field, char*& checksum,
-                                            int& size, int& allocated) {
-    ATLAS_ASSERT(This);
-    ATLAS_ASSERT(field);
-    std::string checksum_str(This->checksum(field));
-    size      = static_cast<int>(checksum_str.size());
-    checksum  = new char[size + 1];
-    allocated = true;
-    std::strncpy(checksum, checksum_str.c_str(), size + 1);
-}
 }
 
 // -----------------------------------------------------------------------------------

--- a/src/atlas/functionspace/CellColumns.h
+++ b/src/atlas/functionspace/CellColumns.h
@@ -83,8 +83,8 @@ public:
     void scatter(const Field&, Field&) const override;
     const parallel::GatherScatter& scatter() const override;
 
-    std::string checksum(const FieldSet&) const;
-    std::string checksum(const Field&) const;
+    std::string checksum(const FieldSet&) const override;
+    std::string checksum(const Field&) const override;
     const parallel::Checksum& checksum() const;
 
     idx_t size() const override { return nb_cells_; }

--- a/src/atlas/functionspace/CellColumns.h
+++ b/src/atlas/functionspace/CellColumns.h
@@ -155,10 +155,6 @@ void atlas__fs__CellColumns__scatter_field(const CellColumns* This, const field:
                                            field::FieldImpl* local);
 const parallel::GatherScatter* atlas__fs__CellColumns__get_scatter(const CellColumns* This);
 
-void atlas__fs__CellColumns__checksum_fieldset(const CellColumns* This, const field::FieldSetImpl* fieldset,
-                                               char*& checksum, int& size, int& allocated);
-void atlas__fs__CellColumns__checksum_field(const CellColumns* This, const field::FieldImpl* field, char*& checksum,
-                                            int& size, int& allocated);
 const parallel::Checksum* atlas__fs__CellColumns__get_checksum(const CellColumns* This);
 }
 

--- a/src/atlas/functionspace/EdgeColumns.cc
+++ b/src/atlas/functionspace/EdgeColumns.cc
@@ -795,29 +795,6 @@ const parallel::Checksum* atlas__fs__EdgeColumns__get_checksum(const EdgeColumns
 
 // -----------------------------------------------------------------------------------
 
-void atlas__fs__EdgeColumns__checksum_fieldset(const EdgeColumns* This, const field::FieldSetImpl* fieldset,
-                                               char*& checksum, int& size, int& allocated) {
-    ATLAS_ASSERT(This);
-    ATLAS_ASSERT(fieldset);
-    std::string checksum_str(This->checksum(fieldset));
-    size      = static_cast<int>(checksum_str.size());
-    checksum  = new char[size + 1];
-    allocated = true;
-    std::strncpy(checksum, checksum_str.c_str(), size + 1);
-}
-
-// -----------------------------------------------------------------------------------
-
-void atlas__fs__EdgeColumns__checksum_field(const EdgeColumns* This, const field::FieldImpl* field, char*& checksum,
-                                            int& size, int& allocated) {
-    ATLAS_ASSERT(This);
-    ATLAS_ASSERT(field);
-    std::string checksum_str(This->checksum(field));
-    size      = static_cast<int>(checksum_str.size());
-    checksum  = new char[size + 1];
-    allocated = true;
-    std::strncpy(checksum, checksum_str.c_str(), size + 1);
-}
 }
 
 // -----------------------------------------------------------------------------------

--- a/src/atlas/functionspace/EdgeColumns.h
+++ b/src/atlas/functionspace/EdgeColumns.h
@@ -79,8 +79,8 @@ public:
     void scatter(const Field&, Field&) const override;
     const parallel::GatherScatter& scatter() const override;
 
-    std::string checksum(const FieldSet&) const;
-    std::string checksum(const Field&) const;
+    std::string checksum(const FieldSet&) const override;
+    std::string checksum(const Field&) const override;
     const parallel::Checksum& checksum() const;
 
     idx_t size() const override { return nb_edges_; }

--- a/src/atlas/functionspace/EdgeColumns.h
+++ b/src/atlas/functionspace/EdgeColumns.h
@@ -149,10 +149,6 @@ void atlas__fs__EdgeColumns__scatter_field(const EdgeColumns* This, const field:
                                            field::FieldImpl* local);
 const parallel::GatherScatter* atlas__fs__EdgeColumns__get_scatter(const EdgeColumns* This);
 
-void atlas__fs__EdgeColumns__checksum_fieldset(const EdgeColumns* This, const field::FieldSetImpl* fieldset,
-                                               char*& checksum, int& size, int& allocated);
-void atlas__fs__EdgeColumns__checksum_field(const EdgeColumns* This, const field::FieldImpl* field, char*& checksum,
-                                            int& size, int& allocated);
 const parallel::Checksum* atlas__fs__EdgeColumns__get_checksum(const EdgeColumns* This);
 }
 

--- a/src/atlas/functionspace/FunctionSpace.cc
+++ b/src/atlas/functionspace/FunctionSpace.cc
@@ -123,6 +123,14 @@ const parallel::GatherScatter& FunctionSpace::scatter() const {
     return get()->scatter();
 }
 
+std::string FunctionSpace::checksum(const FieldSet& fieldset) const {
+    return get()->checksum(fieldset);
+}
+
+std::string FunctionSpace::checksum(const Field& field) const {
+    return get()->checksum(field);
+}
+
 std::string FunctionSpace::mpi_comm() const {
     return get()->mpi_comm();
 }

--- a/src/atlas/functionspace/FunctionSpace.h
+++ b/src/atlas/functionspace/FunctionSpace.h
@@ -75,6 +75,9 @@ public:
     void scatter(const FieldSet&, FieldSet&) const;
     void scatter(const Field&, Field&) const;
 
+    std::string checksum(const FieldSet&) const;
+    std::string checksum(const Field&) const;
+
     const util::PartitionPolygon& polygon(idx_t halo = 0) const;
 
     const util::PartitionPolygons& polygons() const;

--- a/src/atlas/functionspace/NodeColumns.h
+++ b/src/atlas/functionspace/NodeColumns.h
@@ -96,8 +96,8 @@ public:
     void scatter(const Field&, Field&) const override;
     const parallel::GatherScatter& scatter() const override;
 
-    std::string checksum(const FieldSet&) const;
-    std::string checksum(const Field&) const;
+    std::string checksum(const FieldSet&) const override;
+    std::string checksum(const Field&) const override;
     const parallel::Checksum& checksum() const;
 
     /// @brief Compute sum of scalar field

--- a/src/atlas/functionspace/Spectral.cc
+++ b/src/atlas/functionspace/Spectral.cc
@@ -374,7 +374,6 @@ void Spectral::scatter(const Field& global, Field& local) const {
 }
 
 std::string Spectral::checksum(const FieldSet&) const {
-    eckit::MD5 md5;
     ATLAS_NOTIMPLEMENTED;
 }
 std::string Spectral::checksum(const Field& field) const {

--- a/src/atlas/functionspace/Spectral.h
+++ b/src/atlas/functionspace/Spectral.h
@@ -86,8 +86,8 @@ public:
     void scatter(const FieldSet&, FieldSet&) const override;
     void scatter(const Field&, Field&) const override;
 
-    std::string checksum(const FieldSet&) const;
-    std::string checksum(const Field&) const;
+    std::string checksum(const FieldSet&) const override;
+    std::string checksum(const Field&) const override;
 
     void norm(const Field&, double& norm, int rank = 0) const;
     void norm(const Field&, double norm_per_level[], int rank = 0) const;

--- a/src/atlas/functionspace/StructuredColumns.cc
+++ b/src/atlas/functionspace/StructuredColumns.cc
@@ -48,14 +48,6 @@ StructuredColumns::StructuredColumns(const Grid& grid, const grid::Distribution&
     FunctionSpace(new detail::StructuredColumns(grid, distribution, vertical, config)),
     functionspace_(dynamic_cast<const detail::StructuredColumns*>(get())) {}
 
-std::string StructuredColumns::checksum(const FieldSet& fieldset) const {
-    return functionspace_->checksum(fieldset);
-}
-
-std::string StructuredColumns::checksum(const Field& field) const {
-    return functionspace_->checksum(field);
-}
-
 // ----------------------------------------------------------------------------
 
 }  // namespace functionspace

--- a/src/atlas/functionspace/StructuredColumns.h
+++ b/src/atlas/functionspace/StructuredColumns.h
@@ -50,8 +50,8 @@ public:
 
     const StructuredGrid& grid() const { return functionspace_->grid(); }
 
-    std::string checksum(const FieldSet&) const;
-    std::string checksum(const Field&) const;
+    std::string checksum(const FieldSet& fieldset) const { return functionspace_->checksum(fieldset); }
+    std::string checksum(const Field& field) const { return functionspace_->checksum(field); }
 
     idx_t index(idx_t i, idx_t j) const { return functionspace_->index(i, j); }
 

--- a/src/atlas/functionspace/detail/BlockStructuredColumns.h
+++ b/src/atlas/functionspace/detail/BlockStructuredColumns.h
@@ -99,6 +99,7 @@ public:
 
     const Vertical& vertical() const { return structuredcolumns_->vertical(); }
     const StructuredGrid& grid() const override { return structuredcolumns_->grid(); }
+    const Projection& projection() const override { return grid().projection(); }
 
     idx_t levels() const { return structuredcolumns_->levels(); }
     Field lonlat() const override { return structuredcolumns_->lonlat(); }

--- a/src/atlas/functionspace/detail/BlockStructuredColumns.h
+++ b/src/atlas/functionspace/detail/BlockStructuredColumns.h
@@ -120,8 +120,8 @@ public:
     idx_t k_begin() const { return vertical().k_begin(); }
     idx_t k_end() const { return vertical().k_end(); }
 
-    std::string checksum(const FieldSet&) const;
-    std::string checksum(const Field&) const;
+    std::string checksum(const FieldSet&) const override;
+    std::string checksum(const Field&) const override;
 
     const util::PartitionPolygon& polygon(idx_t halo = 0) const override { return structuredcolumns_->polygon(halo); }
 

--- a/src/atlas/functionspace/detail/BlockStructuredColumnsInterface.cc
+++ b/src/atlas/functionspace/detail/BlockStructuredColumnsInterface.cc
@@ -111,29 +111,6 @@ void atlas__functionspace__BStructuredColumns__scatter_fieldset(const detail::Bl
     This->scatter(g, l);
 }
 
-void atlas__fs__BStructuredColumns__checksum_fieldset(const detail::BlockStructuredColumns* This,
-                                                     const field::FieldSetImpl* fieldset, char*& checksum, idx_t& size,
-                                                     int& allocated) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_functionspace_BlockStructuredColumns");
-    ATLAS_ASSERT(fieldset != nullptr, "Cannot access uninitialised atlas_FieldSet");
-    std::string checksum_str(This->checksum(fieldset));
-    size      = static_cast<idx_t>(checksum_str.size());
-    checksum  = new char[size + 1];
-    allocated = true;
-    std::strncpy(checksum, checksum_str.c_str(), size + 1);
-}
-
-void atlas__fs__BStructuredColumns__checksum_field(const detail::BlockStructuredColumns* This, const field::FieldImpl* field,
-                                                  char*& checksum, idx_t& size, int& allocated) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_functionspace_BlockStructuredColumns");
-    ATLAS_ASSERT(field != nullptr, "Cannot access uninitialised atlas_Field");
-    std::string checksum_str(This->checksum(field));
-    size      = static_cast<idx_t>(checksum_str.size());
-    checksum  = new char[size + 1];
-    allocated = true;
-    std::strncpy(checksum, checksum_str.c_str(), size + 1);
-}
-
 void atlas__fs__BStructuredColumns__index_host(const detail::BlockStructuredColumns* This, idx_t*& data, idx_t& i_min,
                                               idx_t& i_max, idx_t& j_min, idx_t& j_max) {
     ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_functionspace_BlockStructuredColumns");

--- a/src/atlas/functionspace/detail/BlockStructuredColumnsInterface.h
+++ b/src/atlas/functionspace/detail/BlockStructuredColumnsInterface.h
@@ -82,11 +82,6 @@ void atlas__functionspace__BStructuredColumns__gather_fieldset(const detail::Blo
 void atlas__functionspace__BStructuredColumns__scatter_fieldset(const detail::BlockStructuredColumns* This,
                                                                const field::FieldSetImpl* global,
                                                                field::FieldSetImpl* local);
-void atlas__fs__BStructuredColumns__checksum_fieldset(const detail::BlockStructuredColumns* This,
-                                                     const field::FieldSetImpl* fieldset, char*& checksum, idx_t& size,
-                                                     int& allocated);
-void atlas__fs__BStructuredColumns__checksum_field(const detail::BlockStructuredColumns* This, const field::FieldImpl* field,
-                                                  char*& checksum, idx_t& size, int& allocated);
 void atlas__fs__BStructuredColumns__index_host(const detail::BlockStructuredColumns* This, idx_t*& data, idx_t& i_min,
                                               idx_t& i_max, idx_t& j_min, idx_t& j_max);
 idx_t atlas__fs__BStructuredColumns__size(const detail::BlockStructuredColumns* This);

--- a/src/atlas/functionspace/detail/CellColumnsInterface.cc
+++ b/src/atlas/functionspace/detail/CellColumnsInterface.cc
@@ -126,28 +126,6 @@ const parallel::Checksum* atlas__CellsFunctionSpace__get_checksum(const CellColu
     return &This->checksum();
 }
 
-void atlas__CellsFunctionSpace__checksum_fieldset(const CellColumns* This, const field::FieldSetImpl* fieldset,
-                                                  char*& checksum, int& size, int& allocated) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_functionspace_CellColumns");
-    ATLAS_ASSERT(fieldset != nullptr, "Cannot access uninitialised atlas_FieldSet");
-    std::string checksum_str(This->checksum(fieldset));
-    size      = static_cast<int>(checksum_str.size());
-    checksum  = new char[size + 1];
-    allocated = true;
-    std::strncpy(checksum, checksum_str.c_str(), size + 1);
-}
-
-void atlas__CellsFunctionSpace__checksum_field(const CellColumns* This, const field::FieldImpl* field, char*& checksum,
-                                               int& size, int& allocated) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_functionspace_CellColumns");
-    ATLAS_ASSERT(field != nullptr, "Cannot access uninitialised atlas_Field");
-    std::string checksum_str(This->checksum(field));
-    size      = static_cast<int>(checksum_str.size());
-    checksum  = new char[size + 1];
-    allocated = true;
-    std::strncpy(checksum, checksum_str.c_str(), size + 1);
-}
-
 }  // extern C
 
 }  // namespace detail

--- a/src/atlas/functionspace/detail/CellColumnsInterface.h
+++ b/src/atlas/functionspace/detail/CellColumnsInterface.h
@@ -47,10 +47,6 @@ void atlas__CellsFunctionSpace__scatter_field(const CellColumns* This, const fie
                                               field::FieldImpl* local);
 const parallel::GatherScatter* atlas__CellsFunctionSpace__get_scatter(const CellColumns* This);
 
-void atlas__CellsFunctionSpace__checksum_fieldset(const CellColumns* This, const field::FieldSetImpl* fieldset,
-                                                  char*& checksum, int& size, int& allocated);
-void atlas__CellsFunctionSpace__checksum_field(const CellColumns* This, const field::FieldImpl* field, char*& checksum,
-                                               int& size, int& allocated);
 const parallel::Checksum* atlas__CellsFunctionSpace__get_checksum(const CellColumns* This);
 }
 

--- a/src/atlas/functionspace/detail/FunctionSpaceImpl.cc
+++ b/src/atlas/functionspace/detail/FunctionSpaceImpl.cc
@@ -81,15 +81,15 @@ Field FunctionSpaceImpl::global_index() const {
 }
 
 const util::PartitionPolygon& FunctionSpaceImpl::polygon(idx_t /*halo */) const {
-    throw_Exception("polygon() not implemented in derived class", Here());
+    throw_Exception("polygon() not implemented in derived class ["+type()+"]", Here());
 }
 
 const util::PartitionPolygons& FunctionSpaceImpl::polygons() const {
-    throw_Exception("polygons() not implemented in derived class", Here());
+    throw_Exception("polygons() not implemented in derived class ["+type()+"]", Here());
 }
 
 const Projection& FunctionSpaceImpl::projection() const {
-    throw_Exception("projection() not implemented in derived class", Here());
+    throw_Exception("projection() not implemented in derived class ["+type()+"]", Here());
 }
 
 template <typename DATATYPE>

--- a/src/atlas/functionspace/detail/FunctionSpaceImpl.cc
+++ b/src/atlas/functionspace/detail/FunctionSpaceImpl.cc
@@ -103,35 +103,43 @@ Field FunctionSpaceImpl::createField() const {
 }
 
 idx_t FunctionSpaceImpl::part() const {
-    ATLAS_NOTIMPLEMENTED;
+    throw_Exception("part() not implemented in derived class ["+type()+"]", Here());
 }
 
 idx_t FunctionSpaceImpl::nb_parts() const {
-    ATLAS_NOTIMPLEMENTED;
+    throw_Exception("nb_parts() not implemented in derived class ["+type()+"]", Here());
 }
 
 void FunctionSpaceImpl::gather(const FieldSet& local, FieldSet& global) const {
-    ATLAS_NOTIMPLEMENTED;
+    throw_Exception("gather() not implemented in derived class ["+type()+"]", Here());
 }
 
 void FunctionSpaceImpl::gather(const Field& local, Field& global) const {
-    ATLAS_NOTIMPLEMENTED;
+    throw_Exception("gather() not implemented in derived class ["+type()+"]", Here());
 }
 
 void FunctionSpaceImpl::scatter(const FieldSet& global, FieldSet& local) const {
-    ATLAS_NOTIMPLEMENTED;
+    throw_Exception("scatter() not implemented in derived class ["+type()+"]", Here());
 }
 
 void FunctionSpaceImpl::scatter(const Field& global, Field& local) const {
-    ATLAS_NOTIMPLEMENTED;
+    throw_Exception("scatter() not implemented in derived class ["+type()+"]", Here());
+}
+
+std::string FunctionSpaceImpl::checksum(const FieldSet&) const {
+    throw_Exception("checksum() not implemented in derived class ["+type()+"]", Here());
+}
+
+std::string FunctionSpaceImpl::checksum(const Field&) const {
+    throw_Exception("checksum() not implemented in derived class ["+type()+"]", Here());
 }
 
 const parallel::GatherScatter& FunctionSpaceImpl::gather() const {
-    ATLAS_NOTIMPLEMENTED;
+    throw_Exception("gather() not implemented in derived class ["+type()+"]", Here());
 }
 
 const parallel::GatherScatter& FunctionSpaceImpl::scatter() const {
-    ATLAS_NOTIMPLEMENTED;
+    throw_Exception("scatter() not implemented in derived class ["+type()+"]", Here());
 }
 
 std::string FunctionSpaceImpl::mpi_comm() const {

--- a/src/atlas/functionspace/detail/FunctionSpaceImpl.h
+++ b/src/atlas/functionspace/detail/FunctionSpaceImpl.h
@@ -90,6 +90,9 @@ public:
     virtual void scatter(const FieldSet&, FieldSet&) const;
     virtual void scatter(const Field&, Field&) const;
 
+    virtual std::string checksum(const FieldSet&) const;
+    virtual std::string checksum(const Field&) const;
+
     virtual const parallel::GatherScatter& gather() const;
     virtual const parallel::GatherScatter& scatter() const;
 

--- a/src/atlas/functionspace/detail/FunctionSpaceInterface.cc
+++ b/src/atlas/functionspace/detail/FunctionSpaceInterface.cc
@@ -111,6 +111,30 @@ void atlas__FunctionSpace__adjoint_halo_exchange_fieldset(const FunctionSpaceImp
     FieldSet f(fieldset);
     This->adjointHaloExchange(f);
 }
+
+//------------------------------------------------------------------------------
+
+void atlas__FunctionSpace__checksum_field(const FunctionSpaceImpl* This, const field::FieldImpl* field,
+                                          char*& checksum, int& size) {
+    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_FunctionSpace");
+    ATLAS_ASSERT(field != nullptr, "Cannot access uninitialised atlas_Field");
+    std::string s = This->checksum(Field(field));
+    size          = static_cast<int>(s.size());
+    checksum      = new char[size + 1];
+    std::strncpy(checksum, s.c_str(), size + 1);
+}
+
+//------------------------------------------------------------------------------
+
+void atlas__FunctionSpace__checksum_fieldset(const FunctionSpaceImpl* This, const field::FieldSetImpl* fieldset,
+                                             char*& checksum, int& size) {
+    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_FunctionSpace");
+    ATLAS_ASSERT(fieldset != nullptr, "Cannot access uninitialised atlas_FieldSet");
+    std::string s = This->checksum(FieldSet(fieldset));
+    size          = static_cast<int>(s.size());
+    checksum      = new char[size + 1];
+    std::strncpy(checksum, s.c_str(), size + 1);
+}
 }
 
 // ------------------------------------------------------------------

--- a/src/atlas/functionspace/detail/FunctionSpaceInterface.h
+++ b/src/atlas/functionspace/detail/FunctionSpaceInterface.h
@@ -41,6 +41,10 @@ void atlas__FunctionSpace__halo_exchange_field(const FunctionSpaceImpl* This, fi
 void atlas__FunctionSpace__halo_exchange_fieldset(const FunctionSpaceImpl* This, field::FieldSetImpl* fieldset);
 void atlas__FunctionSpace__adjoint_halo_exchange_field(const FunctionSpaceImpl* This, field::FieldImpl* field);
 void atlas__FunctionSpace__adjoint_halo_exchange_fieldset(const FunctionSpaceImpl* This, field::FieldSetImpl* fieldset);
+void atlas__FunctionSpace__checksum_field(const FunctionSpaceImpl* This, const field::FieldImpl* field,
+                                          char*& checksum, int& size);
+void atlas__FunctionSpace__checksum_fieldset(const FunctionSpaceImpl* This, const field::FieldSetImpl* fieldset,
+                                             char*& checksum, int& size);
 }
 
 //------------------------------------------------------------------------------------------------------

--- a/src/atlas/functionspace/detail/NodeColumnsInterface.cc
+++ b/src/atlas/functionspace/detail/NodeColumnsInterface.cc
@@ -126,28 +126,6 @@ const parallel::Checksum* atlas__NodesFunctionSpace__get_checksum(const NodeColu
     return &This->checksum();
 }
 
-void atlas__NodesFunctionSpace__checksum_fieldset(const NodeColumns* This, const field::FieldSetImpl* fieldset,
-                                                  char*& checksum, int& size, int& allocated) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_functionspace_NodeColumns");
-    ATLAS_ASSERT(fieldset != nullptr, "Cannot access uninitialised atlas_FieldSet");
-    std::string checksum_str(This->checksum(fieldset));
-    size      = static_cast<int>(checksum_str.size());
-    checksum  = new char[size + 1];
-    allocated = true;
-    std::strncpy(checksum, checksum_str.c_str(), size + 1);
-}
-
-void atlas__NodesFunctionSpace__checksum_field(const NodeColumns* This, const field::FieldImpl* field, char*& checksum,
-                                               int& size, int& allocated) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_functionspace_NodeColumns");
-    ATLAS_ASSERT(field != nullptr, "Cannot access uninitialised atlas_Field");
-    std::string checksum_str(This->checksum(field));
-    size      = static_cast<int>(checksum_str.size());
-    checksum  = new char[size + 1];
-    allocated = true;
-    std::strncpy(checksum, checksum_str.c_str(), size + 1);
-}
-
 void atlas__NodesFunctionSpace__sum_double(const NodeColumns* This, const field::FieldImpl* field, double& sum,
                                            int& N) {
     ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_functionspace_NodeColumns");

--- a/src/atlas/functionspace/detail/NodeColumnsInterface.h
+++ b/src/atlas/functionspace/detail/NodeColumnsInterface.h
@@ -47,10 +47,6 @@ void atlas__NodesFunctionSpace__scatter_field(const NodeColumns* This, const fie
                                               field::FieldImpl* local);
 const parallel::GatherScatter* atlas__NodesFunctionSpace__get_scatter(const NodeColumns* This);
 
-void atlas__NodesFunctionSpace__checksum_fieldset(const NodeColumns* This, const field::FieldSetImpl* fieldset,
-                                                  char*& checksum, int& size, int& allocated);
-void atlas__NodesFunctionSpace__checksum_field(const NodeColumns* This, const field::FieldImpl* field, char*& checksum,
-                                               int& size, int& allocated);
 const parallel::Checksum* atlas__NodesFunctionSpace__get_checksum(const NodeColumns* This);
 
 void atlas__NodesFunctionSpace__sum_double(const NodeColumns* This, const field::FieldImpl* field, double& sum, int& N);

--- a/src/atlas/functionspace/detail/StructuredColumns.h
+++ b/src/atlas/functionspace/detail/StructuredColumns.h
@@ -109,8 +109,8 @@ public:
 
     idx_t halo() const { return halo_; }
 
-    std::string checksum(const FieldSet&) const;
-    std::string checksum(const Field&) const;
+    std::string checksum(const FieldSet&) const override;
+    std::string checksum(const Field&) const override;
 
 
     const Vertical& vertical() const { return vertical_; }

--- a/src/atlas/functionspace/detail/StructuredColumnsInterface.cc
+++ b/src/atlas/functionspace/detail/StructuredColumnsInterface.cc
@@ -111,29 +111,6 @@ void atlas__functionspace__StructuredColumns__scatter_fieldset(const detail::Str
     This->scatter(g, l);
 }
 
-void atlas__fs__StructuredColumns__checksum_fieldset(const detail::StructuredColumns* This,
-                                                     const field::FieldSetImpl* fieldset, char*& checksum, idx_t& size,
-                                                     int& allocated) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_functionspace_StructuredColumns");
-    ATLAS_ASSERT(fieldset != nullptr, "Cannot access uninitialised atlas_FieldSet");
-    std::string checksum_str(This->checksum(fieldset));
-    size      = static_cast<idx_t>(checksum_str.size());
-    checksum  = new char[size + 1];
-    allocated = true;
-    std::strncpy(checksum, checksum_str.c_str(), size + 1);
-}
-
-void atlas__fs__StructuredColumns__checksum_field(const detail::StructuredColumns* This, const field::FieldImpl* field,
-                                                  char*& checksum, idx_t& size, int& allocated) {
-    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_functionspace_StructuredColumns");
-    ATLAS_ASSERT(field != nullptr, "Cannot access uninitialised atlas_Field");
-    std::string checksum_str(This->checksum(field));
-    size      = static_cast<idx_t>(checksum_str.size());
-    checksum  = new char[size + 1];
-    allocated = true;
-    std::strncpy(checksum, checksum_str.c_str(), size + 1);
-}
-
 void atlas__fs__StructuredColumns__index_host(const detail::StructuredColumns* This, idx_t*& data, idx_t& i_min,
                                               idx_t& i_max, idx_t& j_min, idx_t& j_max) {
     ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_functionspace_StructuredColumns");

--- a/src/atlas/functionspace/detail/StructuredColumnsInterface.h
+++ b/src/atlas/functionspace/detail/StructuredColumnsInterface.h
@@ -82,11 +82,6 @@ void atlas__functionspace__StructuredColumns__gather_fieldset(const detail::Stru
 void atlas__functionspace__StructuredColumns__scatter_fieldset(const detail::StructuredColumns* This,
                                                                const field::FieldSetImpl* global,
                                                                field::FieldSetImpl* local);
-void atlas__fs__StructuredColumns__checksum_fieldset(const detail::StructuredColumns* This,
-                                                     const field::FieldSetImpl* fieldset, char*& checksum, idx_t& size,
-                                                     int& allocated);
-void atlas__fs__StructuredColumns__checksum_field(const detail::StructuredColumns* This, const field::FieldImpl* field,
-                                                  char*& checksum, idx_t& size, int& allocated);
 void atlas__fs__StructuredColumns__index_host(const detail::StructuredColumns* This, idx_t*& data, idx_t& i_min,
                                               idx_t& i_max, idx_t& j_min, idx_t& j_max);
 idx_t atlas__fs__StructuredColumns__size(const detail::StructuredColumns* This);

--- a/src/atlas_f/functionspace/atlas_FunctionSpace_module.F90
+++ b/src/atlas_f/functionspace/atlas_FunctionSpace_module.F90
@@ -58,6 +58,9 @@ contains
   procedure, private :: adjoint_halo_exchange_field
   procedure, private :: adjoint_halo_exchange_fieldset
 
+  procedure, private :: checksum_field
+  procedure, private :: checksum_fieldset
+
   generic, public :: create_field => &
     & create_field_args, &
     & create_field_template, &
@@ -66,6 +69,7 @@ contains
 
   generic, public :: halo_exchange => halo_exchange_field, halo_exchange_fieldset
   generic, public :: adjoint_halo_exchange => adjoint_halo_exchange_field, adjoint_halo_exchange_fieldset
+  generic, public :: checksum => checksum_field, checksum_fieldset
 
 #if FCKIT_FINAL_NOT_INHERITING
   final :: atlas_FunctionSpace__final_auto
@@ -201,6 +205,40 @@ subroutine adjoint_halo_exchange_field(this,field)
   type(atlas_Field), intent(inout) :: field
   call atlas__FunctionSpace__adjoint_halo_exchange_field(this%c_ptr(),field%c_ptr())
 end subroutine
+
+!------------------------------------------------------------------------------
+
+function checksum_field(this,field) result(checksum)
+  use atlas_functionspace_c_binding
+  use fckit_c_interop_module, only : c_ptr_to_string, c_ptr_free
+  use, intrinsic :: iso_c_binding, only : c_ptr
+  character(len=:), allocatable :: checksum
+  class(atlas_Functionspace), intent(in) :: this
+  type(atlas_Field), intent(in) :: field
+  type(c_ptr) :: checksum_cptr
+  integer :: checksum_size
+  call atlas__FunctionSpace__checksum_field(this%c_ptr(),field%c_ptr(),checksum_cptr,checksum_size)
+  allocate(character(len=checksum_size) :: checksum)
+  checksum = c_ptr_to_string(checksum_cptr)
+  call c_ptr_free(checksum_cptr)
+end function checksum_field
+
+!------------------------------------------------------------------------------
+
+function checksum_fieldset(this,fieldset) result(checksum)
+  use atlas_functionspace_c_binding
+  use fckit_c_interop_module, only : c_ptr_to_string, c_ptr_free
+  use, intrinsic :: iso_c_binding, only : c_ptr
+  character(len=:), allocatable :: checksum
+  class(atlas_Functionspace), intent(in) :: this
+  type(atlas_FieldSet), intent(in) :: fieldset
+  type(c_ptr) :: checksum_cptr
+  integer :: checksum_size
+  call atlas__FunctionSpace__checksum_fieldset(this%c_ptr(),fieldset%c_ptr(),checksum_cptr,checksum_size)
+  allocate(character(len=checksum_size) :: checksum)
+  checksum = c_ptr_to_string(checksum_cptr)
+  call c_ptr_free(checksum_cptr)
+end function checksum_fieldset
 
 !------------------------------------------------------------------------------
 

--- a/src/atlas_f/functionspace/atlas_functionspace_BlockStructuredColumns_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_BlockStructuredColumns_module.F90
@@ -70,10 +70,6 @@ contains
   procedure, private :: scatter_field
   generic, public :: scatter => scatter_fieldset, scatter_field
 
-  procedure, private :: checksum_fieldset
-  procedure, private :: checksum_field
-  generic, public :: checksum => checksum_fieldset, checksum_field
-
   procedure :: j_begin
   procedure :: j_end
   procedure :: i_begin
@@ -351,39 +347,6 @@ subroutine scatter_fieldset(this,global,local)
   type(atlas_FieldSet), intent(inout) :: local
   call atlas__functionspace__BStructuredColumns__scatter_fieldset(this%c_ptr(),global%c_ptr(),local%c_ptr())
 end subroutine
-
-function checksum_fieldset(this,fieldset) result(checksum)
-  use, intrinsic :: iso_c_binding
-  use atlas_functionspace_BlockStructuredColumns_c_binding
-  character(len=:), allocatable :: checksum
-  class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  type(atlas_FieldSet), intent(in) :: fieldset
-  type(c_ptr) :: checksum_cptr
-  integer(ATLAS_KIND_IDX) :: checksum_size
-  integer(c_int) :: checksum_allocated
-  call atlas__fs__BStructuredColumns__checksum_fieldset( &
-    & this%c_ptr(),fieldset%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
-  allocate(character(len=checksum_size) :: checksum )
-  checksum = c_ptr_to_string(checksum_cptr)
-  if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
-end function
-
-
-function checksum_field(this,field) result(checksum)
-  use, intrinsic :: iso_c_binding
-  use atlas_functionspace_BlockStructuredColumns_c_binding
-  character(len=:), allocatable :: checksum
-  class(atlas_functionspace_BlockStructuredColumns), intent(in) :: this
-  type(atlas_Field), intent(in) :: field
-  type(c_ptr) :: checksum_cptr
-  integer(ATLAS_KIND_IDX) :: checksum_size
-  integer(c_int) :: checksum_allocated
-  call atlas__fs__BStructuredColumns__checksum_field( &
-      & this%c_ptr(),field%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
-  allocate(character(len=checksum_size) :: checksum )
-  checksum = c_ptr_to_string(checksum_cptr)
-  if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
-end function
 
 subroutine set_index(this)
   use, intrinsic :: iso_c_binding, only : c_ptr, c_f_pointer

--- a/src/atlas_f/functionspace/atlas_functionspace_CellColumns_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_CellColumns_module.F90
@@ -74,9 +74,6 @@ contains
   generic, public :: scatter => scatter_fieldset, scatter_field
   procedure, public :: get_scatter
 
-  procedure, private :: checksum_fieldset
-  procedure, private :: checksum_field
-  generic, public :: checksum => checksum_fieldset, checksum_field
   procedure, public :: get_checksum
 
 #if FCKIT_FINAL_NOT_INHERITING
@@ -226,40 +223,6 @@ function get_checksum(this) result(checksum)
   type(atlas_Checksum) :: checksum
   class(atlas_functionspace_CellColumns), intent(in) :: this
   call checksum%reset_c_ptr( atlas__CellsFunctioNSpace__get_checksum(this%c_ptr()) )
-end function
-
-!------------------------------------------------------------------------------
-
-function checksum_fieldset(this,fieldset) result(checksum)
-  use atlas_functionspace_CellColumns_c_binding
-  use, intrinsic :: iso_c_binding, only : c_ptr
-  character(len=:), allocatable :: checksum
-  class(atlas_functionspace_CellColumns), intent(in) :: this
-  type(atlas_FieldSet), intent(in) :: fieldset
-  type(c_ptr) :: checksum_cptr
-  integer :: checksum_size, checksum_allocated
-  call atlas__CellsFunctionSpace__checksum_fieldset( &
-    this%c_ptr(),fieldset%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
-  allocate(character(len=checksum_size) :: checksum )
-  checksum = c_ptr_to_string(checksum_cptr)
-  if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
-end function
-
-!------------------------------------------------------------------------------
-
-function checksum_field(this,field) result(checksum)
-  use atlas_functionspace_CellColumns_c_binding
-  use, intrinsic :: iso_c_binding, only : c_ptr
-  character(len=:), allocatable :: checksum
-  class(atlas_functionspace_CellColumns), intent(in) :: this
-  type(atlas_Field), intent(in) :: field
-  type(c_ptr) :: checksum_cptr
-  integer :: checksum_size, checksum_allocated
-  call atlas__CellsFunctionSpace__checksum_field( &
-    this%c_ptr(),field%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
-  allocate(character(len=checksum_size) :: checksum )
-  checksum = c_ptr_to_string(checksum_cptr)
-  if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
 end function
 
 !------------------------------------------------------------------------------

--- a/src/atlas_f/functionspace/atlas_functionspace_EdgeColumns_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_EdgeColumns_module.F90
@@ -74,9 +74,6 @@ contains
   generic, public :: scatter => scatter_field, scatter_fieldset
   procedure, public :: get_scatter
 
-  procedure, private :: checksum_fieldset
-  procedure, private :: checksum_field
-  generic, public :: checksum => checksum_field, checksum_fieldset
   procedure, public :: get_checksum
 
 #if FCKIT_FINAL_NOT_INHERITING
@@ -231,38 +228,6 @@ function get_checksum(this) result(checksum)
   class(atlas_functionspace_EdgeColumns), intent(in) :: this
   call checksum%reset_c_ptr( atlas__fs__EdgeColumns__get_checksum(this%c_ptr()) )
 !   call checksum%return()
-end function
-
-!------------------------------------------------------------------------------
-
-function checksum_fieldset(this,fieldset) result(checksum)
-  use atlas_functionspace_EdgeColumns_c_binding
-  character(len=:), allocatable :: checksum
-  class(atlas_functionspace_EdgeColumns), intent(in) :: this
-  type(atlas_FieldSet), intent(in) :: fieldset
-  type(c_ptr) :: checksum_cptr
-  integer :: checksum_size, checksum_allocated
-  call atlas__fs__EdgeColumns__checksum_fieldset(this%c_ptr(), &
-    fieldset%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
-  allocate(character(len=checksum_size) :: checksum )
-  checksum = c_ptr_to_string(checksum_cptr)
-  if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
-end function
-
-!------------------------------------------------------------------------------
-
-function checksum_field(this,field) result(checksum)
-  use atlas_functionspace_EdgeColumns_c_binding
-  character(len=:), allocatable :: checksum
-  class(atlas_functionspace_EdgeColumns), intent(in) :: this
-  type(atlas_Field), intent(in) :: field
-  type(c_ptr) :: checksum_cptr
-  integer :: checksum_size, checksum_allocated
-  call atlas__fs__EdgeColumns__checksum_field(this%c_ptr(), &
-    field%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
-  allocate(character(len=checksum_size) :: checksum )
-  checksum = c_ptr_to_string(checksum_cptr)
-  if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
 end function
 
 !-------------------------------------------------------------------------------

--- a/src/atlas_f/functionspace/atlas_functionspace_NodeColumns_module.fypp
+++ b/src/atlas_f/functionspace/atlas_functionspace_NodeColumns_module.fypp
@@ -77,9 +77,6 @@ contains
   generic, public :: scatter => scatter_fieldset, scatter_field
   procedure, public :: get_scatter
 
-  procedure, private :: checksum_fieldset
-  procedure, private :: checksum_field
-  generic, public :: checksum => checksum_fieldset, checksum_field
   procedure, public :: get_checksum
 
 
@@ -258,40 +255,6 @@ function get_checksum(this) result(checksum)
   type(atlas_Checksum) :: checksum
   class(atlas_functionspace_NodeColumns), intent(in) :: this
   call checksum%reset_c_ptr( atlas__NodesFunctioNSpace__get_checksum(this%c_ptr()) )
-end function
-
-!------------------------------------------------------------------------------
-
-function checksum_fieldset(this,fieldset) result(checksum)
-  use atlas_functionspace_NodeColumns_c_binding
-  use, intrinsic :: iso_c_binding, only : c_ptr
-  character(len=:), allocatable :: checksum
-  class(atlas_functionspace_NodeColumns), intent(in) :: this
-  type(atlas_FieldSet), intent(in) :: fieldset
-  type(c_ptr) :: checksum_cptr
-  integer :: checksum_size, checksum_allocated
-  call atlas__NodesFunctionSpace__checksum_fieldset( &
-    this%c_ptr(),fieldset%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
-  allocate(character(len=checksum_size) :: checksum )
-  checksum = c_ptr_to_string(checksum_cptr)
-  if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
-end function
-
-!------------------------------------------------------------------------------
-
-function checksum_field(this,field) result(checksum)
-  use atlas_functionspace_NodeColumns_c_binding
-  use, intrinsic :: iso_c_binding, only : c_ptr
-  character(len=:), allocatable :: checksum
-  class(atlas_functionspace_NodeColumns), intent(in) :: this
-  type(atlas_Field), intent(in) :: field
-  type(c_ptr) :: checksum_cptr
-  integer :: checksum_size, checksum_allocated
-  call atlas__NodesFunctionSpace__checksum_field( &
-    this%c_ptr(),field%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
-  allocate(character(len=checksum_size) :: checksum )
-  checksum = c_ptr_to_string(checksum_cptr)
-  if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
 end function
 
 !------------------------------------------------------------------------------

--- a/src/atlas_f/functionspace/atlas_functionspace_StructuredColumns_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_StructuredColumns_module.F90
@@ -70,10 +70,6 @@ contains
   procedure, private :: scatter_field
   generic, public :: scatter => scatter_fieldset, scatter_field
 
-  procedure, private :: checksum_fieldset
-  procedure, private :: checksum_field
-  generic, public :: checksum => checksum_fieldset, checksum_field
-
   procedure :: j_begin
   procedure :: j_end
   procedure :: i_begin
@@ -332,39 +328,6 @@ subroutine scatter_fieldset(this,global,local)
   type(atlas_FieldSet), intent(inout) :: local
   call atlas__functionspace__StructuredColumns__scatter_fieldset(this%c_ptr(),global%c_ptr(),local%c_ptr())
 end subroutine
-
-function checksum_fieldset(this,fieldset) result(checksum)
-  use, intrinsic :: iso_c_binding
-  use atlas_functionspace_StructuredColumns_c_binding
-  character(len=:), allocatable :: checksum
-  class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  type(atlas_FieldSet), intent(in) :: fieldset
-  type(c_ptr) :: checksum_cptr
-  integer(ATLAS_KIND_IDX) :: checksum_size
-  integer(c_int) :: checksum_allocated
-  call atlas__fs__StructuredColumns__checksum_fieldset( &
-    & this%c_ptr(),fieldset%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
-  allocate(character(len=checksum_size) :: checksum )
-  checksum = c_ptr_to_string(checksum_cptr)
-  if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
-end function
-
-
-function checksum_field(this,field) result(checksum)
-  use, intrinsic :: iso_c_binding
-  use atlas_functionspace_StructuredColumns_c_binding
-  character(len=:), allocatable :: checksum
-  class(atlas_functionspace_StructuredColumns), intent(in) :: this
-  type(atlas_Field), intent(in) :: field
-  type(c_ptr) :: checksum_cptr
-  integer(ATLAS_KIND_IDX) :: checksum_size
-  integer(c_int) :: checksum_allocated
-  call atlas__fs__StructuredColumns__checksum_field( &
-      & this%c_ptr(),field%c_ptr(),checksum_cptr,checksum_size,checksum_allocated)
-  allocate(character(len=checksum_size) :: checksum )
-  checksum = c_ptr_to_string(checksum_cptr)
-  if( checksum_allocated == 1 ) call c_ptr_free(checksum_cptr)
-end function
 
 subroutine set_index(this)
   use, intrinsic :: iso_c_binding, only : c_ptr, c_f_pointer


### PR DESCRIPTION
This pull request refactors and simplifies the implementation of checksum methods across several function space classes in the codebase. The main changes involve standardizing the interface for checksum computations, removing redundant C API wrappers, and improving error messages for unimplemented virtual methods. These changes make the codebase more maintainable and consistent.

**Refactoring and standardization of checksum methods:**

* The `checksum` methods for `FieldSet` and `Field` are now consistently declared as `override` in all relevant function space classes (`NodeColumns`, `EdgeColumns`, `CellColumns`, `Spectral`, `BlockStructuredColumns`, and `StructuredColumns`), ensuring proper virtual dispatch and interface consistency. 
* The `FunctionSpace` base class now provides virtual `checksum` methods, and their implementations delegate to the underlying implementation, reducing code duplication. 

**Removal of redundant or obsolete C API wrappers:**

* Several C API wrapper functions for checksum computation (for `BlockStructuredColumns`, `CellColumns`, and `EdgeColumns`) have been removed from both implementation and header files, as they are no longer necessary with the improved C++ interface. 

**Code simplification and error message improvements:**

* Redundant explicit method implementations in wrapper classes like `BlockStructuredColumns` and `StructuredColumns` have been replaced with inline forwarding methods, reducing boilerplate. [[1]](diffhunk://#diff-b2cbe362199aa95c32878f2b1f7376b5456bc39b189c9b54ea49599827452710L52-L59) [[2]](diffhunk://#diff-ab7b50bf42af4e23b4566fa6aad0513d0ac9bf8eb8c21e6b1e579565b7a63b02L51-L58)
* Error messages for unimplemented virtual methods in `FunctionSpaceImpl` now include the derived class type, aiding debugging.
* The `projection()` method is now properly overridden in `BlockStructuredColumns`, ensuring correct behavior.

**Other improvements:**

* The `Spectral` function space now explicitly marks its `checksum` methods as not implemented, clarifying intended usage.

Overall, this refactoring enhances code clarity, maintainability, and consistency in the handling of checksum operations across the function space hierarchy.

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-383
<!-- STATIC-ANALYSIS_END -->