### PR TITLE
Implement new checksum for Node, Cell, and Edge Columns matching (Block)StructuredColumns

### DIFF
--- a/src/atlas/functionspace/CellColumns.cc
+++ b/src/atlas/functionspace/CellColumns.cc
@@ -15,6 +15,7 @@
 #include "eckit/utils/MD5.h"
 
 #include "atlas/array/MakeView.h"
+#include "atlas/functionspace/detail/ColumnChecksum.h"
 #include "atlas/functionspace/CellColumns.h"
 #include "atlas/grid/UnstructuredGrid.h"
 #include "atlas/library/config.h"
@@ -496,115 +497,18 @@ void CellColumns::scatter(const Field& global, Field& local) const {
     scatter(global_fields, local_fields);
 }
 
-namespace {
-template <typename T>
-std::string checksum_3d_field(const parallel::Checksum& checksum, const Field& field) {
-    auto values = array::make_view<const T, 3>(field);
-    array::ArrayT<T> surface_field(field.shape(0), field.shape(2));
-    auto surface = array::make_view<T, 2>(surface_field);
-    for (idx_t n = 0; n < values.shape(0); ++n) {
-        for (idx_t j = 0; j < surface.shape(1); ++j) {
-            surface(n, j) = 0.;
-            for (idx_t l = 0; l < values.shape(1); ++l) {
-                surface(n, j) += values(n, l, j);
-            }
-        }
-    }
-    return checksum.execute(surface.data(), surface_field.stride(0));
-}
-template <typename T>
-std::string checksum_2d_field(const parallel::Checksum& checksum, const Field& field) {
-    auto values = array::make_view<T, 2>(field);
-    return checksum.execute(values.data(), field.stride(0));
-}
-template <typename T>
-std::string checksum_1d_field(const parallel::Checksum& checksum, const Field& field) {
-    auto values = array::make_view<T, 1>(field);
-    return checksum.execute(values.data(), 1);
-}
-
-}  // namespace
-
 std::string CellColumns::checksum(const FieldSet& fieldset) const {
-    eckit::MD5 md5;
-    for (idx_t f = 0; f < fieldset.size(); ++f) {
-        const Field& field = fieldset[f];
-        std::string field_checksum;
-        if (field.datatype() == array::DataType::kind<int>()) {
-            if (field.rank()==3) {
-                field_checksum = checksum_3d_field<int>(checksum(), field);
-            }
-            else if (field.rank()==2) {
-                field_checksum = checksum_2d_field<int>(checksum(), field);
-            }
-            else if (field.rank()==1) {
-                field_checksum = checksum_1d_field<int>(checksum(), field);
-            }
-            else {
-                ATLAS_NOTIMPLEMENTED;
-            }
-        }
-        else if (field.datatype() == array::DataType::kind<long>()) {
-            if (field.rank()==3) {
-                field_checksum = checksum_3d_field<long>(checksum(), field);
-            }
-            else if (field.rank()==2) {
-                field_checksum = checksum_2d_field<long>(checksum(), field);
-            }
-            else if (field.rank()==1) {
-                field_checksum = checksum_1d_field<long>(checksum(), field);
-            }
-            else {
-                ATLAS_NOTIMPLEMENTED;
-            }
-        }
-        else if (field.datatype() == array::DataType::kind<float>()) {
-            if (field.rank()==3) {
-                field_checksum = checksum_3d_field<float>(checksum(), field);
-            }
-            else if (field.rank()==2) {
-                field_checksum = checksum_2d_field<float>(checksum(), field);
-            }
-            else if (field.rank()==1) {
-                field_checksum = checksum_1d_field<float>(checksum(), field);
-            }
-            else {
-                ATLAS_NOTIMPLEMENTED;
-            }
-        }
-        else if (field.datatype() == array::DataType::kind<double>()) {
-            if (field.rank()==3) {
-                field_checksum = checksum_3d_field<double>(checksum(), field);
-            }
-            else if (field.rank()==2) {
-                field_checksum = checksum_2d_field<double>(checksum(), field);
-            }
-            else if (field.rank()==1) {
-                field_checksum = checksum_1d_field<double>(checksum(), field);
-            }
-            else {
-                ATLAS_NOTIMPLEMENTED;
-            }
-        }
-        else {
-            throw_Exception("datatype not supported", Here());
-        }
-        if (fieldset.size() == 1) {
-            return field_checksum;
-        }
-        else {
-            md5 << field_checksum;
-        }
-    }
-    return md5;
+    return ColumnChecksum<CellColumns>(*this, static_cast<size_t>(nb_cells_global())).compute(fieldset);
 }
 std::string CellColumns::checksum(const Field& field) const {
-    FieldSet fieldset;
-    fieldset.add(field);
-    return checksum(fieldset);
+    return ColumnChecksum<CellColumns>(*this, static_cast<size_t>(nb_cells_global())).compute(field);
 }
 
 const parallel::Checksum& CellColumns::checksum() const {
+    return deprecated_checksum();
+}
+
+const parallel::Checksum& CellColumns::deprecated_checksum() const {
     if (checksum_) {
         return *checksum_;
     }
@@ -846,7 +750,7 @@ void atlas__fs__CellColumns__scatter_field(const CellColumns* This, const field:
 
 const parallel::Checksum* atlas__fs__CellColumns__get_checksum(const CellColumns* This) {
     ATLAS_ASSERT(This);
-    return &This->checksum();
+    return &This->deprecated_checksum();
 }
 
 // -----------------------------------------------------------------------------------
@@ -893,14 +797,6 @@ const mesh::HybridElements& CellColumns::cells() const {
 
 const parallel::HaloExchange& CellColumns::halo_exchange() const {
     return functionspace_->halo_exchange();
-}
-
-std::string CellColumns::checksum(const FieldSet& fieldset) const {
-    return functionspace_->checksum(fieldset);
-}
-
-std::string CellColumns::checksum(const Field& field) const {
-    return functionspace_->checksum(field);
 }
 
 const parallel::Checksum& CellColumns::checksum() const {

--- a/src/atlas/functionspace/CellColumns.cc
+++ b/src/atlas/functionspace/CellColumns.cc
@@ -800,7 +800,7 @@ const parallel::HaloExchange& CellColumns::halo_exchange() const {
 }
 
 const parallel::Checksum& CellColumns::checksum() const {
-    return functionspace_->checksum();
+    return functionspace_->deprecated_checksum();
 }
 
 const mesh::Halo& CellColumns::halo() const {

--- a/src/atlas/functionspace/CellColumns.h
+++ b/src/atlas/functionspace/CellColumns.h
@@ -85,7 +85,12 @@ public:
 
     std::string checksum(const FieldSet&) const override;
     std::string checksum(const Field&) const override;
+
+    [[deprecated("Use FunctionSpaceImpl::checksum(const FieldSet&) or FunctionSpaceImpl::checksum(const Field&) instead")]]
     const parallel::Checksum& checksum() const;
+
+    // Just for internal API at the moment. DO NOT USE!
+    const parallel::Checksum& deprecated_checksum() const;
 
     idx_t size() const override { return nb_cells_; }
 
@@ -190,8 +195,9 @@ public:
 
     const parallel::HaloExchange& halo_exchange() const;
 
-    std::string checksum(const FieldSet&) const;
-    std::string checksum(const Field&) const;
+    using FunctionSpace::checksum;
+
+    [[deprecated("Use FunctionSpace::checksum(const FieldSet&) or FunctionSpace::checksum(const Field&) instead")]]
     const parallel::Checksum& checksum() const;
 
 private:

--- a/src/atlas/functionspace/EdgeColumns.cc
+++ b/src/atlas/functionspace/EdgeColumns.cc
@@ -16,6 +16,7 @@
 
 #include "atlas/array/MakeView.h"
 #include "atlas/field/detail/FieldImpl.h"
+#include "atlas/functionspace/detail/ColumnChecksum.h"
 #include "atlas/functionspace/EdgeColumns.h"
 #include "atlas/grid/UnstructuredGrid.h"
 #include "atlas/library/config.h"
@@ -486,79 +487,18 @@ void EdgeColumns::scatter(const Field& global, Field& local) const {
     scatter(global_fields, local_fields);
 }
 
-namespace {
-template <typename T>
-std::string checksum_3d_field(const parallel::Checksum& checksum, const Field& field) {
-    auto values = array::make_view<T, 3>(field);
-    array::ArrayT<T> surface_field(field.shape(0), field.shape(2));
-    auto surface = array::make_view<T, 2>(surface_field);
-    for (idx_t n = 0; n < values.shape(0); ++n) {
-        for (idx_t j = 0; j < surface.shape(1); ++j) {
-            surface(n, j) = 0.;
-            for (idx_t l = 0; l < values.shape(1); ++l) {
-                surface(n, j) += values(n, l, j);
-            }
-        }
-    }
-    return checksum.execute(surface.data(), surface_field.stride(0));
-}
-template <typename T>
-std::string checksum_2d_field(const parallel::Checksum& checksum, const Field& field) {
-    auto values = array::make_view<T, 2>(field);
-    return checksum.execute(values.data(), field.stride(0));
-}
-
-}  // namespace
-
 std::string EdgeColumns::checksum(const FieldSet& fieldset) const {
-    eckit::MD5 md5;
-    for (idx_t f = 0; f < fieldset.size(); ++f) {
-        const Field& field = fieldset[f];
-        if (field.datatype() == array::DataType::kind<int>()) {
-            if (field.levels()) {
-                md5 << checksum_3d_field<int>(checksum(), field);
-            }
-            else {
-                md5 << checksum_2d_field<int>(checksum(), field);
-            }
-        }
-        else if (field.datatype() == array::DataType::kind<long>()) {
-            if (field.levels()) {
-                md5 << checksum_3d_field<long>(checksum(), field);
-            }
-            else {
-                md5 << checksum_2d_field<long>(checksum(), field);
-            }
-        }
-        else if (field.datatype() == array::DataType::kind<float>()) {
-            if (field.levels()) {
-                md5 << checksum_3d_field<float>(checksum(), field);
-            }
-            else {
-                md5 << checksum_2d_field<float>(checksum(), field);
-            }
-        }
-        else if (field.datatype() == array::DataType::kind<double>()) {
-            if (field.levels()) {
-                md5 << checksum_3d_field<double>(checksum(), field);
-            }
-            else {
-                md5 << checksum_2d_field<double>(checksum(), field);
-            }
-        }
-        else {
-            throw_Exception("datatype not supported", Here());
-        }
-    }
-    return md5;
+    return ColumnChecksum<EdgeColumns>(*this, static_cast<size_t>(nb_edges_global())).compute(fieldset);
 }
 std::string EdgeColumns::checksum(const Field& field) const {
-    FieldSet fieldset;
-    fieldset.add(field);
-    return checksum(fieldset);
+    return ColumnChecksum<EdgeColumns>(*this, static_cast<size_t>(nb_edges_global())).compute(field);
 }
 
 const parallel::Checksum& EdgeColumns::checksum() const {
+    return deprecated_checksum();
+}
+
+const parallel::Checksum& EdgeColumns::deprecated_checksum() const {
     if (checksum_) {
         return *checksum_;
     }
@@ -608,6 +548,13 @@ const Grid& EdgeColumns::grid() const {
 
 Field EdgeColumns::lonlat() const {
     return edges().field("lonlat");
+}
+
+Field EdgeColumns::ghost() const {
+    if (mesh_.edges().has_field("ghost")) {
+        return mesh_.edges().field("ghost");
+    }
+    return mesh_.edges().halo();
 }
 
 Field EdgeColumns::global_index() const {
@@ -790,7 +737,7 @@ void atlas__fs__EdgeColumns__scatter_field(const EdgeColumns* This, const field:
 
 const parallel::Checksum* atlas__fs__EdgeColumns__get_checksum(const EdgeColumns* This) {
     ATLAS_ASSERT(This);
-    return &This->checksum();
+    return &This->deprecated_checksum();
 }
 
 // -----------------------------------------------------------------------------------
@@ -833,14 +780,6 @@ const mesh::HybridElements& EdgeColumns::edges() const {
 
 const parallel::HaloExchange& EdgeColumns::halo_exchange() const {
     return functionspace_->halo_exchange();
-}
-
-std::string EdgeColumns::checksum(const FieldSet& fieldset) const {
-    return functionspace_->checksum(fieldset);
-}
-
-std::string EdgeColumns::checksum(const Field& field) const {
-    return functionspace_->checksum(field);
 }
 
 const parallel::Checksum& EdgeColumns::checksum() const {

--- a/src/atlas/functionspace/EdgeColumns.cc
+++ b/src/atlas/functionspace/EdgeColumns.cc
@@ -783,7 +783,7 @@ const parallel::HaloExchange& EdgeColumns::halo_exchange() const {
 }
 
 const parallel::Checksum& EdgeColumns::checksum() const {
-    return functionspace_->checksum();
+    return functionspace_->deprecated_checksum();
 }
 
 }  // namespace functionspace

--- a/src/atlas/functionspace/EdgeColumns.h
+++ b/src/atlas/functionspace/EdgeColumns.h
@@ -81,13 +81,20 @@ public:
 
     std::string checksum(const FieldSet&) const override;
     std::string checksum(const Field&) const override;
+
+    [[deprecated("Use FunctionSpaceImpl::checksum(const FieldSet&) or FunctionSpaceImpl::checksum(const Field&) instead")]]
     const parallel::Checksum& checksum() const;
+
+    // Just for internal API at the moment. DO NOT USE!
+    const parallel::Checksum& deprecated_checksum() const;
 
     idx_t size() const override { return nb_edges_; }
 
     const Grid& grid() const override;
 
     Field lonlat() const override;
+
+    Field ghost() const override;
 
     Field global_index() const override;
 
@@ -176,8 +183,9 @@ public:
     // -- Parallelisation aware methods
     const parallel::HaloExchange& halo_exchange() const;
 
-    std::string checksum(const FieldSet&) const;
-    std::string checksum(const Field&) const;
+    using FunctionSpace::checksum;
+
+    [[deprecated("Use FunctionSpace::checksum(const FieldSet&) or FunctionSpace::checksum(const Field&) instead")]]
     const parallel::Checksum& checksum() const;
 
 private:

--- a/src/atlas/functionspace/NodeColumns.cc
+++ b/src/atlas/functionspace/NodeColumns.cc
@@ -713,7 +713,7 @@ const parallel::HaloExchange& NodeColumns::halo_exchange() const {
 }
 
 const parallel::Checksum& NodeColumns::checksum() const {
-    return functionspace_->checksum();
+    return functionspace_->deprecated_checksum();
 }
 
 }  // namespace functionspace

--- a/src/atlas/functionspace/NodeColumns.cc
+++ b/src/atlas/functionspace/NodeColumns.cc
@@ -11,11 +11,12 @@
 //#include <cstdarg>
 //#include <functional>
 
-#include "eckit/utils/MD5.h"
+#include "pluto/pluto.h"
 
 #include "atlas/array.h"
 #include "atlas/field/Field.h"
 #include "atlas/field/FieldSet.h"
+#include "atlas/functionspace/detail/ColumnChecksum.h"
 #include "atlas/functionspace/NodeColumns.h"
 #include "atlas/grid/Grid.h"
 #include "atlas/grid/UnstructuredGrid.h"
@@ -32,6 +33,7 @@
 #include "atlas/parallel/omp/omp.h"
 #include "atlas/runtime/Exception.h"
 #include "atlas/runtime/Trace.h"
+#include "atlas/util/Checksum.h"
 #include "atlas/util/detail/Cache.h"
 
 #if ATLAS_HAVE_FORTRAN
@@ -572,60 +574,25 @@ void NodeColumns::scatter(const Field& global, Field& local) const {
     scatter(global_fields, local_fields);
 }
 
-namespace {
-template <typename T>
-std::string checksum_3d_field(const parallel::Checksum& checksum, const Field& field) {
-    auto values = make_leveled_view<const T>(field);
-    array::ArrayT<T> surface_field(values.shape(0), values.shape(2));
-    auto surface     = array::make_view<T, 2>(surface_field);
-    const idx_t npts = values.shape(0);
-    atlas_omp_for(idx_t n = 0; n < npts; ++n) {
-        for (idx_t j = 0; j < surface.shape(1); ++j) {
-            surface(n, j) = 0.;
-            for (idx_t l = 0; l < values.shape(1); ++l) {
-                surface(n, j) += values(n, l, j);
-            }
-        }
-    }
-    return checksum.execute(surface.data(), surface_field.stride(0));
-}
-}  // namespace
-
 std::string NodeColumns::checksum(const FieldSet& fieldset) const {
-    eckit::MD5 md5;
-    for (idx_t f = 0; f < fieldset.size(); ++f) {
-        const Field& field = fieldset[f];
-        if (field.datatype() == array::DataType::kind<int>()) {
-            md5 << checksum_3d_field<int>(checksum(), field);
-        }
-        else if (field.datatype() == array::DataType::kind<long>()) {
-            md5 << checksum_3d_field<long>(checksum(), field);
-        }
-        else if (field.datatype() == array::DataType::kind<float>()) {
-            md5 << checksum_3d_field<float>(checksum(), field);
-        }
-        else if (field.datatype() == array::DataType::kind<double>()) {
-            md5 << checksum_3d_field<double>(checksum(), field);
-        }
-        else {
-            throw_Exception("datatype not supported", Here());
-        }
-    }
-    return md5;
+    return ColumnChecksum<NodeColumns>(*this, static_cast<size_t>(nb_nodes_global())).compute(fieldset);
 }
 std::string NodeColumns::checksum(const Field& field) const {
-    FieldSet fieldset;
-    fieldset.add(field);
-    return checksum(fieldset);
+    return ColumnChecksum<NodeColumns>(*this, static_cast<size_t>(nb_nodes_global())).compute(field);
 }
 
 const parallel::Checksum& NodeColumns::checksum() const {
+    return deprecated_checksum();
+}
+
+const parallel::Checksum& NodeColumns::deprecated_checksum() const {
     if (checksum_) {
         return *checksum_;
     }
     checksum_ = NodeColumnsChecksumCache::instance().get_or_create(mesh_);
     return *checksum_;
 }
+
 
 // std::string NodesFunctionSpace::checksum( const FieldSet& fieldset ) const {
 //  const parallel::Checksum& checksum = mesh_.checksum().get(checksum_name());
@@ -743,14 +710,6 @@ void NodeColumns::haloExchange(const Field& field, bool on_device) const {
 
 const parallel::HaloExchange& NodeColumns::halo_exchange() const {
     return functionspace_->halo_exchange();
-}
-
-std::string NodeColumns::checksum(const FieldSet& fieldset) const {
-    return functionspace_->checksum(fieldset);
-}
-
-std::string NodeColumns::checksum(const Field& field) const {
-    return functionspace_->checksum(field);
 }
 
 const parallel::Checksum& NodeColumns::checksum() const {

--- a/src/atlas/functionspace/NodeColumns.h
+++ b/src/atlas/functionspace/NodeColumns.h
@@ -98,7 +98,13 @@ public:
 
     std::string checksum(const FieldSet&) const override;
     std::string checksum(const Field&) const override;
+
+
+    [[deprecated("Use FunctionSpaceImpl::checksum(const FieldSet&) or FunctionSpaceImpl::checksum(const Field&) instead")]]
     const parallel::Checksum& checksum() const;
+
+    // Just for internal API at the moment. DO NOT USE!
+    const parallel::Checksum& deprecated_checksum() const;
 
     /// @brief Compute sum of scalar field
     /// @param [out] sum    Scalar value containing the sum of the full 3D field
@@ -506,8 +512,9 @@ public:
     void haloExchange(const Field&, bool on_device = false) const;
     const parallel::HaloExchange& halo_exchange() const;
 
-    std::string checksum(const FieldSet&) const;
-    std::string checksum(const Field&) const;
+    using FunctionSpace::checksum;
+
+    [[deprecated("Use FunctionSpace::checksum(const FieldSet&) or FunctionSpace::checksum(const Field&) instead")]]
     const parallel::Checksum& checksum() const;
 
     /// @brief Compute sum of scalar field

--- a/src/atlas/functionspace/detail/CellColumnsInterface.cc
+++ b/src/atlas/functionspace/detail/CellColumnsInterface.cc
@@ -123,7 +123,7 @@ void atlas__CellsFunctionSpace__scatter_field(const CellColumns* This, const fie
 
 const parallel::Checksum* atlas__CellsFunctionSpace__get_checksum(const CellColumns* This) {
     ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_functionspace_CellColumns");
-    return &This->checksum();
+    return &This->deprecated_checksum();
 }
 
 }  // extern C

--- a/src/atlas/functionspace/detail/ColumnChecksum.h
+++ b/src/atlas/functionspace/detail/ColumnChecksum.h
@@ -1,0 +1,215 @@
+/*
+ * (C) Copyright 2026- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "pluto/pluto.h"
+
+#include "atlas/array.h"
+#include "atlas/field/Field.h"
+#include "atlas/field/FieldSet.h"
+#include "atlas/parallel/GatherScatter.h"
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/parallel/omp/omp.h"
+#include "atlas/runtime/Exception.h"
+#include "atlas/util/Checksum.h"
+
+namespace atlas {
+namespace functionspace {
+namespace detail {
+
+/// @brief Shared checksum helper for column-based function spaces.
+///
+/// This helper implements the lane-based checksum algorithm used by
+/// NodeColumns, EdgeColumns, and CellColumns. It is an internal utility in the
+/// functionspace detail layer and is not part of the public Atlas API.
+///
+/// The class assumes the function space exposes the minimal interface needed by
+/// the algorithm: `size()`, `ghost()`, `gather()`, and `mpi_comm()`.
+///
+/// @tparam FunctionSpace Internal function space implementation type.
+template <typename FunctionSpace>
+class ColumnChecksum {
+public:
+    /// @brief Construct a checksum helper for one function space instance.
+    ///
+    /// @param functionspace Internal function space instance providing entity
+    ///                      ownership and gather operations.
+    /// @param global_size   Global number of entities represented on the root
+    ///                      rank after gather.
+    ColumnChecksum(const FunctionSpace& functionspace, size_t global_size): functionspace_(functionspace), global_size_(global_size) {}
+
+    /// @brief Compute the checksum of a field set.
+    ///
+    /// The checksum is built from owned entities only, then gathered and
+    /// reduced to a global hexadecimal digest.
+    ///
+    /// @param fieldset Field set defined on the associated function space.
+    /// @return Hexadecimal checksum string.
+    std::string compute(const FieldSet& fieldset) const {
+        return util::checksum_to_hex_str(compute_checksum(fieldset));
+    }
+
+    /// @brief Compute the checksum of a single field.
+    ///
+    /// This is a convenience overload that wraps the field into a temporary
+    /// FieldSet and reuses the FieldSet-based implementation.
+    ///
+    /// @param field Field defined on the associated function space.
+    /// @return Hexadecimal checksum string made of 4 characters (16 bits), see util::checksum_to_hex_str.
+    std::string compute(const Field& field) const {
+        FieldSet fieldset;
+        fieldset.add(field);
+        return compute(fieldset);
+    }
+
+private:
+    template <typename Value>
+    static void checksum_update_point(util::checksum_t& checksum, const array::Array& field, const Value* data, idx_t dim,
+                                      idx_t offset) {
+        if (dim == field.rank()) {
+            util::checksum_update(checksum, data + offset, size_t{1});
+            return;
+        }
+        for (idx_t index = 0; index < field.shape(dim); ++index) {
+            checksum_update_point(checksum, field, data, dim + 1, offset + index * field.stride(dim));
+        }
+    }
+
+    static bool is_owned(const array::ArrayView<int, 1>& ghost, idx_t index) {
+        return ghost(index) == 0;
+    }
+
+    static idx_t owned_contiguous_prefix_size(const array::ArrayView<int, 1>& ghost, idx_t size) {
+        idx_t owned_size = size;
+        while (owned_size > 0 && ghost(owned_size - 1) != 0) {
+            --owned_size;
+        }
+        for (idx_t index = 0; index < owned_size; ++index) {
+            if (ghost(index) != 0) {
+                return -1;
+            }
+        }
+        return owned_size;
+    }
+
+    template <typename Value>
+    void update_lane_checksums_with_field(const Field& field, const array::ArrayView<int, 1>& ghost,
+                                          util::checksum_t lane_checksums[], size_t lane_checksums_size) const {
+        const idx_t npts = std::min(functionspace_.size(), field.shape(0));
+        ATLAS_ASSERT(lane_checksums_size >= static_cast<size_t>(npts));
+
+        const auto* data = field.array().host_data<Value>();
+
+        if (field.contiguous()) {
+            const auto point_stride     = field.stride(0);
+            const idx_t contiguous_npts = owned_contiguous_prefix_size(ghost, functionspace_.size());
+            if (contiguous_npts >= 0) {
+                atlas_omp_parallel_for(idx_t index = 0; index < contiguous_npts; ++index) {
+                    util::checksum_update(lane_checksums[index], data + index * point_stride, point_stride);
+                }
+            }
+            else {
+                atlas_omp_parallel_for(idx_t index = 0; index < npts; ++index) {
+                    if (is_owned(ghost, index)) {
+                        util::checksum_update(lane_checksums[index], data + index * point_stride, point_stride);
+                    }
+                }
+            }
+            return;
+        }
+
+        atlas_omp_parallel_for(idx_t index = 0; index < npts; ++index) {
+            if (is_owned(ghost, index)) {
+                util::checksum_t lane = lane_checksums[index];
+                checksum_update_point(lane, field, data, idx_t{1}, index * field.stride(0));
+                lane_checksums[index] = lane;
+            }
+        }
+    }
+
+    void update_lane_checksums_with_field_dynamic(const Field& field, const array::ArrayView<int, 1>& ghost,
+                                                  util::checksum_t lane_checksums[], size_t lane_checksums_size) const {
+        switch (field.datatype().kind()) {
+            case array::DataType::kind<int>():
+                return update_lane_checksums_with_field<int>(field, ghost, lane_checksums, lane_checksums_size);
+            case array::DataType::kind<long>():
+                return update_lane_checksums_with_field<long>(field, ghost, lane_checksums, lane_checksums_size);
+            case array::DataType::kind<float>():
+                return update_lane_checksums_with_field<float>(field, ghost, lane_checksums, lane_checksums_size);
+            case array::DataType::kind<double>():
+                return update_lane_checksums_with_field<double>(field, ghost, lane_checksums, lane_checksums_size);
+            default:
+                throw_Exception("datatype not supported", Here());
+        }
+    }
+
+    util::checksum_t compute_checksum(const FieldSet& fieldset) const {
+        pluto::scope scope;
+        auto* memory_resource = pluto::host_pool_resource();
+        pluto::host::set_default_resource(memory_resource);
+
+        const idx_t npts = functionspace_.size();
+        Field ghost_field = functionspace_.ghost();
+        auto ghost        = array::make_view<int, 1>(ghost_field);
+        std::vector<util::checksum_t, pluto::allocator<util::checksum_t>> local_lanes(npts, 0, memory_resource);
+        for (idx_t field_idx = 0; field_idx < fieldset.size(); ++field_idx) {
+            update_lane_checksums_with_field_dynamic(fieldset[field_idx], ghost, local_lanes.data(), local_lanes.size());
+        }
+
+        for (idx_t index = 0; index < npts; ++index) {
+            if (is_owned(ghost, index)) {
+                local_lanes[index] = util::checksum_digest(local_lanes[index]);
+            }
+        }
+
+        const idx_t root = 0;
+        auto& comm       = mpi::comm(functionspace_.mpi_comm());
+        size_t nb_global = (comm.rank() == root) ? global_size_ : 0;
+
+        std::unique_ptr<util::checksum_t[], std::function<void(util::checksum_t*)>> global_lanes(
+            nb_global > 0 ? pluto::allocator<util::checksum_t>(memory_resource).allocate(nb_global) : nullptr,
+            [&](util::checksum_t* ptr) {
+                if (ptr) {
+                    pluto::allocator<util::checksum_t>(memory_resource).deallocate(ptr, nb_global);
+                }
+            });
+
+        {
+            mpi::Scope mpi_scope(functionspace_.mpi_comm());
+            idx_t lvar_stride = 1;
+            idx_t lvar_shape  = 1;
+            idx_t gvar_stride = 1;
+            idx_t gvar_shape  = 1;
+            functionspace_.gather().gather(local_lanes.data(), &lvar_stride, &lvar_shape, 1, global_lanes.get(),
+                                           &gvar_stride, &gvar_shape, 1, root);
+        }
+
+        util::checksum_t global_checksum = 0;
+        if (comm.rank() == root) {
+            global_checksum = util::checksum(global_lanes.get(), nb_global);
+        }
+        comm.broadcast(global_checksum, root);
+        return global_checksum;
+    }
+
+private:
+    const FunctionSpace& functionspace_;
+    size_t global_size_;
+};
+
+}  // namespace detail
+}  // namespace functionspace
+}  // namespace atlas

--- a/src/atlas/functionspace/detail/NodeColumnsInterface.cc
+++ b/src/atlas/functionspace/detail/NodeColumnsInterface.cc
@@ -123,7 +123,7 @@ void atlas__NodesFunctionSpace__scatter_field(const NodeColumns* This, const fie
 
 const parallel::Checksum* atlas__NodesFunctionSpace__get_checksum(const NodeColumns* This) {
     ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_functionspace_NodeColumns");
-    return &This->checksum();
+    return &This->deprecated_checksum();
 }
 
 void atlas__NodesFunctionSpace__sum_double(const NodeColumns* This, const field::FieldImpl* field, double& sum,

--- a/src/atlas/runtime/Log.cc
+++ b/src/atlas/runtime/Log.cc
@@ -330,9 +330,9 @@ std::string_view to_string_view(BarrierTimeoutAction action) {
 }
 
 BarrierTimeoutAction to_BarrierTimeoutAction(const std::string& str) {
-    if (str == "ABORT") return BarrierTimeoutAction::ABORT;
-    if (str == "THROW") return BarrierTimeoutAction::THROW;
-    if (str == "CONTINUE") return BarrierTimeoutAction::CONTINUE;
+    if (str == "ABORT") { return BarrierTimeoutAction::ABORT };
+    if (str == "THROW") { return BarrierTimeoutAction::THROW };
+    if (str == "CONTINUE") { return BarrierTimeoutAction::CONTINUE };
     ATLAS_THROW_EXCEPTION("Invalid value for ATLAS_MPI_BARRIER_TIMEOUT_ACTION: " << str << "."
                           << "Valid options are: ABORT, THROW, CONTINUE.");
 }

--- a/src/atlas/runtime/Log.cc
+++ b/src/atlas/runtime/Log.cc
@@ -330,9 +330,9 @@ std::string_view to_string_view(BarrierTimeoutAction action) {
 }
 
 BarrierTimeoutAction to_BarrierTimeoutAction(const std::string& str) {
-    if (str == "ABORT") { return BarrierTimeoutAction::ABORT };
-    if (str == "THROW") { return BarrierTimeoutAction::THROW };
-    if (str == "CONTINUE") { return BarrierTimeoutAction::CONTINUE };
+    if (str == "ABORT") { return BarrierTimeoutAction::ABORT; }
+    if (str == "THROW") { return BarrierTimeoutAction::THROW; }
+    if (str == "CONTINUE") { return BarrierTimeoutAction::CONTINUE; }
     ATLAS_THROW_EXCEPTION("Invalid value for ATLAS_MPI_BARRIER_TIMEOUT_ACTION: " << str << "."
                           << "Valid options are: ABORT, THROW, CONTINUE.");
 }

--- a/src/sandbox/apps/atlas-benchmark.cc
+++ b/src/sandbox/apps/atlas-benchmark.cc
@@ -571,7 +571,7 @@ double AtlasBenchmark::result() {
     Log::info() << "  minval: " << setw(13) << setprecision(6) << scientific << minval << endl;
     Log::info() << "  norm:   " << setw(13) << setprecision(6) << scientific << norm << endl;
 
-    Log::info() << "  checksum: " << nodes_fs.checksum().execute(grad) << endl;
+    Log::info() << "  checksum: " << nodes_fs.checksum(grad_field) << endl;
 
     return norm;
 }

--- a/src/tests/functionspace/CMakeLists.txt
+++ b/src/tests/functionspace/CMakeLists.txt
@@ -63,6 +63,14 @@ ecbuild_add_test( TARGET atlas_test_cellcolumns
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )
 
+ecbuild_add_test( TARGET atlas_test_columns_checksum
+  MPI         2
+  CONDITION   eckit_HAVE_MPI AND MPI_SLOTS GREATER_EQUAL 2
+  SOURCES     test_columns_checksum.cc
+  LIBS        atlas
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
+
 ecbuild_add_test( TARGET atlas_test_cubedsphere_functionspace
   MPI        8
   CONDITION  eckit_HAVE_MPI AND MPI_SLOTS GREATER_EQUAL 8

--- a/src/tests/functionspace/test_columns_checksum.cc
+++ b/src/tests/functionspace/test_columns_checksum.cc
@@ -1,0 +1,257 @@
+/*
+ * (C) Copyright 2013 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <algorithm>
+#include <vector>
+
+#include "atlas/array/ArrayView.h"
+#include "atlas/array/MakeView.h"
+#include "atlas/field/Field.h"
+#include "atlas/field/FieldSet.h"
+#include "atlas/functionspace/CellColumns.h"
+#include "atlas/functionspace/EdgeColumns.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/util/Checksum.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using namespace atlas;
+using namespace atlas::functionspace;
+using namespace atlas::test;
+
+namespace {
+
+template <typename Value>
+Value point_value(gidx_t global_index, idx_t dim1 = 0, idx_t dim2 = 0) {
+    return static_cast<Value>(global_index * 100 + dim1 * 10 + dim2 + 1);
+}
+
+template <typename FunctionSpace, typename Value>
+void fill_owned_and_ghost_values(const FunctionSpace& fs, Field& field, Value ghost_value) {
+    auto global_index = array::make_view<gidx_t, 1>(fs.global_index());
+    auto ghost        = array::make_view<int, 1>(fs.ghost());
+
+    switch (field.rank()) {
+        case 1: {
+            auto view = array::make_view<Value, 1>(field);
+            for (idx_t point = 0; point < field.shape(0); ++point) {
+                view(point) = ghost(point) ? ghost_value : point_value<Value>(global_index(point));
+            }
+            break;
+        }
+        case 2: {
+            auto view = array::make_view<Value, 2>(field);
+            for (idx_t point = 0; point < field.shape(0); ++point) {
+                for (idx_t dim1 = 0; dim1 < field.shape(1); ++dim1) {
+                    view(point, dim1) = ghost(point) ? ghost_value : point_value<Value>(global_index(point), dim1);
+                }
+            }
+            break;
+        }
+        case 3: {
+            auto view = array::make_view<Value, 3>(field);
+            for (idx_t point = 0; point < field.shape(0); ++point) {
+                for (idx_t dim1 = 0; dim1 < field.shape(1); ++dim1) {
+                    for (idx_t dim2 = 0; dim2 < field.shape(2); ++dim2) {
+                        view(point, dim1, dim2) = ghost(point) ? ghost_value : point_value<Value>(global_index(point), dim1, dim2);
+                    }
+                }
+            }
+            break;
+        }
+        default:
+            ATLAS_NOTIMPLEMENTED;
+    }
+    field.set_dirty();
+}
+
+template <typename Value>
+void update_lane_states_with_global_field(const Field& field, std::vector<util::checksum_t>& lane_states) {
+    ATLAS_ASSERT(field.shape(0) == static_cast<idx_t>(lane_states.size()));
+
+    switch (field.rank()) {
+        case 1: {
+            auto view = array::make_view<Value, 1>(field);
+            for (idx_t point = 0; point < field.shape(0); ++point) {
+                util::checksum_update(lane_states[static_cast<size_t>(point)], &view(point), 1);
+            }
+            break;
+        }
+        case 2: {
+            auto view = array::make_view<Value, 2>(field);
+            for (idx_t point = 0; point < field.shape(0); ++point) {
+                util::checksum_update(lane_states[static_cast<size_t>(point)], &view(point, 0),
+                                      static_cast<size_t>(field.shape(1)));
+            }
+            break;
+        }
+        case 3: {
+            auto view = array::make_view<Value, 3>(field);
+            for (idx_t point = 0; point < field.shape(0); ++point) {
+                util::checksum_update(lane_states[static_cast<size_t>(point)], &view(point, 0, 0),
+                                      static_cast<size_t>(field.shape(1) * field.shape(2)));
+            }
+            break;
+        }
+        default:
+            ATLAS_NOTIMPLEMENTED;
+    }
+}
+
+util::checksum_t checksum_from_lane_states(const std::vector<util::checksum_t>& lane_states) {
+    std::vector<util::checksum_t> lane_digests(lane_states.size());
+    for (size_t point = 0; point < lane_states.size(); ++point) {
+        lane_digests[point] = util::checksum_digest(lane_states[point]);
+    }
+    return util::checksum(lane_digests.data(), lane_digests.size());
+}
+
+template <typename Value>
+std::string expected_field_checksum(const Field& global_field, idx_t root = 0) {
+    util::checksum_t expected_checksum = 0;
+    auto& comm = mpi::comm();
+
+    if (comm.rank() == root) {
+        std::vector<util::checksum_t> lane_states(static_cast<size_t>(global_field.shape(0)));
+        for (auto& lane_state : lane_states) {
+            util::checksum_reset(lane_state);
+        }
+
+        update_lane_states_with_global_field<Value>(global_field, lane_states);
+        expected_checksum = checksum_from_lane_states(lane_states);
+    }
+
+    comm.broadcast(expected_checksum, root);
+    return util::checksum_to_hex_str(expected_checksum);
+}
+
+template <typename Value>
+std::string expected_fieldset_checksum(const FieldSet& global_fields, idx_t root = 0) {
+    util::checksum_t expected_checksum = 0;
+    auto& comm = mpi::comm();
+
+    if (comm.rank() == root) {
+        ATLAS_ASSERT(global_fields.size() > 0);
+        std::vector<util::checksum_t> lane_states(static_cast<size_t>(global_fields[0].shape(0)));
+        for (auto& lane_state : lane_states) {
+            util::checksum_reset(lane_state);
+        }
+
+        for (idx_t field_idx = 0; field_idx < global_fields.size(); ++field_idx) {
+            update_lane_states_with_global_field<Value>(global_fields[field_idx], lane_states);
+        }
+
+        expected_checksum = checksum_from_lane_states(lane_states);
+    }
+
+    comm.broadcast(expected_checksum, root);
+    return util::checksum_to_hex_str(expected_checksum);
+}
+
+template <typename FunctionSpace>
+Field gather_global_field(const FunctionSpace& fs, const Field& local_field, idx_t root = 0) {
+    Field global_field = fs.createField(local_field, option::global(root));
+    fs.gather(local_field, global_field);
+    return global_field;
+}
+
+template <typename FunctionSpace>
+FieldSet gather_global_fieldset(const FunctionSpace& fs, const FieldSet& local_fields, idx_t root = 0) {
+    FieldSet global_fields;
+    for (idx_t field_idx = 0; field_idx < local_fields.size(); ++field_idx) {
+        global_fields.add(fs.createField(local_fields[field_idx], option::global(root)));
+    }
+    fs.gather(local_fields, global_fields);
+    return global_fields;
+}
+
+Mesh generate_mesh() {
+    Grid grid{"O16"};
+    return StructuredMeshGenerator().generate(grid);
+}
+
+template <typename FunctionSpace>
+void expect_checksum_matches_global_field(const char* expected_checksum) {
+    auto levels = 3;
+    FunctionSpace fs(generate_mesh(), option::halo(1) | option::levels(levels));
+    Field field = fs.template createField<double>(option::name("field") | option::variables(2));
+
+    auto first_ghost_value = -999.;
+    fill_owned_and_ghost_values(fs, field, first_ghost_value);
+
+    Field global_field = gather_global_field(fs, field);
+    const auto checksum = expected_field_checksum<double>(global_field);
+    EXPECT_EQ(fs.checksum(field), checksum);
+
+    auto second_ghost_value = -12345.;
+    fill_owned_and_ghost_values(fs, field, second_ghost_value);
+    EXPECT_EQ(fs.checksum(field), checksum);
+    EXPECT_EQ(checksum, expected_checksum);
+}
+
+template <typename FunctionSpace>
+void expect_checksum_matches_global_fieldset(const char* expected_checksum) {
+    auto levels = 2;
+    FunctionSpace fs(generate_mesh(), option::halo(1) | option::levels(levels));
+    Field field1 = fs.template createField<double>(option::name("field1"));
+    Field field2 = fs.template createField<double>(option::name("field2") | option::variables(2));
+
+    fill_owned_and_ghost_values(fs, field1, -1.);
+    fill_owned_and_ghost_values(fs, field2, -2.);
+
+    FieldSet fields;
+    fields.add(field1);
+    fields.add(field2);
+
+    FieldSet global_fields = gather_global_fieldset(fs, fields);
+    const auto checksum = expected_fieldset_checksum<double>(global_fields);
+    EXPECT_EQ(fs.checksum(fields), checksum);
+    EXPECT_EQ(checksum, expected_checksum);
+}
+
+}  // namespace
+
+namespace atlas {
+namespace test {
+
+CASE("test_nodecolumns_checksum_matches_global_field") {
+    expect_checksum_matches_global_field<NodeColumns>("7290");
+}
+
+CASE("test_nodecolumns_checksum_fieldset_matches_global_fieldset") {
+    expect_checksum_matches_global_fieldset<NodeColumns>("b0c2");
+}
+
+CASE("test_cellcolumns_checksum_matches_global_field") {
+    expect_checksum_matches_global_field<CellColumns>("f645");
+}
+
+CASE("test_cellcolumns_checksum_fieldset_matches_global_fieldset") {
+    expect_checksum_matches_global_fieldset<CellColumns>("893a");
+}
+
+CASE("test_edgecolumns_checksum_matches_global_field") {
+    expect_checksum_matches_global_field<EdgeColumns>("7098");
+}
+
+CASE("test_edgecolumns_checksum_fieldset_matches_global_fieldset") {
+    expect_checksum_matches_global_fieldset<EdgeColumns>("263b");
+}
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}

--- a/src/tests/functionspace/test_functionspace_splitcomm.cc
+++ b/src/tests/functionspace/test_functionspace_splitcomm.cc
@@ -57,17 +57,6 @@ std::string expected_checksum() {
     return result;
 }
 
- std::string expected_checksum_nodes() {
-    if (grid().name()=="O32") {
-        return "75e913d400755a0d2782fc65e2035e97";
-    }
-    else if (grid().name()=="N32") {
-        return "bcb344196d20becbb66f098d91f83abb";
-    }
-    else {
-        return "unknown";
-    }
-}
 struct Fixture {
     Fixture() {
         mpi::comm().split(color(),"split");
@@ -129,7 +118,7 @@ CASE("test FunctionSpace NodeColumns") {
 
     // Checksum
     auto checksum = fs.checksum(field);
-    EXPECT_EQ(checksum, expected_checksum_nodes());
+    EXPECT_EQ(checksum, expected_checksum());
 
     Log::error() << "fs.part() = " << fs.part() << " fs.nb_parts() = " << fs.nb_parts() << " grid = " << fs.grid().name() << " checksum = " << checksum << std::endl;
 


### PR DESCRIPTION
This pull request refactors the checksum computation logic for the `NodeColumns`, `EdgeColumns`, and `CellColumns` function spaces in Atlas. The main goal is to centralize and simplify the checksum implementation by delegating it to a new `ColumnChecksum` utility, and to deprecate direct access to the internal `Checksum` object in favor of higher-level APIs. The changes also introduce clearer separation between public and internal APIs, and improve maintainability by reducing code duplication.

**Refactoring and centralization of checksum logic:**

* The checksum computation for `NodeColumns`, `EdgeColumns`, and `CellColumns` is now delegated to a new `ColumnChecksum` utility class, replacing the previous custom per-class implementations and reducing code duplication. (`src/atlas/functionspace/NodeColumns.cc`, `src/atlas/functionspace/EdgeColumns.cc`, `src/atlas/functionspace/CellColumns.cc`, `atlas/functionspace/detail/ColumnChecksum.h`) [[1]](diffhunk://#diff-dbe65d6d36f45b71646b7be3c0209fee003783fab2b9b242b002e0e77ad96183L575-R596) [[2]](diffhunk://#diff-2e68a5af06666ced52956089d52d01ef24dc2ff9d03790443c85226eb5f7e7b2L489-R501) [[3]](diffhunk://#diff-8795632df276c083139c1b974c2dea6a364b2dbe42ea2ca007fff3e770a4da91L499-R511)

**API deprecation and cleanup:**

* The direct access to the internal `Checksum` object via the `checksum()` method in the function space classes is now marked as deprecated, with a new `deprecated_checksum()` method provided for internal use only. The public API encourages using the higher-level `checksum(const FieldSet&)` or `checksum(const Field&)` methods instead. (`atlas/functionspace/NodeColumns.h`, `atlas/functionspace/EdgeColumns.h`, `atlas/functionspace/CellColumns.h`) [[1]](diffhunk://#diff-0dea37d31948de7279930711c8a56702eae354c9862d315196dac91db5b918f3R101-R108) [[2]](diffhunk://#diff-20e371291057d04627740fb447024dcb755dd397cd9e8407a921149e4f1b0f59R84-R98) [[3]](diffhunk://#diff-b7be4008fcf916c9856ae82a79b7838b5a69db3b110831b60b3e6495e0453209R88-R94)

**C and Fortran interface adjustments:**

* The C/Fortran interface functions that previously returned the internal `Checksum` object now use the new `deprecated_checksum()` method to maintain backward compatibility while discouraging external use. (`src/atlas/functionspace/NodeColumns.cc`, `src/atlas/functionspace/EdgeColumns.cc`, `src/atlas/functionspace/CellColumns.cc`, `src/atlas/functionspace/detail/CellColumnsInterface.cc`) [[1]](diffhunk://#diff-2e68a5af06666ced52956089d52d01ef24dc2ff9d03790443c85226eb5f7e7b2L793-R740) [[2]](diffhunk://#diff-8795632df276c083139c1b974c2dea6a364b2dbe42ea2ca007fff3e770a4da91L849-R753) [[3]](diffhunk://#diff-19f16b028a774eedb731c7d29eb68ac239d574bea5d09c918826642f0181fe83L126-R126)

**Other improvements:**

* The `EdgeColumns` class now provides a `ghost()` method, returning the ghost field if available, or falling back to the halo field. (`atlas/functionspace/EdgeColumns.h`, `src/atlas/functionspace/EdgeColumns.cc`) [[1]](diffhunk://#diff-20e371291057d04627740fb447024dcb755dd397cd9e8407a921149e4f1b0f59R84-R98) [[2]](diffhunk://#diff-2e68a5af06666ced52956089d52d01ef24dc2ff9d03790443c85226eb5f7e7b2R553-R559)

**Code cleanup and maintainability:**

* Removed duplicated and complex checksum helper functions from the function space implementations, making the codebase easier to maintain and less error-prone. (`src/atlas/functionspace/NodeColumns.cc`, `src/atlas/functionspace/EdgeColumns.cc`, `src/atlas/functionspace/CellColumns.cc`) [[1]](diffhunk://#diff-dbe65d6d36f45b71646b7be3c0209fee003783fab2b9b242b002e0e77ad96183L575-R596) [[2]](diffhunk://#diff-2e68a5af06666ced52956089d52d01ef24dc2ff9d03790443c85226eb5f7e7b2L489-R501) [[3]](diffhunk://#diff-8795632df276c083139c1b974c2dea6a364b2dbe42ea2ca007fff3e770a4da91L499-R511)

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-388
<!-- STATIC-ANALYSIS_END -->