### PR TITLE
Fix GatherScatter for sparse global indexing in EdgeColumns

### DIFF
--- a/src/atlas/parallel/GatherScatter.cc
+++ b/src/atlas/parallel/GatherScatter.cc
@@ -253,26 +253,28 @@ void GatherScatter::setup(const std::string& mpi_comm, const int part[], const i
     locmap_.resize(loccnt_,-1);
     std::vector<int> idx(nproc, 0);
 
-    auto populate_maps = [&](auto global_index_for_node) {
-        for (const auto& node : nodes) {
-            glbmap_[glbdispls_[node.p] + idx[node.p]] = global_index_for_node(node);
+    auto update_local_map = [&](const Node& node) {
+        if (node.p == myproc) {
+            locmap_[idx[node.p]] = node.i;
+        }
+    };
 
-            if (node.p == myproc) {
-                locmap_[idx[node.p]] = node.i;
-            }
+    if (use_dense_global_indices_directly) {
+        for (const auto& node : nodes) {
+            glbmap_[glbdispls_[node.p] + idx[node.p]] = node.g - glb_idx_base;
+            update_local_map(node);
 
             ++idx[node.p];
         }
-    };
-    gidx_t compact_global_index{0};
-    auto compact_global_index_for_node = [&compact_global_index](const Node&) { return compact_global_index++; };
-    auto dense_global_index_for_node = [&](const Node& node) { return node.g - glb_idx_base; };
-
-    if (use_dense_global_indices_directly) {
-        populate_maps(dense_global_index_for_node);
     }
     else {
-        populate_maps(compact_global_index_for_node);
+        gidx_t compact_global_index{0};
+        for (const auto& node : nodes) {
+            glbmap_[glbdispls_[node.p] + idx[node.p]] = compact_global_index++;
+            update_local_map(node);
+
+            ++idx[node.p];
+        }
     }
 
     is_setup_ = true;

--- a/src/atlas/parallel/GatherScatter.cc
+++ b/src/atlas/parallel/GatherScatter.cc
@@ -128,13 +128,13 @@ void GatherScatter::setup(const std::string& mpi_comm, const int part[], const i
     }
 
     idx_t nb_recv_nodes = glbcnt_;
-    std::vector<Node> node_sort;
+    std::vector<Node> nodes;
 
     try {
-        node_sort.resize(nb_recv_nodes);
+        nodes.resize(nb_recv_nodes);
     }
     catch (const std::bad_alloc& e) {
-        ATLAS_THROW_EXCEPTION("Could not allocate node_sort with size " << eckit::Bytes(nb_recv_nodes * sizeof(Node)));
+        ATLAS_THROW_EXCEPTION("Could not allocate nodes with size " << eckit::Bytes(nb_recv_nodes * sizeof(Node)));
     }
 
     ATLAS_TRACE_SCOPE("receive nodes global index")
@@ -152,7 +152,7 @@ void GatherScatter::setup(const std::string& mpi_comm, const int part[], const i
                               glbcounts_.data(), glbdispls_.data());
         }
         atlas_omp_parallel_for(idx_t n = 0; n < nb_recv_nodes; ++n) {
-            node_sort[n].g = recvnodes_gidx[n];
+            nodes[n].g = recvnodes_gidx[n];
         }
         sendnodes_gidx.clear();
     }
@@ -173,7 +173,7 @@ void GatherScatter::setup(const std::string& mpi_comm, const int part[], const i
                               glbcounts_.data(), glbdispls_.data());
         }
         atlas_omp_parallel_for(idx_t n = 0; n < nb_recv_nodes; ++n) {
-            node_sort[n].p = recvnodes_part[n];
+            nodes[n].p = recvnodes_part[n];
         }
         sendnodes_part.clear();
     }
@@ -193,29 +193,48 @@ void GatherScatter::setup(const std::string& mpi_comm, const int part[], const i
                               glbcounts_.data(), glbdispls_.data());
         }
         atlas_omp_parallel_for(idx_t n = 0; n < nb_recv_nodes; ++n) {
-            node_sort[n].i = recvnodes_ridx[n];
+            nodes[n].i = recvnodes_ridx[n];
         }
         sendnodes_ridx.clear();
     }
 
