### PR TITLE
Fix checksum implementation in hex output and enhance BlockStructuredColumns tests

### DIFF
--- a/src/atlas/functionspace/detail/BlockStructuredColumns.cc
+++ b/src/atlas/functionspace/detail/BlockStructuredColumns.cc
@@ -561,12 +561,12 @@ util::checksum_t fieldset_checksum(const BlockStructuredColumns& fs, const Field
 
 std::string BlockStructuredColumns::checksum(const Field& f) const {
     ATLAS_TRACE("BlockStructuredColumns::checksum");
-    return std::to_string(field_checksum(*this, f));
+    return util::checksum_to_hex_str(field_checksum(*this, f));
 }
 
 std::string BlockStructuredColumns::checksum(const FieldSet& f) const {
     ATLAS_TRACE("BlockStructuredColumns::checksum");
-    return std::to_string(fieldset_checksum(*this, f));
+    return util::checksum_to_hex_str(fieldset_checksum(*this, f));
 }
 
 // ----------------------------------------------------------------------------

--- a/src/atlas/functionspace/detail/BlockStructuredColumns.cc
+++ b/src/atlas/functionspace/detail/BlockStructuredColumns.cc
@@ -521,7 +521,9 @@ util::checksum_t checksum_from_lane_states(const BlockStructuredColumns& fs, Che
         }
     }
 
