### PR TITLE
Match StructuredColumns::checksum with BlockStructuredColumns

### DIFF
--- a/src/atlas/functionspace/detail/StructuredColumns.cc
+++ b/src/atlas/functionspace/detail/StructuredColumns.cc
@@ -16,8 +16,6 @@
 #include <sstream>
 #include <string>
 
-#include "eckit/utils/MD5.h"
-
 #include "atlas/array/Array.h"
 #include "atlas/array/MakeView.h"
 #include "atlas/domain.h"
@@ -29,7 +27,6 @@
 #include "atlas/library/Library.h"
 #include "atlas/library/FloatingPointExceptions.h"
 #include "atlas/mesh/Mesh.h"
-#include "atlas/parallel/Checksum.h"
 #include "atlas/parallel/GatherScatter.h"
 #include "atlas/parallel/HaloExchange.h"
 #include "atlas/parallel/mpi/mpi.h"
@@ -74,29 +71,141 @@ array::LocalView<T, 3> make_leveled_view(Field& field) {
     }
 }
 
+struct ChecksumData {
+    Field local_lane_checksums;
+    Field global_lane_checksums;
+    int root{0};
+};
+
 template <typename T>
-std::string checksum_3d_field(const parallel::Checksum& checksum, const Field& field) {
-    bool disabled_fpe_overflow = library::disable_floating_point_exception(FE_OVERFLOW);
-    bool disabled_fpe_invalid  = library::disable_floating_point_exception(FE_INVALID);
-    auto values = make_leveled_view<const T>(field);
-    array::ArrayT<T> surface_field(values.shape(0), values.shape(2));
-    auto surface     = array::make_view<T, 2>(surface_field);
-    const idx_t npts = values.shape(0);
-    atlas_omp_for(idx_t n = 0; n < npts; ++n) {
-        for (idx_t j = 0; j < surface.shape(1); ++j) {
-            surface(n, j) = 0.;
-            for (idx_t l = 0; l < values.shape(1); ++l) {
-                surface(n, j) += values(n, l, j);
+void checksum_update_point(util::checksum_t& checksum, const array::Array& f, const T* data, idx_t dim, idx_t offset) {
+    if (dim == f.rank()) {
+        util::checksum_update(checksum, data + offset, size_t{1});
+        return;
+    }
+    for (idx_t index = 0; index < f.shape(dim); ++index) {
+        checksum_update_point(checksum, f, data, dim + 1, offset + index * f.stride(dim));
+    }
+}
+
+template <typename T>
+void update_lane_checksums_with_field_contiguous(const StructuredColumns& fs, const Field& f, const T* data,
+                                                 array::ArrayView<util::checksum_t, 1>& local_lane_checksums_view) {
+    const idx_t npts = fs.sizeOwned();
+
+    if (f.rank() == 3) {
+        const idx_t nlev = f.shape(1);
+        const idx_t nvar = f.shape(2);
+        atlas_omp_parallel_for(idx_t point = 0; point < npts; ++point) {
+            util::checksum_t lane_checksum = local_lane_checksums_view(point);
+            const T* point_data = data + point * f.stride(0);
+            for (idx_t jlev = 0; jlev < nlev; ++jlev) {
+                util::checksum_update(lane_checksum, point_data + jlev * f.stride(1), static_cast<size_t>(nvar));
             }
+            local_lane_checksums_view(point) = lane_checksum;
         }
     }
-    if (disabled_fpe_overflow) {
-        library::enable_floating_point_exception(FE_OVERFLOW);
+    else if (f.rank() == 2) {
+        const size_t lane_size = static_cast<size_t>(f.shape(1));
+        atlas_omp_parallel_for(idx_t point = 0; point < npts; ++point) {
+            util::checksum_update(local_lane_checksums_view(point), data + point * f.stride(0), lane_size);
+        }
     }
-    if (disabled_fpe_invalid) {
-        library::enable_floating_point_exception(FE_INVALID);
+    else if (f.rank() == 1) {
+        atlas_omp_parallel_for(idx_t point = 0; point < npts; ++point) {
+            util::checksum_update(local_lane_checksums_view(point), data + point, size_t{1});
+        }
     }
-    return checksum.execute(surface.data(), surface_field.stride(0));
+    else {
+        ATLAS_NOTIMPLEMENTED;
+    }
+}
+
+template <typename T>
+void update_lane_checksums_with_field(const StructuredColumns& fs, const Field& f, ChecksumData& checksum_data) {
+    auto local_lane_checksums_view = array::make_view<util::checksum_t, 1>(checksum_data.local_lane_checksums);
+    const auto* data = f.array().host_data<T>();
+    if (f.contiguous()) {
+        update_lane_checksums_with_field_contiguous(fs, f, data, local_lane_checksums_view);
+        return;
+    }
+
+    const idx_t npts = fs.sizeOwned();
+    atlas_omp_parallel_for(idx_t point = 0; point < npts; ++point) {
+        util::checksum_t lane_checksum = local_lane_checksums_view(point);
+        checksum_update_point(lane_checksum, f, data, idx_t{1}, point * f.stride(0));
+        local_lane_checksums_view(point) = lane_checksum;
+    }
+}
+
+void update_lane_checksums_with_field_dynamic(const StructuredColumns& fs, const Field& f, ChecksumData& checksum_data) {
+    switch (f.datatype().kind()) {
+        case array::DataType::kind<int>():
+            return update_lane_checksums_with_field<int>(fs, f, checksum_data);
+        case array::DataType::kind<long>():
+            return update_lane_checksums_with_field<long>(fs, f, checksum_data);
+        case array::DataType::kind<float>():
+            return update_lane_checksums_with_field<float>(fs, f, checksum_data);
+        case array::DataType::kind<double>():
+            return update_lane_checksums_with_field<double>(fs, f, checksum_data);
+        default:
+            throw_Exception("datatype not supported", Here());
+    }
+}
+
+ChecksumData get_checksum_data(const StructuredColumns& fs) {
+    pluto::scope scope;
+    pluto::host::set_default_resource(pluto::host_pool_resource());
+    ChecksumData checksum_data;
+    checksum_data.root = 0;
+    checksum_data.local_lane_checksums = fs.createField(option::name("checksum_local_lane_checksums") |
+                                                        option::datatypeT<util::checksum_t>() | option::levels(0));
+    checksum_data.global_lane_checksums =
+        fs.createField(checksum_data.local_lane_checksums, option::global(checksum_data.root));
+    auto local_lane_checksums_view = array::make_view<util::checksum_t, 1>(checksum_data.local_lane_checksums);
+    local_lane_checksums_view.assign(0);
+    return checksum_data;
+}
+
+util::checksum_t checksum_from_lane_states(const StructuredColumns& fs, ChecksumData& checksum_data) {
+    auto& local_lane_checksums = checksum_data.local_lane_checksums;
+    auto local_lane_checksums_view = array::make_view<util::checksum_t, 1>(local_lane_checksums);
+    for (idx_t point = 0; point < fs.sizeOwned(); ++point) {
+        local_lane_checksums_view(point) = util::checksum_digest(local_lane_checksums_view(point));
+    }
+
+    auto& mpi_comm = mpi::comm(fs.mpi_comm());
+    if (mpi_comm.size() == 1) {
+        ATLAS_ASSERT(local_lane_checksums.contiguous());
+        const auto* local_lane_checksums_data = local_lane_checksums.array().host_data<util::checksum_t>();
+        return util::checksum(local_lane_checksums_data, static_cast<size_t>(fs.sizeOwned()));
+    }
+
+    auto& global_lane_checksums = checksum_data.global_lane_checksums;
+    fs.gather(local_lane_checksums, global_lane_checksums);
+
+    util::checksum_t global_checksum = 0;
+    if (mpi_comm.rank() == checksum_data.root) {
+        ATLAS_ASSERT(global_lane_checksums.contiguous());
+        const auto* global_lane_checksums_data = global_lane_checksums.array().host_data<util::checksum_t>();
+        global_checksum = util::checksum(global_lane_checksums_data, global_lane_checksums.size());
+    }
+    mpi_comm.broadcast(global_checksum, checksum_data.root);
+    return global_checksum;
+}
+
+util::checksum_t field_checksum(const StructuredColumns& fs, const Field& field) {
+    auto checksum_data = get_checksum_data(fs);
+    update_lane_checksums_with_field_dynamic(fs, field, checksum_data);
+    return checksum_from_lane_states(fs, checksum_data);
+}
+
+util::checksum_t fieldset_checksum(const StructuredColumns& fs, const FieldSet& fieldset) {
+    auto checksum_data = get_checksum_data(fs);
+    for (idx_t f = 0; f < fieldset.size(); ++f) {
+        update_lane_checksums_with_field_dynamic(fs, fieldset[f], checksum_data);
+    }
+    return checksum_from_lane_states(fs, checksum_data);
 }
 
 } // namespace
@@ -203,54 +312,6 @@ private:
     ~StructuredColumnsGatherScatterCache() override = default;
 };
 
-class StructuredColumnsChecksumCache : public util::Cache<std::string, parallel::Checksum>,
-                                       public grid::detail::grid::GridObserver {
-private:
-    using Base = util::Cache<std::string, parallel::Checksum>;
-    StructuredColumnsChecksumCache(): Base("StructuredColumnsChecksumCache") {}
-
-public:
-    static StructuredColumnsChecksumCache& instance() {
-        static StructuredColumnsChecksumCache inst;
-        return inst;
-    }
-    util::ObjectHandle<value_type> get_or_create(const detail::StructuredColumns& funcspace) {
-        registerGrid(*funcspace.grid().get());
-        creator_type creator = std::bind(&StructuredColumnsChecksumCache::create, &funcspace);
-        return Base::get_or_create(key(funcspace), remove_key(funcspace), creator);
-    }
-    void onGridDestruction(grid::detail::grid::Grid& grid) override { remove(remove_key(grid)); }
-
-private:
-    static Base::key_type key(const detail::StructuredColumns& funcspace) {
-        std::ostringstream key;
-        key << "grid[address=" << funcspace.grid().get() << ",halo=" << funcspace.halo()
-            << ",periodic_points=" << std::boolalpha << funcspace.periodic_points_
-            << ",distribution=" << funcspace.distribution() << "]";
-        return key.str();
-    }
-
-    static Base::key_type remove_key(const detail::StructuredColumns& funcspace) {
-        return remove_key(*funcspace.grid().get());
-    }
-
-    static Base::key_type remove_key(const grid::detail::grid::Grid& grid) {
-        std::ostringstream key;
-        key << "grid[address=" << &grid << "]";
-        return key.str();
-    }
-
-    static value_type* create(const detail::StructuredColumns* funcspace) {
-        value_type* value = new value_type();
-        util::ObjectHandle<parallel::GatherScatter> gather(
-            StructuredColumnsGatherScatterCache::instance().get_or_create(*funcspace));
-        value->setup(gather);
-        return value;
-    }
-    ~StructuredColumnsChecksumCache() override = default;
-};
-
-
 const parallel::GatherScatter& StructuredColumns::gather() const {
     if (gather_scatter_) {
         return *gather_scatter_;
@@ -265,14 +326,6 @@ const parallel::GatherScatter& StructuredColumns::scatter() const {
     }
     gather_scatter_ = StructuredColumnsGatherScatterCache::instance().get_or_create(*this);
     return *gather_scatter_;
-}
-
-const parallel::Checksum& StructuredColumns::checksum() const {
-    if (checksum_) {
-        return *checksum_;
-    }
-    checksum_ = StructuredColumnsChecksumCache::instance().get_or_create(*this);
-    return *checksum_;
 }
 
 const parallel::HaloExchange& StructuredColumns::halo_exchange() const {
@@ -703,31 +756,10 @@ void StructuredColumns::scatter(const Field& global, Field& local) const {
 // ----------------------------------------------------------------------------
 
 std::string StructuredColumns::checksum(const FieldSet& fieldset) const {
-    eckit::MD5 md5;
-    for (idx_t f = 0; f < fieldset.size(); ++f) {
-        const Field& field = fieldset[f];
-        if (field.datatype() == array::DataType::kind<int>()) {
-            md5 << checksum_3d_field<int>(checksum(), field);
-        }
-        else if (field.datatype() == array::DataType::kind<long>()) {
-            md5 << checksum_3d_field<long>(checksum(), field);
-        }
-        else if (field.datatype() == array::DataType::kind<float>()) {
-            md5 << checksum_3d_field<float>(checksum(), field);
-        }
-        else if (field.datatype() == array::DataType::kind<double>()) {
-            md5 << checksum_3d_field<double>(checksum(), field);
-        }
-        else {
-            throw_Exception("datatype not supported", Here());
-        }
-    }
-    return md5;
+    return util::checksum_to_hex_str(fieldset_checksum(*this, fieldset));
 }
 std::string StructuredColumns::checksum(const Field& field) const {
-    FieldSet fieldset;
-    fieldset.add(field);
-    return checksum(fieldset);
+    return util::checksum_to_hex_str(field_checksum(*this, field));
 }
 
 const StructuredGrid& StructuredColumns::grid() const {

--- a/src/atlas/functionspace/detail/StructuredColumns.h
+++ b/src/atlas/functionspace/detail/StructuredColumns.h
@@ -33,7 +33,6 @@ namespace atlas {
 namespace parallel {
 class GatherScatter;
 class HaloExchange;
-class Checksum;
 }  // namespace parallel
 }  // namespace atlas
 
@@ -57,7 +56,6 @@ namespace detail {
 
 class StructuredColumnsHaloExchangeCache;
 class StructuredColumnsGatherScatterCache;
-class StructuredColumnsChecksumCache;
 
 
 // -------------------------------------------------------------------
@@ -195,7 +193,6 @@ private:  // methods
 
     const parallel::GatherScatter& gather() const override;
     const parallel::GatherScatter& scatter() const override;
-    const parallel::Checksum& checksum() const;
     const parallel::HaloExchange& halo_exchange() const;
 
     void create_remote_index() const;
@@ -212,12 +209,10 @@ private:  // data
 
     friend class StructuredColumnsHaloExchangeCache;
     friend class StructuredColumnsGatherScatterCache;
-    friend class StructuredColumnsChecksumCache;
     bool periodic_points_{false};
 
     const StructuredGrid* grid_;
     mutable util::ObjectHandle<parallel::GatherScatter> gather_scatter_;
-    mutable util::ObjectHandle<parallel::Checksum> checksum_;
     mutable util::ObjectHandle<parallel::HaloExchange> halo_exchange_;
     mutable std::vector<util::ObjectHandle<util::PartitionPolygon>> polygons_;
     mutable util::PartitionPolygons all_polygons_;

--- a/src/tests/functionspace/test_functionspace_splitcomm.cc
+++ b/src/tests/functionspace/test_functionspace_splitcomm.cc
@@ -45,21 +45,6 @@ Grid grid() {
 std::string expected_checksum() {
     static std::string result = [&]() {
         if (grid().name()=="O32") {
-            return "75e913d400755a0d2782fc65e2035e97";
-        }
-        else if (grid().name()=="N32") {
-            return "bcb344196d20becbb66f098d91f83abb";
-        }
-        else {
-            return "unknown";
-        }
-    }();
-    return result;
-}
-
-std::string expected_checksum_blocked() {
-    static std::string result = [&]() {
-        if (grid().name()=="O32") {
             return "6408";
         }
         else if (grid().name()=="N32") {
@@ -70,6 +55,18 @@ std::string expected_checksum_blocked() {
         }
     }();
     return result;
+}
+
+ std::string expected_checksum_nodes() {
+    if (grid().name()=="O32") {
+        return "75e913d400755a0d2782fc65e2035e97";
+    }
+    else if (grid().name()=="N32") {
+        return "bcb344196d20becbb66f098d91f83abb";
+    }
+    else {
+        return "unknown";
+    }
 }
 struct Fixture {
     Fixture() {
@@ -132,7 +129,7 @@ CASE("test FunctionSpace NodeColumns") {
 
     // Checksum
     auto checksum = fs.checksum(field);
-    EXPECT_EQ(checksum, expected_checksum());
+    EXPECT_EQ(checksum, expected_checksum_nodes());
 
     Log::error() << "fs.part() = " << fs.part() << " fs.nb_parts() = " << fs.nb_parts() << " grid = " << fs.grid().name() << " checksum = " << checksum << std::endl;
 
@@ -202,7 +199,7 @@ CASE("test FunctionSpace BlockStructuredColumns") {
 
     // Checksum
     auto checksum = fs.checksum(field);
-    EXPECT_EQ(checksum, expected_checksum_blocked());
+    EXPECT_EQ(checksum, expected_checksum());
 
     Log::error() << "fs.part() = " << fs.part() << " fs.nb_parts() = " << fs.nb_parts() << " grid = " << fs.grid().name() << " checksum = " << checksum << std::endl;
 }

--- a/src/tests/functionspace/test_structuredcolumns.cc
+++ b/src/tests/functionspace/test_structuredcolumns.cc
@@ -13,6 +13,8 @@
 
 #include "atlas/array/ArrayView.h"
 #include "atlas/array/MakeView.h"
+#include "atlas/field/FieldSet.h"
+#include "atlas/functionspace/BlockStructuredColumns.h"
 #include "atlas/field/Field.h"
 #include "atlas/functionspace/NodeColumns.h"
 #include "atlas/functionspace/StructuredColumns.h"
@@ -33,6 +35,42 @@ using namespace atlas::util;
 
 namespace atlas {
 namespace test {
+
+namespace {
+
+template <typename Value>
+void fill_structured_field(Field& field, Value first_value = Value{1}) {
+    Value next_value = first_value;
+    if (field.variables() && field.levels()) {
+        auto value = array::make_view<Value, 3>(field);
+        for (idx_t point = 0; point < field.shape(0); ++point) {
+            for (idx_t jlev = 0; jlev < field.shape(1); ++jlev) {
+                for (idx_t jvar = 0; jvar < field.shape(2); ++jvar) {
+                    value(point, jlev, jvar) = next_value;
+                    next_value += Value{1};
+                }
+            }
+        }
+    }
+    else if (field.variables() || field.levels()) {
+        auto value = array::make_view<Value, 2>(field);
+        for (idx_t point = 0; point < field.shape(0); ++point) {
+            for (idx_t entry = 0; entry < field.shape(1); ++entry) {
+                value(point, entry) = next_value;
+                next_value += Value{1};
+            }
+        }
+    }
+    else {
+        auto value = array::make_view<Value, 1>(field);
+        for (idx_t point = 0; point < field.shape(0); ++point) {
+            value(point) = next_value;
+            next_value += Value{1};
+        }
+    }
+}
+
+}  // namespace
 
 //-----------------------------------------------------------------------------
 
@@ -271,6 +309,268 @@ CASE("test_functionspace_StructuredColumns_halo with output") {
              "plt.show()"
              "\n";
     }
+}
+
+CASE("StructuredColumns checksum matches BlockStructuredColumns for identical data") {
+    using Value = double;
+    mpi::Scope scope("self");
+
+    auto grid = StructuredGrid("O8");
+    auto structured_fs = [&] {
+        util::Config config;
+        config.set("halo", 0);
+        return functionspace::StructuredColumns(grid, config);
+    }();
+    auto block_fs = [&] {
+        util::Config config;
+        config.set("halo", 0);
+        config.set("nproma", 5);
+        return functionspace::BlockStructuredColumns(grid, config);
+    }();
+
+    auto check_field_checksum_stable_with_blocked = [&](const util::Config& options, Value first_value) {
+        Field structured = structured_fs.createField<Value>(option::name("structured") | options);
+        Field blocked = block_fs.createField<Value>(option::name("blocked") | options);
+        fill_structured_field(structured, first_value);
+        block_fs.scatter(structured, blocked);
+        EXPECT_EQ(structured_fs.checksum(structured), block_fs.checksum(blocked));
+    };
+
+    check_field_checksum_stable_with_blocked(option::variables(3) | option::levels(4), Value{1});
+    check_field_checksum_stable_with_blocked(option::variables(3), Value{1000});
+    check_field_checksum_stable_with_blocked(option::levels(4), Value{2000});
+    check_field_checksum_stable_with_blocked(util::Config{}, Value{3000});
+
+    auto check_fieldset_checksum_stable_with_blocked = [&](const util::Config& options_a, const util::Config& options_b) {
+        FieldSet structured_fieldset;
+        FieldSet blocked_fieldset;
+        Field structured_a = structured_fs.createField<Value>(option::name("structured_a") | options_a);
+        Field structured_b = structured_fs.createField<Value>(option::name("structured_b") | options_b);
+        Field blocked_a = block_fs.createField<Value>(option::name("blocked_a") | options_a);
+        Field blocked_b = block_fs.createField<Value>(option::name("blocked_b") | options_b);
+
+        fill_structured_field(structured_a, Value{4000});
+        fill_structured_field(structured_b, Value{5000});
+        block_fs.scatter(structured_a, blocked_a);
+        block_fs.scatter(structured_b, blocked_b);
+
+        structured_fieldset.add(structured_a);
+        structured_fieldset.add(structured_b);
+        blocked_fieldset.add(blocked_a);
+        blocked_fieldset.add(blocked_b);
+
+        EXPECT_EQ(structured_fs.checksum(structured_fieldset), block_fs.checksum(blocked_fieldset));
+    };
+    check_fieldset_checksum_stable_with_blocked(/*a*/ option::variables(2) | option::levels(3), /*b*/ option::variables(4));
+}
+
+CASE("StructuredColumns checksum matches BlockStructuredColumns in MPI for identical scattered data") {
+    using Value = double;
+
+    constexpr int root = 0;
+    auto grid = StructuredGrid("O8");
+    auto structured_fs = [&] {
+        util::Config config;
+        config.set("halo", 0);
+        return functionspace::StructuredColumns(grid, config);
+    }();
+    auto block_fs = [&] {
+        util::Config config;
+        config.set("halo", 0);
+        config.set("nproma", 5);
+        return functionspace::BlockStructuredColumns(grid, config);
+    }();
+
+    auto run_case = [&](const util::Config& options, Value first_value) {
+        Field global = structured_fs.createField<Value>(option::name("global") | option::global(root) | options);
+        Field structured = structured_fs.createField<Value>(option::name("structured") | options);
+        Field blocked = block_fs.createField<Value>(option::name("blocked") | options);
+        if (mpi::comm().rank() == root) {
+            fill_structured_field(global, first_value);
+        }
+        structured_fs.scatter(global, structured);
+        block_fs.scatter(global, blocked);
+        EXPECT_EQ(structured_fs.checksum(structured), block_fs.checksum(blocked));
+    };
+
+    run_case(option::variables(3) | option::levels(4), Value{1});
+    run_case(option::variables(3), Value{1000});
+    run_case(option::levels(4), Value{2000});
+    run_case(util::Config{}, Value{3000});
+
+    Field global_a = structured_fs.createField<Value>(option::name("global_a") | option::global(root) |
+                                                      option::variables(2) | option::levels(3));
+    Field global_b = structured_fs.createField<Value>(option::name("global_b") | option::global(root) |
+                                                      option::variables(4));
+    Field structured_a = structured_fs.createField<Value>(option::name("structured_a") | option::variables(2) |
+                                                          option::levels(3));
+    Field structured_b = structured_fs.createField<Value>(option::name("structured_b") | option::variables(4));
+    Field blocked_a = block_fs.createField<Value>(option::name("blocked_a") | option::variables(2) | option::levels(3));
+    Field blocked_b = block_fs.createField<Value>(option::name("blocked_b") | option::variables(4));
+
+    if (mpi::comm().rank() == root) {
+        fill_structured_field(global_a, Value{4000});
+        fill_structured_field(global_b, Value{5000});
+    }
+
+    structured_fs.scatter(global_a, structured_a);
+    structured_fs.scatter(global_b, structured_b);
+    block_fs.scatter(global_a, blocked_a);
+    block_fs.scatter(global_b, blocked_b);
+
+    FieldSet structured_fieldset;
+    FieldSet blocked_fieldset;
+    structured_fieldset.add(structured_a);
+    structured_fieldset.add(structured_b);
+    blocked_fieldset.add(blocked_a);
+    blocked_fieldset.add(blocked_b);
+
+    EXPECT_EQ(structured_fs.checksum(structured_fieldset), block_fs.checksum(blocked_fieldset));
+}
+
+CASE("StructuredColumns and BlockStructuredColumns checksums are stable with halo=2") {
+    using Value = double;
+    mpi::Scope scope("self");
+
+    auto grid = StructuredGrid("O8");
+    auto structured_fs = [&] {
+        util::Config config;
+        config.set("halo", 2);
+        return functionspace::StructuredColumns(grid, config);
+    }();
+    auto block_fs = [&] {
+        util::Config config;
+        config.set("halo", 2);
+        config.set("nproma", 5);
+        return functionspace::BlockStructuredColumns(grid, config);
+    }();
+    util::Config options = option::variables(3) | option::levels(4);
+    Field structured = structured_fs.createField<Value>(option::name("structured") | options);
+    fill_structured_field(structured, Value{6000});
+    FieldSet structured_fieldset;
+    structured_fieldset.add(structured);
+    EXPECT_EQ(structured_fs.checksum(structured), structured_fs.checksum(structured_fieldset));
+    EXPECT_EQ(structured_fs.checksum(structured), structured_fs.checksum(structured));
+
+    Field blocked = block_fs.createField<Value>(option::name("blocked") | options);
+    block_fs.scatter(structured, blocked);
+    FieldSet blocked_fieldset;
+    blocked_fieldset.add(blocked);
+    EXPECT_EQ(block_fs.checksum(blocked), block_fs.checksum(blocked_fieldset));
+    EXPECT_EQ(block_fs.checksum(blocked), block_fs.checksum(blocked));
+}
+
+CASE("StructuredColumns checksum with halo=2 matches halo=0 exactly (mpi-serial)") {
+    using Value = double;
+    mpi::Scope scope("self");
+
+    auto grid = StructuredGrid("O8");
+    auto fs_h0 = [&] {
+        util::Config config;
+        config.set("halo", 0);
+        return functionspace::StructuredColumns(grid, config);
+    }();
+    auto fs_h2 = [&] {
+        util::Config config;
+        config.set("halo", 2);
+        return functionspace::StructuredColumns(grid, config);
+    }();
+
+    auto check_field_checksum_stable_with_halo = [&](const util::Config& options, Value first_value) {
+        Field field_h0 = fs_h0.createField<Value>(option::name("field_h0") | options);
+        Field field_h2 = fs_h2.createField<Value>(option::name("field_h2") | options);
+        fill_structured_field(field_h0, first_value);
+        fill_structured_field(field_h2, first_value);
+        EXPECT_EQ(fs_h0.checksum(field_h0), fs_h2.checksum(field_h2));
+    };
+
+    check_field_checksum_stable_with_halo(option::variables(3) | option::levels(4), Value{12000});
+    check_field_checksum_stable_with_halo(option::variables(3), Value{13000});
+    check_field_checksum_stable_with_halo(option::levels(4), Value{14000});
+    check_field_checksum_stable_with_halo(util::Config{}, Value{15000});
+
+    auto check_fieldset_checksum_stable_with_halo = [&](const util::Config& options_a, const util::Config& options_b) {
+        Field field_h0_a = fs_h0.createField<Value>(option::name("field_h0_a") | options_a);
+        Field field_h0_b = fs_h0.createField<Value>(option::name("field_h0_b") | options_b);
+        Field field_h2_a = fs_h2.createField<Value>(option::name("field_h2_a") | options_a);
+        Field field_h2_b = fs_h2.createField<Value>(option::name("field_h2_b") | options_b);
+
+        fill_structured_field(field_h0_a, Value{16000});
+        fill_structured_field(field_h0_b, Value{17000});
+        fill_structured_field(field_h2_a, Value{16000});
+        fill_structured_field(field_h2_b, Value{17000});
+
+        FieldSet fieldset_h0;
+        FieldSet fieldset_h2;
+        fieldset_h0.add(field_h0_a);
+        fieldset_h0.add(field_h0_b);
+        fieldset_h2.add(field_h2_a);
+        fieldset_h2.add(field_h2_b);
+
+        EXPECT_EQ(fs_h0.checksum(fieldset_h0), fs_h2.checksum(fieldset_h2));
+    };
+
+    check_fieldset_checksum_stable_with_halo(/*a*/ option::variables(2) | option::levels(3), /*b*/ option::variables(4));
+
+}
+
+CASE("StructuredColumns checksum with halo=2 matches halo=0 exactly (MPI)") {
+    using Value = double;
+
+    constexpr int root = 0;
+    auto grid = StructuredGrid("O8");
+    auto fs_h0 = [&] {
+        return functionspace::StructuredColumns(grid, option::halo(0));
+    }();
+    auto fs_h2 = [&] {
+        return functionspace::StructuredColumns(grid, option::halo(2));
+    }();
+
+    auto check_field_checksum_stable_with_halo = [&](const util::Config& options, Value first_value) {
+        Field global = fs_h0.createField<Value>(option::name("global") | option::global(root) | options);
+        Field local_h0 = fs_h0.createField<Value>(option::name("local_h0") | options);
+        Field local_h2 = fs_h2.createField<Value>(option::name("local_h2") | options);
+        if (mpi::comm().rank() == root) {
+            fill_structured_field(global, first_value);
+        }
+        fs_h0.scatter(global, local_h0);
+        fs_h2.scatter(global, local_h2);
+        EXPECT_EQ(fs_h0.checksum(local_h0), fs_h2.checksum(local_h2));
+    };
+
+    check_field_checksum_stable_with_halo(option::variables(3) | option::levels(4), Value{18000});
+    check_field_checksum_stable_with_halo(option::variables(3), Value{19000});
+    check_field_checksum_stable_with_halo(option::levels(4), Value{20000});
+    check_field_checksum_stable_with_halo(util::Config{}, Value{21000});
+
+    auto check_fieldset_checksum_stable_with_halo = [&](const util::Config& options_a, const util::Config& options_b) {
+        Field global_a = fs_h0.createField<Value>(option::name("global_a") | option::global(root) | options_a);
+        Field global_b = fs_h0.createField<Value>(option::name("global_b") | option::global(root) | options_b);
+        Field local_h0_a = fs_h0.createField<Value>(option::name("local_h0_a") | options_a);
+        Field local_h0_b = fs_h0.createField<Value>(option::name("local_h0_b") | options_b);
+        Field local_h2_a = fs_h2.createField<Value>(option::name("local_h2_a") | options_a);
+        Field local_h2_b = fs_h2.createField<Value>(option::name("local_h2_b") | options_b);
+
+        if (mpi::comm().rank() == root) {
+            fill_structured_field(global_a, Value{22000});
+            fill_structured_field(global_b, Value{23000});
+        }
+
+        fs_h0.scatter(global_a, local_h0_a);
+        fs_h0.scatter(global_b, local_h0_b);
+        fs_h2.scatter(global_a, local_h2_a);
+        fs_h2.scatter(global_b, local_h2_b);
+
+        FieldSet fieldset_h0;
+        FieldSet fieldset_h2;
+        fieldset_h0.add(local_h0_a);
+        fieldset_h0.add(local_h0_b);
+        fieldset_h2.add(local_h2_a);
+        fieldset_h2.add(local_h2_b);
+
+        EXPECT_EQ(fs_h0.checksum(fieldset_h0), fs_h2.checksum(fieldset_h2));
+    };
+    check_fieldset_checksum_stable_with_halo(/*a*/ option::variables(2) | option::levels(3), /*b*/ option::variables(4));
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This pull request refactors and modernizes the checksum calculation logic for `StructuredColumns` in Atlas, removing the old `parallel::Checksum`-based implementation and replacing it with a new, more flexible, and efficient approach. The changes also update tests and clean up related code and dependencies.

**Major highlights:**
- Removes the `parallel::Checksum` class and its associated caching infrastructure from `StructuredColumns`.
- Introduces a new, internal checksum calculation mechanism that operates directly on fields and fieldsets.
- Updates the test suite to match the new checksum outputs and refactors test helpers for clarity.

**Key changes:**

### Checksum calculation refactor

* Replaces the old `parallel::Checksum`-based checksum infrastructure in `StructuredColumns` with a new, internal implementation that computes checksums directly from data. This includes new helper structures and functions such as `ChecksumData`, `update_lane_checksums_with_field_dynamic`, and `field_checksum`. The new approach supports various data types and improves handling of field memory layout. (`src/atlas/functionspace/detail/StructuredColumns.cc` [src/atlas/functionspace/detail/StructuredColumns.ccR74-R208](diffhunk://#diff-0c3b56e9aa8289ad9ac525c7088617b7e7eef898785bbb3c3477a01ce5c9e7e8R74-R208))

* Removes the `StructuredColumnsChecksumCache` class and all related code, simplifying the class structure and eliminating the need for a checksum cache. (`src/atlas/functionspace/detail/StructuredColumns.cc` [[1]](diffhunk://#diff-0c3b56e9aa8289ad9ac525c7088617b7e7eef898785bbb3c3477a01ce5c9e7e8L206-L253) `src/atlas/functionspace/detail/StructuredColumns.h` [[2]](diffhunk://#diff-b26dddc2a7b7d2cfa72f101342b83ef5baec8462995529251551921d92737ae8L60) [[3]](diffhunk://#diff-b26dddc2a7b7d2cfa72f101342b83ef5baec8462995529251551921d92737ae8L215-L220)

* Deletes the `checksum()` member function from `StructuredColumns` that returned a `parallel::Checksum` reference, as it is no longer needed. (`src/atlas/functionspace/detail/StructuredColumns.cc` [[1]](diffhunk://#diff-0c3b56e9aa8289ad9ac525c7088617b7e7eef898785bbb3c3477a01ce5c9e7e8L270-L277) `src/atlas/functionspace/detail/StructuredColumns.h` [[2]](diffhunk://#diff-b26dddc2a7b7d2cfa72f101342b83ef5baec8462995529251551921d92737ae8L198)

### API and dependency cleanup

* Removes all includes and references to `parallel/Checksum.h` and `eckit/utils/MD5.h`, as well as the `parallel::Checksum` forward declaration. (`src/atlas/functionspace/detail/StructuredColumns.cc` [[1]](diffhunk://#diff-0c3b56e9aa8289ad9ac525c7088617b7e7eef898785bbb3c3477a01ce5c9e7e8L19-L20) [[2]](diffhunk://#diff-0c3b56e9aa8289ad9ac525c7088617b7e7eef898785bbb3c3477a01ce5c9e7e8L32); `src/atlas/functionspace/detail/StructuredColumns.h` [[3]](diffhunk://#diff-b26dddc2a7b7d2cfa72f101342b83ef5baec8462995529251551921d92737ae8L36)

### Test updates

* Updates checksum expectations in tests to match the new checksum logic and output format (now a short hex string instead of an MD5 hash). Refactors the helpers and test cases to distinguish between node-based and block-based checksums. (`src/tests/functionspace/test_functionspace_splitcomm.cc` [[1]](diffhunk://#diff-fd043bb805e82e8933fd8535f7cdc59dbab12961a9baba508ac1d9420fc86ec4L48-R51) [[2]](diffhunk://#diff-fd043bb805e82e8933fd8535f7cdc59dbab12961a9baba508ac1d9420fc86ec4L60-L72) [[3]](diffhunk://#diff-fd043bb805e82e8933fd8535f7cdc59dbab12961a9baba508ac1d9420fc86ec4L135-R132) [[4]](diffhunk://#diff-fd043bb805e82e8933fd8535f7cdc59dbab12961a9baba508ac1d9420fc86ec4L205-R202)

* Adds a utility function to fill structured fields with sequential values for more robust and flexible test setup. (`src/tests/functionspace/test_structuredcolumns.cc` [src/tests/functionspace/test_structuredcolumns.ccR39-R74](diffhunk://#diff-5cf820a38ccb374fc3c75318ebad27cc8c16d21ff2feef4dd27e36b9bf5ae86aR39-R74))

---

These changes collectively modernize the checksum infrastructure, improve code maintainability, and ensure that tests accurately reflect the new logic.

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-384
<!-- STATIC-ANALYSIS_END -->