-    bool use_sorted_nodes = false; // `use_sorted_nodes = true` is the behaviour as it has been with atlas versions <= 0.42.0
+    auto can_use_dense_global_indices_directly = [&]() {
+        if (nb_recv_nodes == 0) {
+            return true;
+        }
 
-    if (use_sorted_nodes) {
+        std::vector<bool> dense_global_index_seen(nb_recv_nodes, false);
+        for (const auto& node : nodes) {
+            const gidx_t dense_index = node.g - glb_idx_base;
+            if (dense_index < 0 || dense_index >= nb_recv_nodes || dense_global_index_seen[dense_index]) {
+                return false;
+            }
+            dense_global_index_seen[dense_index] = true;
+        }
+        return true;
+    };
+
+    auto normalize_sparse_global_indices = [&]() {
         // Sort on "g" member, and remove duplicates
         ATLAS_TRACE_SCOPE("sorting") {
-            //        omp::sort(node_sort.begin(), node_sort.end());
-            std::sort(node_sort.begin(), node_sort.end());
+            //        omp::sort(nodes.begin(), nodes.end());
+            std::sort(nodes.begin(), nodes.end());
         }
         ATLAS_TRACE_SCOPE("remove duplicates") {
-            node_sort.erase(std::unique(node_sort.begin(), node_sort.end()), node_sort.end());
+            nodes.erase(std::unique(nodes.begin(), nodes.end()), nodes.end());
         }
+    };
+
+    const bool use_dense_global_indices_directly = can_use_dense_global_indices_directly();
+    if (!use_dense_global_indices_directly) {
+        normalize_sparse_global_indices();
     }
 
     glbcounts_.assign(nproc, 0);
     glbdispls_.assign(nproc, 0);
 
-    for (size_t n = 0; n < node_sort.size(); ++n) {
-        ++glbcounts_[node_sort[n].p];
+    for (size_t n = 0; n < nodes.size(); ++n) {
+        ++glbcounts_[nodes[n].p];
     }
 
     glbdispls_[0] = 0;
@@ -234,15 +253,26 @@ void GatherScatter::setup(const std::string& mpi_comm, const int part[], const i
     locmap_.resize(loccnt_,-1);
     std::vector<int> idx(nproc, 0);
 
-    gidx_t n{node_sort.begin()->g - 1};
-    for (const auto& node : node_sort) {
-        glbmap_[glbdispls_[node.p] + idx[node.p]] = (use_sorted_nodes ? n++ : node.g - glb_idx_base);
+    auto populate_maps = [&](auto global_index_for_node) {
+        for (const auto& node : nodes) {
+            glbmap_[glbdispls_[node.p] + idx[node.p]] = global_index_for_node(node);
 
-        if (node.p == myproc) {
-            locmap_[idx[node.p]] = node.i;
+            if (node.p == myproc) {
+                locmap_[idx[node.p]] = node.i;
+            }
+
+            ++idx[node.p];
         }
+    };
+    gidx_t compact_global_index{0};
+    auto compact_global_index_for_node = [&compact_global_index](const Node&) { return compact_global_index++; };
+    auto dense_global_index_for_node = [&](const Node& node) { return node.g - glb_idx_base; };
 
-        ++idx[node.p];
+    if (use_dense_global_indices_directly) {
+        populate_maps(dense_global_index_for_node);
+    }
+    else {
+        populate_maps(compact_global_index_for_node);
     }
 
     is_setup_ = true;

--- a/src/atlas/parallel/GatherScatter.h
+++ b/src/atlas/parallel/GatherScatter.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <numeric>
+#include <sstream>
 #include <stdexcept>
 #include <type_traits>
 #include <vector>
@@ -189,12 +190,16 @@ public:  // methods
     const mpi::Comm& comm() const { return *comm_; }
 
 private:  // methods
-    template <typename DATA_TYPE>
-    void pack_send_buffer(const parallel::Field<DATA_TYPE const>& field, const std::vector<int>& sendmap,
-                          DATA_TYPE send_buffer[]) const;
+    template <typename FIELD>
+    void validate_field_and_map(const char* context, const FIELD& field, const std::vector<int>& map,
+                                idx_t field_point_count, idx_t buffer_point_count, size_t buffer_size) const;
 
     template <typename DATA_TYPE>
-    void unpack_recv_buffer(const std::vector<int>& recvmap, const DATA_TYPE recv_buffer[],
+    void pack_send_buffer(const parallel::Field<DATA_TYPE const>& field, const std::vector<int>& sendmap,
+                          DATA_TYPE send_buffer[], size_t send_buffer_size) const;
+
+    template <typename DATA_TYPE>
+    void unpack_recv_buffer(const std::vector<int>& recvmap, const DATA_TYPE recv_buffer[], size_t recv_buffer_size,
                             const parallel::Field<DATA_TYPE>& field) const;
 
     template <typename DATA_TYPE, int RANK>
@@ -238,6 +243,8 @@ void GatherScatter::gather(parallel::Field<DATA_TYPE const> lfields[], parallel:
         throw_Exception("GatherScatter was not setup", Here());
     }
 
+    std::vector<int> glb_displs(nproc);
+    std::vector<int> glb_counts(nproc);
     for (idx_t jfield = 0; jfield < nb_fields; ++jfield) {
         const idx_t lvar_size =
             std::accumulate(lfields[jfield].var_shape.data(),
@@ -249,27 +256,30 @@ void GatherScatter::gather(parallel::Field<DATA_TYPE const> lfields[], parallel:
         const size_t glb_size = glb_cnt(root) * gvar_size;
         std::vector<DATA_TYPE, pluto::host::allocator<DATA_TYPE>> loc_buffer(loc_size);
         std::vector<DATA_TYPE, pluto::host::allocator<DATA_TYPE>> glb_buffer(glb_size);
-        std::vector<int> glb_displs(nproc);
-        std::vector<int> glb_counts(nproc);
 
         for (idx_t jproc = 0; jproc < nproc; ++jproc) {
             glb_counts[jproc] = glbcounts_[jproc] * gvar_size;
             glb_displs[jproc] = glbdispls_[jproc] * gvar_size;
         }
 
-        /// Pack
+#if !defined(NDEBUG)
+        validate_field_and_map("GatherScatter::gather local field", lfields[jfield], locmap_, parsize_, loccnt_, loc_size);
+        if (myproc == root) {
+            validate_field_and_map("GatherScatter::gather global field", gfields[jfield], glbmap_, glb_cnt(root), glb_cnt(root), glb_size);
+        }
+#endif
 
-        pack_send_buffer(lfields[jfield], locmap_, loc_buffer.data());
+        /// Pack
+        pack_send_buffer(lfields[jfield], locmap_, loc_buffer.data(), loc_size);
 
         /// Gather
-
         ATLAS_TRACE_MPI(GATHER) {
             comm().gatherv(loc_buffer.begin(), loc_buffer.end(), glb_buffer.begin(), glb_buffer.end(), glb_counts, glb_displs, root);
         }
 
         /// Unpack
         if (myproc == root)
-            unpack_recv_buffer(glbmap_, glb_buffer.data(), gfields[jfield]);
+            unpack_recv_buffer(glbmap_, glb_buffer.data(), glb_size, gfields[jfield]);
     }
 }
 
@@ -290,6 +300,9 @@ void GatherScatter::scatter(parallel::Field<DATA_TYPE const> gfields[], parallel
         throw_Exception("GatherScatter was not setup", Here());
     }
 
+    std::vector<int> glb_displs(nproc);
+    std::vector<int> glb_counts(nproc);
+
     for (idx_t jfield = 0; jfield < nb_fields; ++jfield) {
         const int lvar_size =
             std::accumulate(lfields[jfield].var_shape.data(),
@@ -301,28 +314,32 @@ void GatherScatter::scatter(parallel::Field<DATA_TYPE const> gfields[], parallel
         const size_t glb_size = glb_cnt(root) * gvar_size;
         std::vector<DATA_TYPE, pluto::host::allocator<DATA_TYPE>> loc_buffer(loc_size);
         std::vector<DATA_TYPE, pluto::host::allocator<DATA_TYPE>> glb_buffer(glb_size);
-        std::vector<int> glb_displs(nproc);
-        std::vector<int> glb_counts(nproc);
 
         for (idx_t jproc = 0; jproc < nproc; ++jproc) {
             glb_counts[jproc] = glbcounts_[jproc] * gvar_size;
             glb_displs[jproc] = glbdispls_[jproc] * gvar_size;
         }
 
+#if !defined(NDEBUG)
+        validate_field_and_map("GatherScatter::scatter local field", lfields[jfield], locmap_, parsize_, loccnt_, loc_size);
+        if (myproc == root) {
+            validate_field_and_map("GatherScatter::scatter global field", gfields[jfield], glbmap_, glb_cnt(root), glb_cnt(root), glb_size);
+        }
+#endif
+
         /// Pack
         if (myproc == root) {
-            pack_send_buffer(gfields[jfield], glbmap_, glb_buffer.data());
+            pack_send_buffer(gfields[jfield], glbmap_, glb_buffer.data(), glb_size);
         }
 
         /// Scatter
-
         ATLAS_TRACE_MPI(SCATTER) {
             comm().scatterv(glb_buffer.begin(), glb_buffer.end(), glb_counts, glb_displs, loc_buffer.begin(),
                             loc_buffer.end(), root);
         }
 
         /// Unpack
-        unpack_recv_buffer(locmap_, loc_buffer.data(), lfields[jfield]);
+        unpack_recv_buffer(locmap_, loc_buffer.data(), loc_size, lfields[jfield]);
     }
 }
 
@@ -335,10 +352,88 @@ void GatherScatter::scatter(const DATA_TYPE gdata[], const idx_t gvar_strides[],
     scatter(&gfield, &lfield, 1, root);
 }
 
+template <typename FIELD>
+void GatherScatter::validate_field_and_map(const char* context, const FIELD& field, const std::vector<int>& map,
+                                           idx_t field_point_count, idx_t buffer_point_count, size_t buffer_size) const {
+    auto format_idx_vector = [](const auto& values) {
+        std::ostringstream out;
+        out << '[';
+        for (size_t idx = 0; idx < values.size(); ++idx) {
+            if (idx > 0) {
+                out << ',';
+            }
+            out << values[idx];
+        }
+        out << ']';
+        return out.str();
+    };
+
+    auto base_message = [&]() {
+        std::ostringstream out;
+        out << context << ": "
+            << "var_rank=" << field.var_rank
+            << ", var_shape=" << format_idx_vector(field.var_shape)
+            << ", var_strides=" << format_idx_vector(field.var_strides)
+            << ", map_size=" << map.size()
+            << ", field_point_count=" << field_point_count
+            << ", buffer_point_count=" << buffer_point_count
+            << ", buffer_size=" << buffer_size
+            << ", data=" << static_cast<const void*>(field.data);
+        return out.str();
+    };
+
+    if (field.var_rank < 1 || field.var_rank > 3) {
+        throw_Exception(base_message() + ", unsupported field rank", Here());
+    }
+    if (field.var_shape.size() != static_cast<size_t>(field.var_rank) ||
+        field.var_strides.size() != static_cast<size_t>(field.var_rank)) {
+        throw_Exception(base_message() + ", invalid field metadata", Here());
+    }
+
+    idx_t per_point_size = 1;
+    for (idx_t dim = 0; dim < field.var_rank; ++dim) {
+        if (field.var_shape[dim] < 0) {
+            std::ostringstream out;
+            out << base_message() << ", invalid field shape at dim=" << dim << ", value=" << field.var_shape[dim];
+            throw_Exception(out.str(), Here());
+        }
+        per_point_size *= field.var_shape[dim];
+    }
+
+    const size_t expected_buffer_size = static_cast<size_t>(buffer_point_count * per_point_size);
+    if (expected_buffer_size != buffer_size) {
+        std::ostringstream out;
+        out << base_message() << ", inconsistent buffer size, expected_buffer_size=" << expected_buffer_size
+            << ", per_point_size=" << per_point_size;
+        throw_Exception(out.str(), Here());
+    }
+    if (buffer_size > 0 && field.data == nullptr) {
+        throw_Exception(base_message() + ", field data pointer is null", Here());
+    }
+    if (buffer_size > 0 && per_point_size > 0 && field_point_count == 0) {
+        std::ostringstream out;
+        out << base_message() << ", non-empty buffer with zero field extent, per_point_size=" << per_point_size;
+        throw_Exception(out.str(), Here());
+    }
+
+    for (size_t map_idx = 0; map_idx < map.size(); ++map_idx) {
+        const int mapped_point = map[map_idx];
+        if (mapped_point < 0 || static_cast<idx_t>(mapped_point) >= field_point_count) {
+            std::ostringstream out;
+            out << base_message() << ", map index out of range at map_idx=" << map_idx
+                << ", mapped_point=" << mapped_point;
+            throw_Exception(out.str(), Here());
+        }
+    }
+}
+
 template <typename DATA_TYPE>
 void GatherScatter::pack_send_buffer(const parallel::Field<DATA_TYPE const>& field, const std::vector<int>& sendmap,
-                                     DATA_TYPE send_buffer[]) const {
+                                     DATA_TYPE send_buffer[], size_t send_buffer_size) const {
     const idx_t sendcnt = static_cast<idx_t>(sendmap.size());
+    const idx_t send_buffer_elements =
+        std::accumulate(field.var_shape.begin(), field.var_shape.end(), idx_t{1}, std::multiplies<idx_t>()) * sendcnt;
+    ATLAS_ASSERT(static_cast<size_t>(send_buffer_elements) == send_buffer_size);
 
     idx_t ibuf              = 0;
     const idx_t send_stride = field.var_strides[0] * field.var_shape[0];
@@ -381,12 +476,18 @@ void GatherScatter::pack_send_buffer(const parallel::Field<DATA_TYPE const>& fie
         default:
             ATLAS_NOTIMPLEMENTED;
     }
+
+    ATLAS_ASSERT(static_cast<size_t>(ibuf) == send_buffer_size);
 }
 
 template <typename DATA_TYPE>
 void GatherScatter::unpack_recv_buffer(const std::vector<int>& recvmap, const DATA_TYPE recv_buffer[],
+                                       size_t recv_buffer_size,
                                        const parallel::Field<DATA_TYPE>& field) const {
     const idx_t recvcnt = static_cast<idx_t>(recvmap.size());
+    const idx_t recv_buffer_elements =
+        std::accumulate(field.var_shape.begin(), field.var_shape.end(), idx_t{1}, std::multiplies<idx_t>()) * recvcnt;
+    ATLAS_ASSERT(static_cast<size_t>(recv_buffer_elements) == recv_buffer_size);
 
     size_t ibuf             = 0;
     const idx_t recv_stride = field.var_strides[0] * field.var_shape[0];
@@ -428,6 +529,8 @@ void GatherScatter::unpack_recv_buffer(const std::vector<int>& recvmap, const DA
         default:
             ATLAS_NOTIMPLEMENTED;
     }
+
+    ATLAS_ASSERT(ibuf == recv_buffer_size);
 }
 
 template <typename DATA_TYPE, int RANK>

--- a/src/tests/parallel/test_gather.cc
+++ b/src/tests/parallel/test_gather.cc
@@ -30,6 +30,7 @@ namespace atlas {
 namespace test {
 
 constexpr size_t MB = 1024 * 1024;
+constexpr size_t GB = 1024 * MB;
 
 size_t peakMemory() {
     return eckit::system::ResourceUsage().maxResidentSetSize();
@@ -744,32 +745,33 @@ CASE("test_gather") {
 
 CASE("test_gather_sparse_global_indices") {
     SparseGlobalIndexFixture f;
-    constexpr size_t sparse_global_index_memory_limit = 256 * MB;
+    // The fixture includes global-index 14399999990.
+    // An 64-bit-value array of this size (a global gathered field) would
+    // require more than 100GB.
+    constexpr size_t sparse_global_index_memory_limit = 10 * GB; // less than 100 GB
 
-    SECTION("test_gather_rank0_sparse_global_indices") {
-        EXPECT(peakMemory() < sparse_global_index_memory_limit);
+    for (f.root = 0; f.root < f.comm_size; ++f.root) {
+        std::vector<POD> loc(f.Nl);
+        std::vector<POD> glb(f.Ng());
 
-        for (f.root = 0; f.root < f.comm_size; ++f.root) {
-            std::vector<POD> loc(f.Nl);
-            std::vector<POD> glb(f.Ng());
+        for (int j = 0; j < f.Nl; ++j) {
+            loc[j] = (idx_t(f.part[j]) != f.rank ? -1. : f.gidx[j] * 10.);
+        }
 
-            for (int j = 0; j < f.Nl; ++j) {
-                loc[j] = (idx_t(f.part[j]) != f.rank ? -1. : f.gidx[j] * 10.);
-            }
+        idx_t strides[] = {1};
+        idx_t extents[] = {1};
+        f.gather_scatter.gather(loc.data(), strides, extents, 1, glb.data(), strides, extents, 1, f.root);
 
-            idx_t strides[] = {1};
-            idx_t extents[] = {1};
-            f.gather_scatter.gather(loc.data(), strides, extents, 1, glb.data(), strides, extents, 1, f.root);
-            EXPECT(peakMemory() < sparse_global_index_memory_limit);
+        EXPECT(f.gather_scatter.glb_dof() == 6);
 
-            EXPECT(f.gather_scatter.glb_dof() == 6);
-
-            if (f.rank == f.root) {
-                POD glb_c[] = {100, 200, 300, 400, 500, 14399999990.};
-                EXPECT(glb == eckit::testing::make_view(glb_c, glb_c + f.Ng()));
-            }
+        if (f.rank == f.root) {
+            POD glb_c[] = {100, 200, 300, 400, 500, 14399999990.};
+            EXPECT(glb == eckit::testing::make_view(glb_c, glb_c + f.Ng()));
         }
     }
+
+    Log::warning() << "test_gather_sparse_global_indices: peak memory usage = " << peakMemory() / MB << " MB" << std::endl;
+    EXPECT(peakMemory() < sparse_global_index_memory_limit);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/tests/parallel/test_gather.cc
+++ b/src/tests/parallel/test_gather.cc
@@ -18,6 +18,7 @@
 #include "atlas/library/config.h"
 #include "atlas/parallel/GatherScatter.h"
 #include "atlas/parallel/mpi/mpi.h"
+#include "eckit/system/ResourceUsage.h"
 #include "eckit/utils/Translator.h"
 
 #include "tests/AtlasTestEnvironment.h"
@@ -27,6 +28,12 @@ using POD = double;
 
 namespace atlas {
 namespace test {
+
+constexpr size_t MB = 1024 * 1024;
+
+size_t peakMemory() {
+    return eckit::system::ResourceUsage().maxResidentSetSize();
+}
 
 //-----------------------------------------------------------------------------
 
@@ -73,6 +80,59 @@ struct Fixture {
         }
         gather_scatter.setup(part.data(), ridx.data(), 0, gidx.data(), Nl);
     }
+    parallel::GatherScatter gather_scatter;
+    std::vector<int> nb_nodes;
+    std::vector<int> part;
+    std::vector<idx_t> ridx;
+    std::vector<gidx_t> gidx;
+
+    int Nl;
+    int root;
+    int rank;
+    int comm_size;
+
+    int Ng() { return rank == root ? gather_scatter.glb_dof() : 0; }
+};
+
+struct SparseGlobalIndexFixture {
+    SparseGlobalIndexFixture() {
+        rank      = static_cast<int>(mpi::comm().rank());
+        comm_size = static_cast<int>(mpi::comm().size());
+        int nnodes_c[] = {4, 4, 4};
+        nb_nodes       = vec(nnodes_c);
+        Nl             = nb_nodes[rank];
+        switch (rank) {
+            case 0: {
+                int part_c[]    = {0, 0, 1, 2};
+                part            = vec(part_c);
+                idx_t ridx_c[]  = {0, 1, 0, 0};
+                ridx            = vec(ridx_c);
+                gidx_t gidx_c[] = {10, 30, 20, 40};
+                gidx            = vec(gidx_c);
+                break;
+            }
+            case 1: {
+                int part_c[]    = {1, 1, 0, 2};
+                part            = vec(part_c);
+                idx_t ridx_c[]  = {0, 1, 1, 1};
+                ridx            = vec(ridx_c);
+                gidx_t gidx_c[] = {20, 50, 30, 1439999999};
+                gidx            = vec(gidx_c);
+                break;
+            }
+            case 2: {
+                int part_c[]    = {2, 2, 0, 1};
+                part            = vec(part_c);
+                idx_t ridx_c[]  = {0, 1, 0, 1};
+                ridx            = vec(ridx_c);
+                gidx_t gidx_c[] = {40, 1439999999, 10, 50};
+                gidx            = vec(gidx_c);
+                break;
+            }
+        }
+        gather_scatter.setup(part.data(), ridx.data(), 0, gidx.data(), Nl);
+    }
+
     parallel::GatherScatter gather_scatter;
     std::vector<int> nb_nodes;
     std::vector<int> part;
@@ -677,6 +737,36 @@ CASE("test_gather") {
                     }
                     break;
                 }
+            }
+        }
+    }
+}
+
+CASE("test_gather_sparse_global_indices") {
+    SparseGlobalIndexFixture f;
+    constexpr size_t sparse_global_index_memory_limit = 256 * MB;
+
+    SECTION("test_gather_rank0_sparse_global_indices") {
+        EXPECT(peakMemory() < sparse_global_index_memory_limit);
+
+        for (f.root = 0; f.root < f.comm_size; ++f.root) {
+            std::vector<POD> loc(f.Nl);
+            std::vector<POD> glb(f.Ng());
+
+            for (int j = 0; j < f.Nl; ++j) {
+                loc[j] = (idx_t(f.part[j]) != f.rank ? -1. : f.gidx[j] * 10.);
+            }
+
+            idx_t strides[] = {1};
+            idx_t extents[] = {1};
+            f.gather_scatter.gather(loc.data(), strides, extents, 1, glb.data(), strides, extents, 1, f.root);
+            EXPECT(peakMemory() < sparse_global_index_memory_limit);
+
+            EXPECT(f.gather_scatter.glb_dof() == 6);
+
+            if (f.rank == f.root) {
+                POD glb_c[] = {100, 200, 300, 400, 500, 14399999990.};
+                EXPECT(glb == eckit::testing::make_view(glb_c, glb_c + f.Ng()));
             }
         }
     }


### PR DESCRIPTION
This pull request introduces significant improvements to the `GatherScatter` class, focusing on robust handling of sparse global indices, enhanced validation and safety in gather/scatter operations, and improved test coverage. The main changes include a new mechanism for supporting non-dense (sparse) global indices, extensive buffer and field validation (especially in debug builds), and new tests to ensure correctness and memory efficiency.

**Key changes:**

### Support for Sparse Global Indices

* Refactored the `GatherScatter::setup` method to robustly handle both dense and sparse global indices, introducing logic to detect when indices are not dense and to normalize or compact them as needed. This avoids large memory allocations and ensures correct mapping for gather/scatter operations. (`src/atlas/parallel/GatherScatter.cc` [[1]](diffhunk://#diff-b8966e8d01ae1f9d38407002fe8e1f234a973a52298ffbee85cbdd00fa6cff96L131-R137) [[2]](diffhunk://#diff-b8966e8d01ae1f9d38407002fe8e1f234a973a52298ffbee85cbdd00fa6cff96L155-R155) [[3]](diffhunk://#diff-b8966e8d01ae1f9d38407002fe8e1f234a973a52298ffbee85cbdd00fa6cff96L176-R176) [[4]](diffhunk://#diff-b8966e8d01ae1f9d38407002fe8e1f234a973a52298ffbee85cbdd00fa6cff96L196-R237) [[5]](diffhunk://#diff-b8966e8d01ae1f9d38407002fe8e1f234a973a52298ffbee85cbdd00fa6cff96L237-R276)

### Validation and Safety Enhancements

* Added the `validate_field_and_map` method, which performs thorough checks on field metadata, buffer sizes, and mapping indices to catch inconsistencies or invalid memory access in debug builds. This validation is now called in both `gather` and `scatter` methods. (`src/atlas/parallel/GatherScatter.h` [[1]](diffhunk://#diff-3ea9e06338d8584745fb56a5630e88295e071eb09d645405f61f1dc37c3de7f8R193-R202) [[2]](diffhunk://#diff-3ea9e06338d8584745fb56a5630e88295e071eb09d645405f61f1dc37c3de7f8R246-R247) [[3]](diffhunk://#diff-3ea9e06338d8584745fb56a5630e88295e071eb09d645405f61f1dc37c3de7f8L252-R282) [[4]](diffhunk://#diff-3ea9e06338d8584745fb56a5630e88295e071eb09d645405f61f1dc37c3de7f8R303-R305) [[5]](diffhunk://#diff-3ea9e06338d8584745fb56a5630e88295e071eb09d645405f61f1dc37c3de7f8L304-R342) [[6]](diffhunk://#diff-3ea9e06338d8584745fb56a5630e88295e071eb09d645405f61f1dc37c3de7f8R355-R436)

* Modified `pack_send_buffer` and `unpack_recv_buffer` to require and check buffer sizes, asserting that the number of packed/unpacked elements matches expectations, further improving safety. (`src/atlas/parallel/GatherScatter.h` [[1]](diffhunk://#diff-3ea9e06338d8584745fb56a5630e88295e071eb09d645405f61f1dc37c3de7f8R479-R490) [[2]](diffhunk://#diff-3ea9e06338d8584745fb56a5630e88295e071eb09d645405f61f1dc37c3de7f8R532-R533)

### Testing Improvements

* Added a new `SparseGlobalIndexFixture` and a dedicated `test_gather_sparse_global_indices` test case to ensure correct gather/scatter behavior and controlled memory usage when working with highly sparse global indices. (`src/tests/parallel/test_gather.cc` [[1]](diffhunk://#diff-65758b811f4d398647953367c1f7743a591669e899ea52cd24b1fe10310943f3R97-R149) [[2]](diffhunk://#diff-65758b811f4d398647953367c1f7743a591669e899ea52cd24b1fe10310943f3R745-R774)

* Introduced utility functions for measuring peak memory usage in tests, supporting verification of memory efficiency. (`src/tests/parallel/test_gather.cc` [[1]](diffhunk://#diff-65758b811f4d398647953367c1f7743a591669e899ea52cd24b1fe10310943f3R21) [[2]](diffhunk://#diff-65758b811f4d398647953367c1f7743a591669e899ea52cd24b1fe10310943f3R32-R37)

### Minor Code Quality Improvements

* Added necessary includes (`<sstream>`) and improved code organization for clarity and maintainability. (`src/atlas/parallel/GatherScatter.h` [src/atlas/parallel/GatherScatter.hR14](diffhunk://#diff-3ea9e06338d8584745fb56a5630e88295e071eb09d645405f61f1dc37c3de7f8R14))

Overall, these changes make the gather/scatter operations more robust, especially in scenarios with irregular or sparse data layouts, and provide better diagnostics and safer execution in development builds.

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-387
<!-- STATIC-ANALYSIS_END -->