-    if (mpi::comm().size() == 1) {
+    auto& mpi_comm = mpi::comm(fs.mpi_comm());
+
+    if (mpi_comm.size() == 1) {
         ATLAS_ASSERT(local_lane_checksums.contiguous());
         const auto* local_lane_checksums_data = local_lane_checksums.array().host_data<util::checksum_t>();
         return util::checksum(local_lane_checksums_data, static_cast<size_t>(fs.structuredcolumns().sizeOwned()));
@@ -531,12 +533,12 @@ util::checksum_t checksum_from_lane_states(const BlockStructuredColumns& fs, Che
     fs.gather(local_lane_checksums, global_lane_checksums);
 
     util::checksum_t global_checksum = 0;
-    if (mpi::comm().rank() == checksum_data.root) {
+    if (mpi_comm.rank() == checksum_data.root) {
         ATLAS_ASSERT(global_lane_checksums.contiguous());
         const auto* global_lane_checksums_data = global_lane_checksums.array().host_data<util::checksum_t>();
         global_checksum = util::checksum(global_lane_checksums_data, global_lane_checksums.size());
     }
-    mpi::comm().broadcast(global_checksum, checksum_data.root);
+    mpi_comm.broadcast(global_checksum, checksum_data.root);
     return global_checksum;
 }
 

--- a/src/atlas/functionspace/detail/BlockStructuredColumns.h
+++ b/src/atlas/functionspace/detail/BlockStructuredColumns.h
@@ -125,6 +125,8 @@ public:
 
     const util::PartitionPolygon& polygon(idx_t halo = 0) const override { return structuredcolumns_->polygon(halo); }
 
+    std::string mpi_comm() const override { return structuredcolumns_->mpi_comm(); }
+
 private:  // methods
     array::ArrayShape config_shape(const eckit::Configuration&) const;
     array::ArrayAlignment config_alignment(const eckit::Configuration&) const;

--- a/src/atlas/functionspace/detail/StructuredColumns.cc
+++ b/src/atlas/functionspace/detail/StructuredColumns.cc
@@ -123,9 +123,11 @@ public:
 private:
     static Base::key_type key(const detail::StructuredColumns& funcspace) {
         std::ostringstream key;
-        key << "grid[address=" << funcspace.grid().get() << ",halo=" << funcspace.halo()
+        key << "grid[name=" << funcspace.grid().name() << ",address=" << funcspace.grid().get() << "]"
+            << "functionspace[halo=" << funcspace.halo()
             << ",periodic_points=" << std::boolalpha << funcspace.periodic_points_
-            << ",distribution=" << funcspace.distribution() << "]";
+            << ",distribution=" << funcspace.distribution() << "]"
+            << ",comm[name=" << funcspace.mpi_comm() << ",address=" << &mpi::comm(funcspace.mpi_comm()) << "]";
         return key.str();
     }
 
@@ -172,9 +174,11 @@ public:
 private:
     static Base::key_type key(const detail::StructuredColumns& funcspace) {
         std::ostringstream key;
-        key << "grid[address=" << funcspace.grid().get() << ",halo=" << funcspace.halo()
+        key << "grid[name=" << funcspace.grid().name() << ",address=" << funcspace.grid().get() << "]"
+            << "functionspace[halo=" << funcspace.halo()
             << ",periodic_points=" << std::boolalpha << funcspace.periodic_points_
-            << ",distribution=" << funcspace.distribution() << "]";
+            << ",distribution=" << funcspace.distribution() << "]"
+            << ",comm[name=" << funcspace.mpi_comm() << ",address=" << &mpi::comm(funcspace.mpi_comm()) << "]";
         return key.str();
     }
 
@@ -190,7 +194,6 @@ private:
 
     static value_type* create(const detail::StructuredColumns* funcspace) {
         value_type* value = new value_type();
-
         value->setup(funcspace->mpi_comm(),
                      array::make_view<int, 1>(funcspace->partition()).data(),
                      array::make_view<idx_t, 1>(funcspace->remote_index()).data(), REMOTE_IDX_BASE,

--- a/src/atlas/util/Checksum.cc
+++ b/src/atlas/util/Checksum.cc
@@ -104,13 +104,6 @@ static uint16_t fletcher16(const uint8_t* data, size_t size) {
   return fletcher16_finish(checksum);
 }
 
-
-}  // namespace
-
-void checksum_reset(checksum_t& checksum) {
-  fletcher16_reset(reinterpret_cast<Fletcher16&>(checksum));
-}
-
 static void checksum_update(checksum_t& checksum, const char* data, size_t bytes) {
   fletcher16_update(reinterpret_cast<Fletcher16&>(checksum), reinterpret_cast<const uint8_t*>(data), bytes);
 }
@@ -124,12 +117,14 @@ static void checksum_update_strided(checksum_t& checksum, const Value values[], 
   fletcher16_update(f, data, size, stride_bytes, value_bytes);
 }
 
-checksum_t checksum_digest(const checksum_t& checksum) {
-    return fletcher16_finish(reinterpret_cast<const Fletcher16&>(checksum));
-}
-
 static checksum_t checksum(const char* data, size_t size) {
     return fletcher16(reinterpret_cast<const uint8_t*>(data), size / sizeof(uint8_t));
+}
+
+}  // namespace
+
+void checksum_reset(checksum_t& checksum) {
+  fletcher16_reset(reinterpret_cast<Fletcher16&>(checksum));
 }
 
 checksum_t checksum(const int values[], size_t size) {
@@ -190,6 +185,28 @@ void checksum_update(checksum_t& c, const double values[], size_t size, size_t s
 
 void checksum_update(checksum_t& c, const checksum_t values[], size_t size, size_t stride) {
   checksum_update_strided(c, values, size, stride);
+}
+
+checksum_t checksum_digest(const checksum_t& checksum) {
+    return fletcher16_finish(reinterpret_cast<const Fletcher16&>(checksum));
+}
+
+namespace {
+inline std::string to_hex_str(util::checksum_t digest) {
+  // Configure the stream for hex, lowercase, and zero padding
+
+  std::stringstream ss;
+  ss << std::hex
+      << std::nouppercase
+      << std::setw(4)
+      << std::setfill('0')
+      << digest;
+  return ss.str();
+}
+}
+
+std::string checksum_to_hex_str(const util::checksum_t& digest) {
+  return to_hex_str(digest);
 }
 
 }  // namespace util

--- a/src/atlas/util/Checksum.h
+++ b/src/atlas/util/Checksum.h
@@ -27,6 +27,7 @@ checksum_t checksum(const float values[], size_t size);
 checksum_t checksum(const double values[], size_t size);
 checksum_t checksum(const checksum_t values[], size_t size);
 
+void checksum_reset(checksum_t&);
 void checksum_update(checksum_t&, const int values[], size_t size);
 void checksum_update(checksum_t&, const long values[], size_t size);
 void checksum_update(checksum_t&, const float values[], size_t size);
@@ -38,7 +39,7 @@ void checksum_update(checksum_t&, const float values[], size_t size, size_t stri
 void checksum_update(checksum_t&, const double values[], size_t size, size_t stride);
 void checksum_update(checksum_t&, const checksum_t values[], size_t size, size_t stride);
 checksum_t checksum_digest(const checksum_t&);
-void checksum_reset(checksum_t&);
+std::string checksum_to_hex_str(const util::checksum_t& digest);
 
 }  // namespace util
 }  // namespace atlas

--- a/src/tests/functionspace/fctest_blockstructuredcolumns_checksum.F90
+++ b/src/tests/functionspace/fctest_blockstructuredcolumns_checksum.F90
@@ -653,19 +653,19 @@ field_1 = atlas_Field(name="field_1", data=gfl(:,:,1,:))
 checksum = fs%checksum(field_1)  ! Should compute checksum without error on wrapped data
 write(msg,*) "Checksum for field_1 wrapping 3D slice: ", trim(checksum)
 call atlas_log%info(msg)
-FCTEST_CHECK_EQUAL(checksum, "35704")
+FCTEST_CHECK_EQUAL(checksum, "8b78")
 
 field_2 = atlas_Field(name="field_2", data=gfl(:,:,2,:))
 checksum = fs%checksum(field_2)  ! Should compute checksum without error on wrapped data
 write(msg,*) "Checksum for field_2 wrapping 3D slice: ", trim(checksum)
 call atlas_log%info(msg)
-FCTEST_CHECK_EQUAL(checksum, "12704")
+FCTEST_CHECK_EQUAL(checksum, "31a0")
 
 field_3 = atlas_Field(name="field_3", data=gfl(:,:,3,:))
 checksum = fs%checksum(field_3)  ! Should compute checksum without error on wrapped data
 write(msg,*) "Checksum for field_3 wrapping 3D slice: ", trim(checksum)
 call atlas_log%info(msg)
-FCTEST_CHECK_EQUAL(checksum, "21654")
+FCTEST_CHECK_EQUAL(checksum, "5496")
 
 fieldset = atlas_FieldSet()
 call fieldset%add(field_1)
@@ -674,13 +674,13 @@ call fieldset%add(field_3)
 checksum = fs%checksum(fieldset)  ! Should compute checksum without error on fieldset of wrapped fields
 write(msg,*) "Checksum for fieldset of 3 wrapped fields: ", trim(checksum)
 call atlas_log%info(msg)
-FCTEST_CHECK_EQUAL(checksum, "37637")
+FCTEST_CHECK_EQUAL(checksum, "9305")
 
 field_gfl = atlas_Field(name="gfl", data=gfl(:,:,:,:))
 checksum = fs%checksum(field_gfl)  ! Should compute checksum without error on wrapped data
 write(msg,*) "Checksum for field_gfl wrapping 4D array: ", trim(checksum)
 call atlas_log%info(msg)
-FCTEST_CHECK_EQUAL(checksum, "13196")
+FCTEST_CHECK_EQUAL(checksum, "338c")
 END_TEST
 
 END_TESTSUITE

--- a/src/tests/functionspace/test_blockstructuredcolumns_checksum.cc
+++ b/src/tests/functionspace/test_blockstructuredcolumns_checksum.cc
@@ -101,7 +101,7 @@ std::string fill_field_and_expected_checksum(const BlockStructuredColumns& fs, F
         }
     }
 
-    return std::to_string(util::checksum(lane_checksums.data(), lane_checksums.size()));
+    return util::checksum_to_hex_str(util::checksum(lane_checksums.data(), lane_checksums.size()));
 }
 
 template <typename Value>
@@ -145,7 +145,7 @@ std::string expected_fieldset_checksum(const BlockStructuredColumns& fs, const F
     for (size_t jlane = 0; jlane < lane_states.size(); ++jlane) {
         lane_digests[jlane] = util::checksum_digest(lane_states[jlane]);
     }
-    return std::to_string(util::checksum(lane_digests.data(), lane_digests.size()));
+    return util::checksum_to_hex_str(util::checksum(lane_digests.data(), lane_digests.size()));
 }
 
 template <typename Value>
@@ -402,8 +402,9 @@ CASE("test_BlockStructuredColumns checksum in mpi-serial uses generic path for b
 
     fs.scatter(global, local);
 
-    Log::info() << "Expected checksum: " << expected_checksum << std::endl;
-    EXPECT_EQ(fs.checksum(local), std::to_string(expected_checksum));
+    auto expected_checksum_hex_str = util::checksum_to_hex_str(expected_checksum);
+    Log::info() << "Expected checksum: " << expected_checksum_hex_str << std::endl;
+    EXPECT_EQ(fs.checksum(local), expected_checksum_hex_str);
 }
 
 CASE("test_BlockStructuredColumns checksum(fieldset) matches checksum(field) for a single field (mpi-serial)") {
@@ -498,8 +499,9 @@ void run_mpi_checksum_caseT(const functionspace::BlockStructuredColumns& fs, idx
     idx_t expected_rank = idx_t{2} /*nblks, nproma*/ + std::min<idx_t>(nlev,1) + std::min<idx_t>(nvar,1);
     EXPECT_EQ(local.rank(), expected_rank);
 
-    Log::info() << "Expected checksum: " << expected_checksum << std::endl;
-    EXPECT_EQ(fs.checksum(local), std::to_string(expected_checksum));
+    auto expected_checksum_hex_str = util::checksum_to_hex_str(expected_checksum);
+    Log::info() << "Expected checksum: " << expected_checksum_hex_str << std::endl;
+    EXPECT_EQ(fs.checksum(local), expected_checksum_hex_str);
 };
 
 void run_mpi_checksum_cases(const functionspace::BlockStructuredColumns& fs, idx_t nlev, idx_t nvar) {
@@ -545,8 +547,9 @@ void run_mpi_fieldset_checksum_caseT(const functionspace::BlockStructuredColumns
     local_fieldset.add(local_a);
     local_fieldset.add(local_b);
 
-    Log::info() << "Expected fieldset checksum (MPI): " << expected_fieldset << std::endl;
-    EXPECT_EQ(fs.checksum(local_fieldset), std::to_string(expected_fieldset));
+    auto expected_fieldset_hex_str = util::checksum_to_hex_str(expected_fieldset);
+    Log::info() << "Expected fieldset checksum (MPI): " << expected_fieldset_hex_str << std::endl;
+    EXPECT_EQ(fs.checksum(local_fieldset), expected_fieldset_hex_str);
 }
 
 void run_mpi_fieldset_checksum_cases(const functionspace::BlockStructuredColumns& fs, idx_t nlev, idx_t nvar) {

--- a/src/tests/functionspace/test_functionspace_splitcomm.cc
+++ b/src/tests/functionspace/test_functionspace_splitcomm.cc
@@ -57,6 +57,20 @@ std::string expected_checksum() {
     return result;
 }
 
+std::string expected_checksum_blocked() {
+    static std::string result = [&]() {
+        if (grid().name()=="O32") {
+            return "6408";
+        }
+        else if (grid().name()=="N32") {
+            return "ca85";
+        }
+        else {
+            return "unknown";
+        }
+    }();
+    return result;
+}
 struct Fixture {
     Fixture() {
         mpi::comm().split(color(),"split");
@@ -70,8 +84,20 @@ struct Fixture {
 
 void field_init(Field& field) {
     auto fs = field.functionspace();
-    auto f = array::make_view<double,1>(field);
     auto g = array::make_view<gidx_t,1>(fs.global_index());
+
+    if (functionspace::BlockStructuredColumns fsb{fs}) {
+        auto f = array::make_view<double,2>(field);
+        auto g = array::make_view<gidx_t,1>(fs.global_index());
+        for( idx_t jblk=0; jblk<fsb.nblks(); ++jblk ) {
+            auto block = fsb.block(jblk);
+            for( idx_t jlane=0; jlane<block.size(); ++jlane ) {
+                f(jblk,jlane) = g(block.index(jlane));
+            }
+        }
+        return;
+    }
+    auto f = array::make_view<double,1>(field);
     for( idx_t j=0; j<f.size(); ++j ) {
         f(j) = g(j);
     }
@@ -157,7 +183,7 @@ CASE("test FunctionSpace BlockStructuredColumns") {
     EXPECT_EQUAL(fs.nb_parts(),mpi::comm("split").size());
 
     auto field  = fs.createField<double>();
-    // field_init(field);
+    field_init(field);
 
     // HaloExchange
     // field.haloExchange();
@@ -165,18 +191,20 @@ CASE("test FunctionSpace BlockStructuredColumns") {
 
     // Gather
     auto fieldg = fs.createField<double>(atlas::option::global());
-    // fs.gather(field,fieldg);
+    fs.gather(field,fieldg);
 
-    // if (fieldg.size()) {
-    //     idx_t g{0};
-    //     field::for_each_value(fieldg,[&](double x) {
-    //         EXPECT_EQ(++g,x);
-    //     });
-    // }
+    if (fieldg.size()) {
+        idx_t g{0};
+        field::for_each_value(fieldg,[&](double x) {
+            EXPECT_EQ(++g,x);
+        });
+    }
 
-    // // Checksum
-    // auto checksum = fs.checksum(field);
-    // EXPECT_EQ(checksum, expected_checksum());
+    // Checksum
+    auto checksum = fs.checksum(field);
+    EXPECT_EQ(checksum, expected_checksum_blocked());
+
+    Log::error() << "fs.part() = " << fs.part() << " fs.nb_parts() = " << fs.nb_parts() << " grid = " << fs.grid().name() << " checksum = " << checksum << std::endl;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/tests/functionspace/test_functionspace_splitcomm.cc
+++ b/src/tests/functionspace/test_functionspace_splitcomm.cc
@@ -39,20 +39,22 @@ int color() {
 }
 
 Grid grid() {
-    static Grid g (color() == 0 ? "O32" : "N32" );
-    return g;
+    return Grid(color() == 0 ? "O32" : "N32" );
 }
 
 std::string expected_checksum() {
-    if (grid().name()=="O32") {
-        return "75e913d400755a0d2782fc65e2035e97";
-    }
-    else if (grid().name()=="N32") {
-        return "bcb344196d20becbb66f098d91f83abb";
-    }
-    else {
-        return "unknown";
-    }
+    static std::string result = [&]() {
+        if (grid().name()=="O32") {
+            return "75e913d400755a0d2782fc65e2035e97";
+        }
+        else if (grid().name()=="N32") {
+            return "bcb344196d20becbb66f098d91f83abb";
+        }
+        else {
+            return "unknown";
+        }
+    }();
+    return result;
 }
 
 struct Fixture {
@@ -106,11 +108,14 @@ CASE("test FunctionSpace NodeColumns") {
     auto checksum = fs.checksum(field);
     EXPECT_EQ(checksum, expected_checksum());
 
+    Log::error() << "fs.part() = " << fs.part() << " fs.nb_parts() = " << fs.nb_parts() << " grid = " << fs.grid().name() << " checksum = " << checksum << std::endl;
+
     // Output
-    output::Gmsh gmsh(grid().name()+".msh");
+    output::Gmsh gmsh(mesh.grid().name()+".msh");
     gmsh.write(mesh);
     gmsh.write(field);
 }
+
 
 CASE("test FunctionSpace StructuredColumns") {
     Fixture fixture;
@@ -140,6 +145,8 @@ CASE("test FunctionSpace StructuredColumns") {
     // Checksum
     auto checksum = fs.checksum(field);
     EXPECT_EQ(checksum, expected_checksum());
+
+    Log::error() << "fs.part() = " << fs.part() << " fs.nb_parts() = " << fs.nb_parts() << " grid = " << fs.grid().name() << " checksum = " << checksum << std::endl;
 }
 
 CASE("test FunctionSpace BlockStructuredColumns") {
@@ -208,9 +215,9 @@ CASE("test FunctionSpace PointCloud") {
 
 CASE("test FunctionSpace StructuredColumns with MatchingPartitioner") {
     Fixture fixture;
-
-    auto fs_A = functionspace::StructuredColumns(grid(), option::mpi_split_comm());
-    auto fs_B = functionspace::StructuredColumns(grid(), grid::MatchingPartitioner(fs_A), option::mpi_split_comm());
+    auto g = grid();
+    auto fs_A = functionspace::StructuredColumns(g, option::mpi_split_comm());
+    auto fs_B = functionspace::StructuredColumns(g, grid::MatchingPartitioner(fs_A), option::mpi_split_comm());
     fs_A.polygon().outputPythonScript("fs_A_polygons.py");
     fs_B.polygon().outputPythonScript("fs_B_polygons.py");
 }


### PR DESCRIPTION
This pull request updates the checksum computation and representation in the Atlas library, focusing on improving checksum usability, consistency, and test coverage. The changes standardize the checksum output to hexadecimal strings, enhance MPI communicator handling, and improve test reliability and clarity.

**Checksum Representation and API Improvements**
- Changed the output of `BlockStructuredColumns::checksum` and related functions to return hexadecimal strings using the new `util::checksum_to_hex_str` utility, instead of plain decimal numbers. This improves readability and consistency across the codebase. [[1]](diffhunk://#diff-eec89df65aa09cdea18d3507934280bc74109972b0145375ac79681e62a9fb89L562-R569) [[2]](diffhunk://#diff-01a1990877bd8f0cb34eff610da85e66fb930a70c79d0b03290f144c7ba61850L104-R104) [[3]](diffhunk://#diff-01a1990877bd8f0cb34eff610da85e66fb930a70c79d0b03290f144c7ba61850L148-R148) [[4]](diffhunk://#diff-01a1990877bd8f0cb34eff610da85e66fb930a70c79d0b03290f144c7ba61850L405-R407) [[5]](diffhunk://#diff-01a1990877bd8f0cb34eff610da85e66fb930a70c79d0b03290f144c7ba61850L501-R504) [[6]](diffhunk://#diff-01a1990877bd8f0cb34eff610da85e66fb930a70c79d0b03290f144c7ba61850L548-R552)
- Added the `checksum_to_hex_str` function to `util::Checksum`, with a helper for formatting as lowercase, zero-padded hex. [[1]](diffhunk://#diff-8634ffb4281fb8db0de561dd099ceb7a01a527e40067aac3d3a1694ef32d61f9R190-R211) [[2]](diffhunk://#diff-bcbe8b6f7d7f5bc6b042824de6535146e8538e61255030b403bfb72cd8618d66L41-R42)

**MPI Communicator Handling**
- Updated checksum and gather/scatter logic to use the correct MPI communicator associated with the function space, improving correctness in parallel environments. [[1]](diffhunk://#diff-eec89df65aa09cdea18d3507934280bc74109972b0145375ac79681e62a9fb89L524-R526) [[2]](diffhunk://#diff-eec89df65aa09cdea18d3507934280bc74109972b0145375ac79681e62a9fb89L534-R541)
- Added an override for `mpi_comm()` in `BlockStructuredColumns` to expose the communicator used.
- Enhanced cache key generation for `StructuredColumnsHaloExchangeCache` and `StructuredColumnsGatherScatterCache` to include MPI communicator details, improving cache uniqueness and debugging. [[1]](diffhunk://#diff-0c3b56e9aa8289ad9ac525c7088617b7e7eef898785bbb3c3477a01ce5c9e7e8L126-R130) [[2]](diffhunk://#diff-0c3b56e9aa8289ad9ac525c7088617b7e7eef898785bbb3c3477a01ce5c9e7e8L175-R181)

**Testing and Validation**
- Updated Fortran and C++ tests to check for the new hexadecimal checksum outputs and added new expected values. [[1]](diffhunk://#diff-f33a629bf3389a726310c1f0f614d3b6d8f849e989955d491427b6002177fef6L656-R668) [[2]](diffhunk://#diff-f33a629bf3389a726310c1f0f614d3b6d8f849e989955d491427b6002177fef6L677-R683) [[3]](diffhunk://#diff-01a1990877bd8f0cb34eff610da85e66fb930a70c79d0b03290f144c7ba61850L104-R104) [[4]](diffhunk://#diff-01a1990877bd8f0cb34eff610da85e66fb930a70c79d0b03290f144c7ba61850L148-R148) [[5]](diffhunk://#diff-01a1990877bd8f0cb34eff610da85e66fb930a70c79d0b03290f144c7ba61850L405-R407) [[6]](diffhunk://#diff-01a1990877bd8f0cb34eff610da85e66fb930a70c79d0b03290f144c7ba61850L501-R504) [[7]](diffhunk://#diff-01a1990877bd8f0cb34eff610da85e66fb930a70c79d0b03290f144c7ba61850L548-R552)
- Improved test fixtures and output in `test_functionspace_splitcomm.cc`, including new expected checksum values for blocked layouts and more informative logging. [[1]](diffhunk://#diff-fd043bb805e82e8933fd8535f7cdc59dbab12961a9baba508ac1d9420fc86ec4L42-R46) [[2]](diffhunk://#diff-fd043bb805e82e8933fd8535f7cdc59dbab12961a9baba508ac1d9420fc86ec4R56-R73) [[3]](diffhunk://#diff-fd043bb805e82e8933fd8535f7cdc59dbab12961a9baba508ac1d9420fc86ec4L71-R100) [[4]](diffhunk://#diff-fd043bb805e82e8933fd8535f7cdc59dbab12961a9baba508ac1d9420fc86ec4R137-R145) [[5]](diffhunk://#diff-fd043bb805e82e8933fd8535f7cdc59dbab12961a9baba508ac1d9420fc86ec4R174-R175) [[6]](diffhunk://#diff-fd043bb805e82e8933fd8535f7cdc59dbab12961a9baba508ac1d9420fc86ec4L153-R207)

**Internal Refactoring**
- Refactored the implementation of checksum update and digest functions for clarity and to ensure correct namespace usage. [[1]](diffhunk://#diff-8634ffb4281fb8db0de561dd099ceb7a01a527e40067aac3d3a1694ef32d61f9L107-L113) [[2]](diffhunk://#diff-8634ffb4281fb8db0de561dd099ceb7a01a527e40067aac3d3a1694ef32d61f9L127-R129)
- Minor improvements to field initialization logic in tests to better support block-structured layouts.

These changes collectively improve the reliability, clarity, and maintainability of checksum computation and validation in Atlas, especially in parallel and block-structured contexts.

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-386
<!-- STATIC-ANALYSIS_END -->