### PR TITLE
Add ATLAS_DEBUG_SYNC macros with a timeout to catch deadlocks

### DIFF
--- a/src/atlas/runtime/Log.cc
+++ b/src/atlas/runtime/Log.cc
@@ -11,9 +11,18 @@
 #include "eckit/os/BackTrace.h"
 #include "eckit/config/Resource.h"
 
+#include <chrono>
+#include <thread>
+#include <unistd.h>
+#include "eckit/io/FDataSync.h"
+
+#include "eckit/config/Resource.h"
+
 #include "atlas/library/Library.h"
 #include "atlas/parallel/mpi/mpi.h"
 #include "atlas/runtime/Log.h"
+#include "atlas/runtime/trace/StopWatch.h"
+#include "atlas/runtime/Exception.h"
 
 
 
@@ -297,16 +306,200 @@ std::string backtrace() {
 
 namespace detail {
 
-void debug_parallel_here(const eckit::CodeLocation& here) {
-    const auto& comm = mpi::comm();
-    comm.barrier();
-    Log::info() << "DEBUG_PARALLEL() @ " << here << std::endl;
+namespace {
+
+double ATLAS_MPI_BARRIER_TIMEOUT() {
+    static double timeout = eckit::Resource<double>("$ATLAS_MPI_BARRIER_TIMEOUT", 3.);
+    return timeout;
 }
 
-void debug_parallel_what(const eckit::CodeLocation& here, const std::string& what) {
-    const auto& comm = mpi::comm();
-    comm.barrier();
-    Log::info() << "DEBUG_PARALLEL(" << what << ") @ " << here << std::endl;
+enum class BarrierTimeoutAction
+{
+    ABORT,
+    THROW,
+    CONTINUE
+};
+
+std::string_view to_string_view(BarrierTimeoutAction action) {
+    switch (action) {
+        case BarrierTimeoutAction::ABORT: return "ABORT";
+        case BarrierTimeoutAction::THROW: return "THROW";
+        case BarrierTimeoutAction::CONTINUE: return "CONTINUE";
+    }
+    return "UNKNOWN";
+}
+
+BarrierTimeoutAction to_BarrierTimeoutAction(const std::string& str) {
+    if (str == "ABORT") return BarrierTimeoutAction::ABORT;
+    if (str == "THROW") return BarrierTimeoutAction::THROW;
+    if (str == "CONTINUE") return BarrierTimeoutAction::CONTINUE;
+    ATLAS_THROW_EXCEPTION("Invalid value for ATLAS_MPI_BARRIER_TIMEOUT_ACTION: " << str << "."
+                          << "Valid options are: ABORT, THROW, CONTINUE.");
+}
+
+BarrierTimeoutAction ATLAS_MPI_BARRIER_TIMEOUT_ACTION() {
+    static BarrierTimeoutAction action = to_BarrierTimeoutAction(eckit::Resource<std::string>("$ATLAS_MPI_BARRIER_TIMEOUT_ACTION", "THROW"));
+    return action;
+}
+
+bool mpi_barrier_timeout(const mpi::Comm& comm, double seconds) {
+    if (seconds <= 0.) {
+        return false;
+    }
+    auto req = comm.iBarrier();
+    const auto test_interval = std::chrono::milliseconds(10);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::duration<double>(seconds);
+    while (not req.test()) {
+        std::this_thread::sleep_for(test_interval);
+        if (std::chrono::steady_clock::now() > deadline) {
+            return not req.test();
+        }
+    }
+    return false;
+}
+
+std::vector<int> get_mpi_ranks_that_timed_out(const mpi::Comm& comm) {
+    int local_timed_out = 0;
+    const int size = comm.size();
+    const int rank = comm.rank();
+    const int tag  = 0;
+
+    std::vector<int> all_timed_out(size);
+    all_timed_out[rank] = local_timed_out;
+
+    std::vector<int> peers;
+    peers.reserve(size > 0 ? size - 1 : 0);
+    std::vector<eckit::mpi::Request> recv_requests;
+    std::vector<eckit::mpi::Request> send_requests;
+    recv_requests.reserve(size > 0 ? size - 1 : 0);
+    send_requests.reserve(size > 0 ? size - 1 : 0);
+
+    for (int peer = 0; peer < size; ++peer) {
+        if (peer == rank) {
+            continue;
+        }
+        peers.push_back(peer);
+        recv_requests.push_back(comm.iReceive(all_timed_out[peer], peer, tag));
+    }
+
+    for (int peer : peers) {
+        send_requests.push_back(comm.iSend(local_timed_out, peer, tag));
+    }
+
+    std::vector<bool> recv_completed(recv_requests.size(), false);
+    std::vector<bool> send_completed(send_requests.size(), false);
+    size_t recv_pending = recv_requests.size();
+    size_t send_pending = send_requests.size();
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+    while (recv_pending > 0 || send_pending > 0) {
+        for (size_t i = 0; i < recv_requests.size(); ++i) {
+            if (not recv_completed[i] && recv_requests[i].test()) {
+                recv_completed[i] = true;
+                --recv_pending;
+            }
+        }
+        for (size_t i = 0; i < send_requests.size(); ++i) {
+            if (not send_completed[i] && send_requests[i].test()) {
+                send_completed[i] = true;
+                --send_pending;
+            }
+        }
+
+        if (recv_pending == 0 && send_pending == 0) {
+            break;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        if (std::chrono::steady_clock::now() > deadline) {
+            for (size_t i = 0; i < recv_requests.size(); ++i) {
+                if (not recv_completed[i]) {
+                    all_timed_out[peers[i]] = 1;
+                }
+            }
+            break;
+        }
+    }
+
+    std::vector<int> timed_out_ranks;
+    for (int i = 0; i < all_timed_out.size(); ++i) {
+        if (all_timed_out[i]) {
+            timed_out_ranks.push_back(i);
+        }
+    }
+    return timed_out_ranks;
+}
+
+void debug_mpi_barrier(const eckit::CodeLocation& here, const mpi::Comm& comm,
+                                     std::string_view what = {}) {
+    if (mpi_barrier_timeout(comm, ATLAS_MPI_BARRIER_TIMEOUT())) {
+        std::ostringstream out;
+        out << "DEBUG_SYNC[" << comm.name() << "]";
+        if (not what.empty()) {
+            out << "(" << what << ")";
+        }
+        out << " @ " << here << "\n";
+        out << "ATLAS_DEBUG_SYNC MPI barrier timed out on ranks " << get_mpi_ranks_that_timed_out(comm)
+            << " in communicator '" << comm.name() << "' (${ATLAS_MPI_BARRIER_TIMEOUT}=" << ATLAS_MPI_BARRIER_TIMEOUT()
+            << ", ${ATLAS_MPI_BARRIER_TIMEOUT_ACTION}=" << to_string_view(ATLAS_MPI_BARRIER_TIMEOUT_ACTION()) << ").\n"
+            << "-----------------------------------------\n"
+            << "BACKTRACE [rank=" << comm.rank() << "]\n"
+            << "-----------------------------------------\n"
+            << backtrace() << "\n"
+            << "-----------------------------------------";
+        switch (ATLAS_MPI_BARRIER_TIMEOUT_ACTION()) {
+            case BarrierTimeoutAction::ABORT:
+                Log::error() << out.str() << " Calling MPI_Abort..." << std::endl;
+                comm.abort();
+                break;
+            case BarrierTimeoutAction::THROW:
+                ATLAS_THROW_EXCEPTION("ATLAS_MPI_BARRIER_TIMEOUT: \n" << out.str());
+                break;
+            case BarrierTimeoutAction::CONTINUE:
+                Log::warning() << out.str() << " Continuing execution despite barrier timeout..." << std::endl;
+                break;
+        }
+    }
+}
+
+void flush_and_sync_output_streams() {
+    for( auto& channel : {
+        &Log::info(),
+        &Log::warning(),
+        &Log::trace(),
+        &Log::debug(),
+        &Log::error()} ) {
+        if (channel) {
+            channel->flush();
+        }
+    }
+    std::cout.flush();
+    std::cerr.flush();
+
+    eckit::fdatasync(STDOUT_FILENO);
+    eckit::fdatasync(STDERR_FILENO);
+}
+
+}  // namespace
+
+void debug_sync(const eckit::CodeLocation& here, const mpi::Comm& comm) {
+    flush_and_sync_output_streams();
+    debug_mpi_barrier(here, comm);
+    Log::info() << "DEBUG_SYNC["<<comm.name()<<"] @ " << here << std::endl;
+}
+
+void debug_sync(const eckit::CodeLocation& here) {
+    debug_sync(here, mpi::comm());
+}
+
+void debug_sync(const eckit::CodeLocation& here, const mpi::Comm& comm, std::string_view what) {
+    flush_and_sync_output_streams();
+    debug_mpi_barrier(here, comm, what);
+    Log::info() << "DEBUG_SYNC["<<comm.name()<<"](" << what << ") @ " << here << std::endl;
+}
+
+void debug_sync(const eckit::CodeLocation& here, std::string_view what) {
+    debug_sync(here, mpi::comm(), what);
 }
 
 }  // namespace detail

--- a/src/atlas/runtime/Log.cc
+++ b/src/atlas/runtime/Log.cc
@@ -19,6 +19,7 @@
 
 // for MacOS backtrace
 #ifdef __APPLE__
+#include <algorithm>
 #include <execinfo.h>
 #include <dlfcn.h>
 #include <cstdlib>
@@ -257,11 +258,15 @@ std::string macos_backtrace() {
         }
     }
 
+    int nb_emitted_frames = std::count(emit_frame.begin(), emit_frame.end(), true);
     std::stringstream out;
     for (int i = 0, f = 0; f < frames; ++f) {
         if (emit_frame[f]) {
             std::string frame_index_str = "#" + std::to_string(i++);
-            out << std::left << std::setw(6) << frame_index_str << formatted_frames[f] << '\n';
+            out << std::left << std::setw(6) << frame_index_str << formatted_frames[f];
+            if (i < nb_emitted_frames) {
+                out << '\n';
+            }
         }
     }
     return out.str();

--- a/src/atlas/runtime/Log.h
+++ b/src/atlas/runtime/Log.h
@@ -34,14 +34,23 @@ std::string backtrace();
 
 }  // namespace atlas
 
+namespace eckit {
+namespace mpi {
+class Comm;
+}  // namespace mpi
+}  // namespace eckit
+
 #include <sstream>
+#include <string_view>
 #include "atlas/library/detail/BlackMagic.h"
 #include "eckit/log/CodeLocation.h"
 
 namespace atlas {
 namespace detail {
-void debug_parallel_here(const eckit::CodeLocation&);
-void debug_parallel_what(const eckit::CodeLocation&, const std::string&);
+void debug_sync(const eckit::CodeLocation&, const eckit::mpi::Comm&);
+void debug_sync(const eckit::CodeLocation&);
+void debug_sync(const eckit::CodeLocation&, const eckit::mpi::Comm&, std::string_view);
+void debug_sync(const eckit::CodeLocation&, std::string_view);
 }  // namespace detail
 }  // namespace atlas
 
@@ -67,19 +76,39 @@ void debug_parallel_what(const eckit::CodeLocation&, const std::string&);
         ::atlas::Log::info() << "DEBUG() @ " << Here() << "Backtrace:\n" << ::atlas::backtrace() << std::endl; \
     } while (0)
 
-#define ATLAS_DEBUG_PARALLEL_HERE()                   \
-    do {                                              \
-        ::atlas::detail::debug_parallel_here(Here()); \
+#define ATLAS_DEBUG_SYNC_HERE()                \
+    do {                                           \
+        ::atlas::detail::debug_sync(Here());   \
     } while (0)
-#define ATLAS_DEBUG_PARALLEL_WHAT(WHAT)                        \
-    do {                                                       \
-        std::stringstream w;                                   \
-        w << WHAT;                                             \
-        ::atlas::detail::debug_parallel_what(Here(), w.str()); \
+#define ATLAS_DEBUG_SYNC_HERE_1(ARG1)              \
+    do {                                           \
+        ::atlas::detail::debug_sync(Here(), ARG1); \
+    } while (0)
+#define ATLAS_DEBUG_SYNC_HERE_2(ARG1, ARG2)              \
+    do {                                                \
+        ::atlas::detail::debug_sync(Here(), ARG1, ARG2); \
     } while (0)
 
-#define ATLAS_DEBUG_PARALLEL(...)                                      \
-    __ATLAS_SPLICE(__ATLAS_DEBUG_PARALLEL_, __ATLAS_NARG(__VA_ARGS__)) \
+#define ATLAS_DEBUG_SYNC(...)                                      \
+    __ATLAS_SPLICE(__ATLAS_DEBUG_SYNC_, __ATLAS_NARG(__VA_ARGS__)) \
     (__VA_ARGS__)
-#define __ATLAS_DEBUG_PARALLEL_0 ATLAS_DEBUG_PARALLEL_HERE
-#define __ATLAS_DEBUG_PARALLEL_1 ATLAS_DEBUG_PARALLEL_WHAT
+#define __ATLAS_DEBUG_SYNC_0 ATLAS_DEBUG_SYNC_HERE
+#define __ATLAS_DEBUG_SYNC_1 ATLAS_DEBUG_SYNC_HERE_1
+#define __ATLAS_DEBUG_SYNC_2 ATLAS_DEBUG_SYNC_HERE_2
+
+#define __ATLAS_DEBUG_SYNC_VAR_1(VAR)                                                                 \
+    do {                                                                                              \
+        std::ostringstream oss_debug_var;                                                             \
+        oss_debug_var << #VAR << " : " << VAR;                                                        \
+        ::atlas::detail::debug_sync(Here(), oss_debug_var.str());                                     \
+    } while (0)
+#define __ATLAS_DEBUG_SYNC_VAR_2(COMM, VAR)                                                          \
+    do {                                                                                              \
+        std::ostringstream oss_debug_var;                                                             \
+        oss_debug_var << #VAR << " : " << VAR;                                                        \
+        ::atlas::detail::debug_sync(Here(), COMM, oss_debug_var.str());                               \
+    } while (0)
+
+#define ATLAS_DEBUG_SYNC_VAR(...)                                        \
+    __ATLAS_SPLICE(__ATLAS_DEBUG_SYNC_VAR_, __ATLAS_NARG(__VA_ARGS__)) \
+    (__VA_ARGS__)

--- a/src/tests/runtime/CMakeLists.txt
+++ b/src/tests/runtime/CMakeLists.txt
@@ -16,14 +16,14 @@ ecbuild_add_test( TARGET atlas_test_trace
 ecbuild_add_test( TARGET atlas_test_debug_logging
   SOURCES     test_debug_logging.cc
   LIBS        atlas
-  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} ATLAS_MPI_BARRIER_TIMEOUT=0.5
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} ATLAS_MPI_BARRIER_TIMEOUT=3
 )
 
 ecbuild_add_test( TARGET atlas_test_debug_logging_mpi
   COMMAND     atlas_test_debug_logging
   MPI        3
   CONDITION  eckit_HAVE_MPI AND MPI_SLOTS GREATER_EQUAL 3
-  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} ATLAS_MPI_BARRIER_TIMEOUT=0.5
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} ATLAS_MPI_BARRIER_TIMEOUT=3
 )
 
 foreach( test test_library test_library_noargs test_library_init_nofinal test_library_noinit_final )

--- a/src/tests/runtime/CMakeLists.txt
+++ b/src/tests/runtime/CMakeLists.txt
@@ -13,6 +13,19 @@ ecbuild_add_test( TARGET atlas_test_trace
   OMP         2
 )
 
+ecbuild_add_test( TARGET atlas_test_debug_logging
+  SOURCES     test_debug_logging.cc
+  LIBS        atlas
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} ATLAS_MPI_BARRIER_TIMEOUT=0.5
+)
+
+ecbuild_add_test( TARGET atlas_test_debug_logging_mpi
+  COMMAND     atlas_test_debug_logging
+  MPI        3
+  CONDITION  eckit_HAVE_MPI AND MPI_SLOTS GREATER_EQUAL 3
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} ATLAS_MPI_BARRIER_TIMEOUT=0.5
+)
+
 foreach( test test_library test_library_noargs test_library_init_nofinal test_library_noinit_final )
   ecbuild_add_test( TARGET atlas_${test}
     SOURCES     ${test}.cc

--- a/src/tests/runtime/test_debug_logging.cc
+++ b/src/tests/runtime/test_debug_logging.cc
@@ -1,0 +1,258 @@
+/*
+ * (C) Copyright 2013 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <sstream>
+#include <cstdlib>
+#include <thread>
+#include <vector>
+
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/runtime/Log.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+namespace atlas {
+namespace test {
+
+CASE("test_debug_synchronized_logging_basic") {
+    // Test that ATLAS_DEBUG properly logs from multiple MPI ranks
+    // without race conditions or garbled output.
+    const auto& comm = mpi::comm();
+    const int rank = comm.rank();
+    const int size = comm.size();
+
+    Log::info() << "[Rank " << rank << "] Starting basic debug test" << std::endl;
+
+    // All ranks call ATLAS_DEBUG at roughly the same time
+    // This creates contention in the logging system which could expose
+    // race conditions if buffers are not properly synchronized
+    ATLAS_DEBUG("All ranks logging simultaneously from basic test");
+
+    // Verify each rank can log independently after the debug call
+    Log::info() << "[Rank " << rank << "/" << size << "] Post-debug logging" << std::endl;
+
+    ATLAS_DEBUG_VAR(backtrace());
+    mpi::comm().barrier();
+    Log::info() << "[Rank " << rank << "] Basic debug test completed" << std::endl;
+}
+
+CASE("test_debug_with_variable_logging") {
+    // Test ATLAS_DEBUG_VAR with multiple ranks logging concurrently
+    const auto& comm = mpi::comm();
+    const int rank = comm.rank();
+    const int size = comm.size();
+
+    Log::info() << "[Rank " << rank << "] Starting variable debug test" << std::endl;
+
+    // Each rank logs its rank and size - creates concurrent logging
+    ATLAS_DEBUG_VAR(rank);
+    ATLAS_DEBUG_VAR(size);
+
+    Log::info() << "[Rank " << rank << "] Variable debug test completed" << std::endl;
+    mpi::comm().barrier();
+}
+
+CASE("test_debug_sync_basic") {
+    // Test ATLAS_DEBUG_SYNC which is designed for barrier synchronization
+    // The macro itself provides synchronization, so concurrent calls
+    // from all ranks should not cause races.
+    const auto& comm = mpi::comm();
+    const int rank = comm.rank();
+
+    Log::info() << "[Rank " << rank << "] Starting sync debug test" << std::endl;
+
+    // All ranks call ATLAS_DEBUG_SYNC simultaneously
+    // This barrier ensures synchronization and tests buffer flushing
+    ATLAS_DEBUG_SYNC();
+
+    Log::info() << "[Rank " << rank << "] Post-sync logging" << std::endl;
+    mpi::comm().barrier();
+}
+
+CASE("test_debug_sync_with_message") {
+    // Test ATLAS_DEBUG_SYNC with message parameter from multiple ranks
+    const auto& comm = mpi::comm();
+    const int rank = comm.rank();
+
+    Log::info() << "[Rank " << rank << "] Starting sync with message test" << std::endl;
+
+    // All ranks call ATLAS_DEBUG_SYNC with a message
+    std::ostringstream oss;
+    oss << "rank_" << rank << "_message";
+    ATLAS_DEBUG_SYNC(oss.str());
+
+    Log::info() << "[Rank " << rank << "] Sync with message test completed" << std::endl;
+    mpi::comm().barrier();
+}
+
+CASE("test_debug_sync_with_communicator") {
+    // Test ATLAS_DEBUG_SYNC with explicit communicator
+    const auto& comm = mpi::comm();
+    const int rank = comm.rank();
+
+    Log::info() << "[Rank " << rank << "] Starting sync with comm test" << std::endl;
+
+    // All ranks call ATLAS_DEBUG_SYNC with explicit communicator
+    ATLAS_DEBUG_SYNC(comm);
+
+    Log::info() << "[Rank " << rank << "] Sync with comm test completed" << std::endl;
+    mpi::comm().barrier();
+}
+
+CASE("test_debug_sync_with_communicator_and_message") {
+    // Test ATLAS_DEBUG_SYNC with both communicator and message parameters
+    // This is the most complex case and would be most prone to logging races
+    const auto& comm = mpi::comm();
+    const int rank = comm.rank();
+
+    Log::info() << "[Rank " << rank << "] Starting sync with comm and message test" << std::endl;
+
+    // All ranks call ATLAS_DEBUG_SYNC with both parameters
+    std::ostringstream oss;
+    oss << "concurrent_sync_rank_" << rank;
+    ATLAS_DEBUG_SYNC(comm, oss.str());
+
+    Log::info() << "[Rank " << rank << "] Sync with comm and message test completed" << std::endl;
+    mpi::comm().barrier();
+}
+
+CASE("test_debug_concurrent_multiple_calls") {
+    // Test multiple concurrent ATLAS_DEBUG calls from all ranks
+    // This creates higher contention on the logging system and tests buffer flushing
+    const auto& comm = mpi::comm();
+    const int rank = comm.rank();
+
+    for (int iteration = 0; iteration < 3; ++iteration) {
+        std::ostringstream oss;
+        oss << "concurrent_iteration_" << iteration << "_rank_" << rank;
+
+        // All ranks simultaneously call ATLAS_DEBUG
+        ATLAS_DEBUG(oss.str());
+
+        // Brief local work to simulate realistic MPI application behavior
+        Log::info() << "[Rank " << rank << "] Iteration " << iteration << " work" << std::endl;
+    }
+
+    Log::info() << "[Rank " << rank << "] Concurrent test completed" << std::endl;
+    mpi::comm().barrier();
+}
+
+CASE("test_debug_split_communicator") {
+    // Test ATLAS_DEBUG_SYNC with a split communicator to verify it works
+    // with non-default MPI communicators
+    const auto& world_comm = mpi::comm();
+    const int rank = world_comm.rank();
+
+    // Split communicator by rank parity (even/odd)
+    int color = rank % 2;
+    mpi::comm().split(color, "split_" + std::to_string(color));
+
+    const auto& split_comm = mpi::comm("split_" + std::to_string(color));
+    const int local_rank = split_comm.rank();
+    const int local_size = split_comm.size();
+
+    Log::info() << "[WorldRank " << rank << ", LocalRank " << local_rank << "/" << local_size
+                << "] Starting split comm test" << std::endl;
+
+    // Call ATLAS_DEBUG_SYNC with the split communicator
+    ATLAS_DEBUG_SYNC(split_comm);
+
+    Log::info() << "[WorldRank " << rank << ", LocalRank " << local_rank
+                << "] Split comm test completed" << std::endl;
+
+    mpi::comm().barrier();
+}
+
+CASE("test_debug_sync_var_basic") {
+    // Test ATLAS_DEBUG_SYNC_VAR with just a variable (default communicator)
+    const int rank = mpi::comm().rank();
+
+    Log::info() << "[Rank " << rank << "] Starting sync var test" << std::endl;
+
+    // All ranks call ATLAS_DEBUG_SYNC_VAR with their rank variable
+    ATLAS_DEBUG_SYNC_VAR(rank);
+
+    Log::info() << "[Rank " << rank << "] Sync var test completed" << std::endl;
+    mpi::comm().barrier();
+}
+
+CASE("test_debug_sync_var_with_communicator") {
+    // Test ATLAS_DEBUG_SYNC_VAR with explicit communicator
+    const auto& comm = mpi::comm();
+    const int rank = comm.rank();
+    const int size = comm.size();
+
+    Log::info() << "[Rank " << rank << "] Starting sync var with comm test" << std::endl;
+
+    // All ranks call ATLAS_DEBUG_SYNC_VAR with variable and communicator
+    ATLAS_DEBUG_SYNC_VAR(comm, size);
+
+    Log::info() << "[Rank " << rank << "] Sync var with comm test completed" << std::endl;
+    mpi::comm().barrier();
+}
+
+CASE("test_debug_sync_var_concurrent_multiple_calls") {
+    // Test multiple concurrent ATLAS_DEBUG_SYNC_VAR calls to verify robustness
+    const auto& comm = mpi::comm();
+    const int rank = comm.rank();
+
+    for (int iteration = 0; iteration < 3; ++iteration) {
+        int value = rank * 10 + iteration;
+
+        // All ranks simultaneously call ATLAS_DEBUG_SYNC_VAR
+        ATLAS_DEBUG_SYNC_VAR(comm, value);
+
+        Log::info() << "[Rank " << rank << "] Iteration " << iteration << " completed" << std::endl;
+    }
+
+    Log::info() << "[Rank " << rank << "] Concurrent sync var test completed" << std::endl;
+    mpi::comm().barrier();
+}
+
+CASE("test_debug_sync_timeout_throws_when_configured") {
+    const auto& comm = mpi::comm();
+    if (comm.size() == 1) {
+        Log::warning() << "Skipping this test which is designed for multiple ranks." << std::endl;
+        return;
+    }
+    const std::string timeout_action = eckit::Resource<std::string>("$ATLAS_MPI_BARRIER_TIMEOUT_ACTION", "THROW");
+    ATLAS_DEBUG_VAR(timeout_action);
+    if (timeout_action != "THROW") {
+        Log::warning() << "Skipping this test since ATLAS_MPI_BARRIER_TIMEOUT_ACTION=" << timeout_action << " is not set to THROW." << std::endl;
+        return;
+    }
+
+    const int rank = comm.rank();
+    const double timeout_seconds = eckit::Resource<double>("$ATLAS_MPI_BARRIER_TIMEOUT", 3.0);
+    bool did_throw = false;
+    if (rank > 0) {
+         // Sleep longer than the barrier timeout to ensure rank 0 times out
+        int sleep_ms = static_cast<int>((timeout_seconds + 1.) * 1000);
+        std::this_thread::sleep_for( std::chrono::milliseconds(sleep_ms));
+    }
+    try {
+        ATLAS_DEBUG_SYNC("forced timeout throw");
+    }
+    catch (const eckit::Exception& exception) {
+        did_throw = true;
+        EXPECT(std::string(exception.what()).find("ATLAS_MPI_BARRIER_TIMEOUT") != std::string::npos);
+        Log::info() << "Caught expected exception on rank " << rank << ": " << exception.what() << std::endl;
+    }
+
+    mpi::comm().barrier();
+    EXPECT(did_throw == (rank == 0));
+}
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}

--- a/src/tests/runtime/test_debug_logging.cc
+++ b/src/tests/runtime/test_debug_logging.cc
@@ -229,6 +229,9 @@ CASE("test_debug_sync_timeout_throws_when_configured") {
         return;
     }
 
+    mpi::comm().split(0, "work_comm");  // before forcing the timeout
+    const auto& work_comm = mpi::comm("work_comm");
+
     const int rank = comm.rank();
     const double timeout_seconds = eckit::Resource<double>("$ATLAS_MPI_BARRIER_TIMEOUT", 3.0);
     bool did_throw = false;
@@ -238,7 +241,8 @@ CASE("test_debug_sync_timeout_throws_when_configured") {
         std::this_thread::sleep_for( std::chrono::milliseconds(sleep_ms));
     }
     try {
-        ATLAS_DEBUG_SYNC("forced timeout throw");
+        ATLAS_DEBUG_SYNC(work_comm, "forced timeout throw");
+        // The internal barrier must be on a separate (work_comm) if we are expected to recover
     }
     catch (const eckit::Exception& exception) {
         did_throw = true;


### PR DESCRIPTION
This pull request introduces a new, robust, and synchronized debugging and logging mechanism for MPI-parallel applications in Atlas. It replaces the older `ATLAS_DEBUG_PARALLEL` macros with new `ATLAS_DEBUG_SYNC` macros, which ensure output is properly synchronized across MPI ranks, handle timeouts, and provide flexible configuration for debugging complex parallel scenarios. It also adds comprehensive tests to validate the new debugging features.

The most important changes are:

### Synchronized Debugging and Logging Functionality

* Introduced new `ATLAS_DEBUG_SYNC` and `ATLAS_DEBUG_SYNC_VAR` macros in `Log.h` to replace the old `ATLAS_DEBUG_PARALLEL` macros, providing synchronized logging across MPI ranks with flexible argument handling and improved usability.
* Implemented a new set of `debug_sync` functions in `Log.cc` that handle MPI barriers with configurable timeouts and actions (abort, throw, continue), as well as synchronized flushing of output streams and detailed backtraces for debugging.

### Timeout and Error Handling for MPI Barriers

* Added logic to detect and handle MPI barrier timeouts, including configurable actions via the `ATLAS_MPI_BARRIER_TIMEOUT_ACTION` environment variable and reporting of ranks that timed out.

### Code Modernization and Refactoring

* Refactored and removed the old `debug_parallel_here` and `debug_parallel_what` functions, fully replacing them with the new `debug_sync` infrastructure. [[1]](diffhunk://#diff-7143eccc4090a64be4aa74377c54c5c73b4d9a9330909ca187b133a4fa132169R37-R53) [[2]](diffhunk://#diff-f527f68bebf64b393c4ebe827d640ba2985d4e8bcace8b6095b5af19108c8cceL295-R502)
* Improved formatting in the MacOS backtrace output for better readability.

### Testing

* Added a comprehensive test suite (`test_debug_logging.cc`) and corresponding CMake test targets to validate the new debugging macros and timeout behaviors in both serial and MPI-parallel contexts. [[1]](diffhunk://#diff-f4c0b94eb182bbc2aef92b6a7cb92337803838bc84fca682935a509fa490ae6eR1-R258) [[2]](diffhunk://#diff-5788bb9faad7c66d0473dc05f2de77b57c4a524baf0b0a4eee9fd15e77c4b8ebR16-R28)

### Dependency and Include Updates

* Updated includes in `Log.cc` to support new features, such as threading, chrono, and data synchronization, and to ensure compatibility across platforms.

These changes collectively improve the reliability, configurability, and usability of debugging and logging in parallel Atlas applications.

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-385
<!-- STATIC-ANALYSIS_END -->