### PR TITLE
Add Fortran API for FunctionSpace checksum with array support

### DIFF
--- a/src/atlas_f/CMakeLists.txt
+++ b/src/atlas_f/CMakeLists.txt
@@ -223,7 +223,7 @@ ecbuild_add_library( TARGET atlas_f
         util/atlas_allocate_module.F90
         output/atlas_output_module.F90
         domain/atlas_Domain_module.F90
-        functionspace/atlas_FunctionSpace_module.F90
+        functionspace/atlas_FunctionSpace_module.fypp
         functionspace/atlas_functionspace_EdgeColumns_module.F90
         functionspace/atlas_functionspace_CellColumns_module.F90
         functionspace/atlas_functionspace_NodeColumns_module.fypp
@@ -261,6 +261,7 @@ ecbuild_add_library( TARGET atlas_f
         internals/Library.h
         internals/Library.cc
         runtime/atlas_trace.cc
+        runtime/atlas_Deprecation_module.F90
         runtime/atlas_Trace_module.F90
         ${atlas_trans_srcs}
         ${atlas_interpolation_srcs}

--- a/src/atlas_f/functionspace/atlas_FunctionSpace_module.fypp
+++ b/src/atlas_f/functionspace/atlas_FunctionSpace_module.fypp
@@ -7,6 +7,7 @@
 ! does it submit to any jurisdiction.
 
 #include "atlas/atlas_f.h"
+#:include "internals/atlas_generics.fypp"
 
 module atlas_functionspace_module
 
@@ -60,6 +61,11 @@ contains
 
   procedure, private :: checksum_field
   procedure, private :: checksum_fieldset
+#:for rank in ranks
+#:for dtype in dtypes[:4]
+  procedure, private :: checksum_${dtype}$_r${rank}$
+#:endfor
+#:endfor
 
   generic, public :: create_field => &
     & create_field_args, &
@@ -69,7 +75,17 @@ contains
 
   generic, public :: halo_exchange => halo_exchange_field, halo_exchange_fieldset
   generic, public :: adjoint_halo_exchange => adjoint_halo_exchange_field, adjoint_halo_exchange_fieldset
-  generic, public :: checksum => checksum_field, checksum_fieldset
+  generic, public :: checksum => &
+    & checksum_field, &
+    & checksum_fieldset, &
+#:set counter = 1
+#:set last = len(ranks) * len(dtypes[:4])
+#:for rank in ranks
+#:for dtype in dtypes[:4]
+    & checksum_${dtype}$_r${rank}$#{if counter < last}#, & #{endif}#
+#:set counter = counter + 1
+#:endfor
+#:endfor
 
 #if FCKIT_FINAL_NOT_INHERITING
   final :: atlas_FunctionSpace__final_auto
@@ -241,6 +257,22 @@ function checksum_fieldset(this,fieldset) result(checksum)
 end function checksum_fieldset
 
 !------------------------------------------------------------------------------
+
+#:for rank in ranks
+#:for dtype,ftype,ctype in types[:4]
+function checksum_${dtype}$_r${rank}$(this,array) result(checksum)
+  use, intrinsic :: iso_c_binding, only : c_int, c_long, c_float, c_double
+  character(len=:), allocatable :: checksum
+  class(atlas_Functionspace), intent(in) :: this
+  ${ftype}$, intent(in), target :: array(${dim[rank]}$)
+  type(atlas_Field) :: field
+  field = atlas_Field(array)
+  checksum = checksum_field(this, field)
+  call field%final()
+end function checksum_${dtype}$_r${rank}$
+
+#:endfor
+#:endfor
 
 !------------------------------------------------------------------------------
 

--- a/src/atlas_f/functionspace/atlas_functionspace_CellColumns_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_CellColumns_module.F90
@@ -228,7 +228,8 @@ function get_checksum(this) result(checksum)
   end if
 
   if (atlas_deprecation_errors()) then
-    write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] atlas_functionspace_CellColumns%get_checksum should no longer be used. Please use atlas_functionspace_CellColumns%checksum instead."
+    write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] atlas_functionspace_CellColumns%get_checksum should no longer be used.&
+                   & Please use atlas_functionspace_CellColumns%checksum instead."
     write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] This error can be disabled with `export ATLAS_DEPRECATION_ERRORS=0`"
     error stop
   end if

--- a/src/atlas_f/functionspace/atlas_functionspace_CellColumns_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_CellColumns_module.F90
@@ -244,7 +244,8 @@ subroutine warn_cellcolumns_get_checksum_deprecation_once()
 
   if (.not. warned) then
     warned = .true.
-    write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] atlas_functionspace_CellColumns%get_checksum should no longer be used. Please use atlas_functionspace_CellColumns%checksum instead."
+    write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] atlas_functionspace_CellColumns%get_checksum should no longer be used.&
+                   & Please use atlas_functionspace_CellColumns%checksum instead."
     write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] This warning can be disabled with `export ATLAS_DEPRECATION_WARNINGS=0`"
   end if
 end subroutine

--- a/src/atlas_f/functionspace/atlas_functionspace_CellColumns_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_CellColumns_module.F90
@@ -219,11 +219,34 @@ end function
 !------------------------------------------------------------------------------
 
 function get_checksum(this) result(checksum)
+  use atlas_Deprecation_module, only : atlas_deprecation_errors, atlas_deprecation_warnings
   use atlas_functionspace_CellColumns_c_binding
   type(atlas_Checksum) :: checksum
   class(atlas_functionspace_CellColumns), intent(in) :: this
+  if (atlas_deprecation_warnings()) then
+    call warn_cellcolumns_get_checksum_deprecation_once()
+  end if
+
+  if (atlas_deprecation_errors()) then
+    write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] atlas_functionspace_CellColumns%get_checksum should no longer be used. Please use atlas_functionspace_CellColumns%checksum instead."
+    write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] This error can be disabled with `export ATLAS_DEPRECATION_ERRORS=0`"
+    error stop
+  end if
+
   call checksum%reset_c_ptr( atlas__CellsFunctioNSpace__get_checksum(this%c_ptr()) )
 end function
+
+!------------------------------------------------------------------------------
+
+subroutine warn_cellcolumns_get_checksum_deprecation_once()
+  logical, save :: warned = .false.
+
+  if (.not. warned) then
+    warned = .true.
+    write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] atlas_functionspace_CellColumns%get_checksum should no longer be used. Please use atlas_functionspace_CellColumns%checksum instead."
+    write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] This warning can be disabled with `export ATLAS_DEPRECATION_WARNINGS=0`"
+  end if
+end subroutine
 
 !------------------------------------------------------------------------------
 

--- a/src/atlas_f/functionspace/atlas_functionspace_EdgeColumns_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_EdgeColumns_module.F90
@@ -232,7 +232,8 @@ function get_checksum(this) result(checksum)
   end if
 
   if (atlas_deprecation_errors()) then
-    write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] atlas_functionspace_EdgeColumns%get_checksum should no longer be used. Please use atlas_functionspace_EdgeColumns%checksum instead."
+    write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] atlas_functionspace_EdgeColumns%get_checksum should no longer be used.&
+                   & Please use atlas_functionspace_EdgeColumns%checksum instead."
     write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] This error can be disabled with `export ATLAS_DEPRECATION_ERRORS=0`"
     error stop
   end if
@@ -247,7 +248,8 @@ subroutine warn_edgecolumns_get_checksum_deprecation_once()
 
   if (.not. warned) then
     warned = .true.
-    write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] atlas_functionspace_EdgeColumns%get_checksum should no longer be used. Please use atlas_functionspace_EdgeColumns%checksum instead."
+    write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] atlas_functionspace_EdgeColumns%get_checksum should no longer be used.&
+                   & Please use atlas_functionspace_EdgeColumns%checksum instead."
     write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] This warning can be disabled with `export ATLAS_DEPRECATION_WARNINGS=0`"
   end if
 end subroutine

--- a/src/atlas_f/functionspace/atlas_functionspace_EdgeColumns_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_EdgeColumns_module.F90
@@ -223,12 +223,34 @@ end function
 !------------------------------------------------------------------------------
 
 function get_checksum(this) result(checksum)
+  use atlas_Deprecation_module, only : atlas_deprecation_errors, atlas_deprecation_warnings
   use atlas_functionspace_EdgeColumns_c_binding
   type(atlas_Checksum) :: checksum
   class(atlas_functionspace_EdgeColumns), intent(in) :: this
+  if (atlas_deprecation_warnings()) then
+    call warn_edgecolumns_get_checksum_deprecation_once()
+  end if
+
+  if (atlas_deprecation_errors()) then
+    write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] atlas_functionspace_EdgeColumns%get_checksum should no longer be used. Please use atlas_functionspace_EdgeColumns%checksum instead."
+    write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] This error can be disabled with `export ATLAS_DEPRECATION_ERRORS=0`"
+    error stop
+  end if
+
   call checksum%reset_c_ptr( atlas__fs__EdgeColumns__get_checksum(this%c_ptr()) )
-!   call checksum%return()
 end function
+
+!-------------------------------------------------------------------------------
+
+subroutine warn_edgecolumns_get_checksum_deprecation_once()
+  logical, save :: warned = .false.
+
+  if (.not. warned) then
+    warned = .true.
+    write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] atlas_functionspace_EdgeColumns%get_checksum should no longer be used. Please use atlas_functionspace_EdgeColumns%checksum instead."
+    write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] This warning can be disabled with `export ATLAS_DEPRECATION_WARNINGS=0`"
+  end if
+end subroutine
 
 !-------------------------------------------------------------------------------
 

--- a/src/atlas_f/functionspace/atlas_functionspace_NodeColumns_module.fypp
+++ b/src/atlas_f/functionspace/atlas_functionspace_NodeColumns_module.fypp
@@ -251,11 +251,34 @@ end function
 !------------------------------------------------------------------------------
 
 function get_checksum(this) result(checksum)
+  use atlas_Deprecation_module, only : atlas_deprecation_errors, atlas_deprecation_warnings
   use atlas_functionspace_NodeColumns_c_binding
   type(atlas_Checksum) :: checksum
   class(atlas_functionspace_NodeColumns), intent(in) :: this
+  if (atlas_deprecation_warnings()) then
+    call warn_nodecolumns_get_checksum_deprecation_once()
+  end if
+
+  if (atlas_deprecation_errors()) then
+    write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] atlas_functionspace_NodeColumns%get_checksum should no longer be used. Please use atlas_functionspace_NodeColumns%checksum instead."
+    write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] This error can be disabled with `export ATLAS_DEPRECATION_ERRORS=0`"
+    error stop
+  end if
+
   call checksum%reset_c_ptr( atlas__NodesFunctioNSpace__get_checksum(this%c_ptr()) )
 end function
+
+!------------------------------------------------------------------------------
+
+subroutine warn_nodecolumns_get_checksum_deprecation_once()
+  logical, save :: warned = .false.
+
+  if (.not. warned) then
+    warned = .true.
+    write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] atlas_functionspace_NodeColumns%get_checksum should no longer be used. Please use atlas_functionspace_NodeColumns%checksum instead."
+    write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] This warning can be disabled with `export ATLAS_DEPRECATION_WARNINGS=0`"
+  end if
+end subroutine
 
 !------------------------------------------------------------------------------
 

--- a/src/atlas_f/functionspace/atlas_functionspace_NodeColumns_module.fypp
+++ b/src/atlas_f/functionspace/atlas_functionspace_NodeColumns_module.fypp
@@ -260,7 +260,8 @@ function get_checksum(this) result(checksum)
   end if
 
   if (atlas_deprecation_errors()) then
-    write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] atlas_functionspace_NodeColumns%get_checksum should no longer be used. Please use atlas_functionspace_NodeColumns%checksum instead."
+    write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] atlas_functionspace_NodeColumns%get_checksum should no longer be used.&
+                   & Please use atlas_functionspace_NodeColumns%checksum instead."
     write(0, '(A)') "[ATLAS_DEPRECATION_ERROR] This error can be disabled with `export ATLAS_DEPRECATION_ERRORS=0`"
     error stop
   end if
@@ -275,7 +276,8 @@ subroutine warn_nodecolumns_get_checksum_deprecation_once()
 
   if (.not. warned) then
     warned = .true.
-    write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] atlas_functionspace_NodeColumns%get_checksum should no longer be used. Please use atlas_functionspace_NodeColumns%checksum instead."
+    write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] atlas_functionspace_NodeColumns%get_checksum should no longer be used.&
+                   & Please use atlas_functionspace_NodeColumns%checksum instead."
     write(0, '(A)') "[ATLAS_DEPRECATION_WARNING] This warning can be disabled with `export ATLAS_DEPRECATION_WARNINGS=0`"
   end if
 end subroutine

--- a/src/atlas_f/runtime/atlas_Deprecation_module.F90
+++ b/src/atlas_f/runtime/atlas_Deprecation_module.F90
@@ -1,0 +1,66 @@
+! (C) Copyright 2013 ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation nor
+! does it submit to any jurisdiction.
+
+module atlas_Deprecation_module
+
+implicit none
+
+public :: atlas_deprecation_errors
+public :: atlas_deprecation_warnings
+
+private
+
+contains
+
+logical function atlas_deprecation_warnings() result(enabled)
+  logical, save :: initialized = .false.
+  logical, save :: value = .true.
+  character(len=16) :: env_value
+  integer :: env_status
+  integer :: env_length
+  integer :: env_int
+  integer :: read_status
+
+  if (.not. initialized) then
+    call get_environment_variable("ATLAS_DEPRECATION_WARNINGS", env_value, env_length, env_status)
+    if (env_status == 0 .and. env_length > 0) then
+      read(env_value(1:env_length), *, iostat=read_status) env_int
+      if (read_status == 0) then
+        value = (env_int /= 0)
+      end if
+    end if
+    initialized = .true.
+  end if
+
+  enabled = value
+end function
+
+logical function atlas_deprecation_errors() result(enabled)
+  logical, save :: initialized = .false.
+  logical, save :: value = .false.
+  character(len=16) :: env_value
+  integer :: env_status
+  integer :: env_length
+  integer :: env_int
+  integer :: read_status
+
+  if (.not. initialized) then
+    call get_environment_variable("ATLAS_DEPRECATION_ERRORS", env_value, env_length, env_status)
+    if (env_status == 0 .and. env_length > 0) then
+      read(env_value(1:env_length), *, iostat=read_status) env_int
+      if (read_status == 0) then
+        value = (env_int /= 0)
+      end if
+    end if
+    initialized = .true.
+  end if
+
+  enabled = value
+end function
+
+end module atlas_Deprecation_module

--- a/src/tests/functionspace/fctest_blockstructuredcolumns_checksum.F90
+++ b/src/tests/functionspace/fctest_blockstructuredcolumns_checksum.F90
@@ -683,4 +683,40 @@ call atlas_log%info(msg)
 FCTEST_CHECK_EQUAL(checksum, "338c")
 END_TEST
 
+TEST( test_blockstructuredcolumns_checksum_array_api )
+type(atlas_StructuredGrid) :: grid
+type(atlas_functionspace_BlockStructuredColumns) :: fs
+real(c_double), allocatable :: gfl(:,:,:,:)
+character(len=256) :: checksum
+integer(c_int) :: nlev = 10, nproma = 8, nvar = 3
+
+grid = atlas_StructuredGrid("O32")
+fs = atlas_functionspace_BlockStructuredColumns(grid, nproma=nproma)
+allocate(gfl(fs%nproma(),nlev,nvar,fs%nblks()))
+call fill_field_with_data(fs, gfl, 42)
+
+checksum = fs%checksum(gfl(:,:,1,:))
+write(msg,*) "Checksum for array API wrapping 3D slice 1: ", trim(checksum)
+call atlas_log%info(msg)
+FCTEST_CHECK_EQUAL(checksum, "8b78")
+
+checksum = fs%checksum(gfl(:,:,2,:))
+write(msg,*) "Checksum for array API wrapping 3D slice 2: ", trim(checksum)
+call atlas_log%info(msg)
+FCTEST_CHECK_EQUAL(checksum, "31a0")
+
+checksum = fs%checksum(gfl(:,:,3,:))
+write(msg,*) "Checksum for array API wrapping 3D slice 3: ", trim(checksum)
+call atlas_log%info(msg)
+FCTEST_CHECK_EQUAL(checksum, "5496")
+
+checksum = fs%checksum(gfl(:,:,:,:))
+write(msg,*) "Checksum for array API wrapping 4D array: ", trim(checksum)
+call atlas_log%info(msg)
+FCTEST_CHECK_EQUAL(checksum, "338c")
+
+call fs%final()
+call grid%final()
+END_TEST
+
 END_TESTSUITE


### PR DESCRIPTION
This pull request improves the Fortran API for function space checksums, with a focus on deprecating old methods, expanding array API support, and improving deprecation handling. The changes also include new tests and internal refactoring to support these updates.

**Key changes:**

### Deprecation Handling and Warnings

* Introduced a new `atlas_Deprecation_module.F90` that provides environment-variable-controlled deprecation warnings and errors, allowing users to enable or disable deprecation messages for legacy API usage. [[1]](diffhunk://#diff-19e8c20ca24716e1666393a6e6fda2c0d81970a5e44e689e17194be16698b584R1-R66) [[2]](diffhunk://#diff-e477fe0af2df1d4e141a99baeedd63d6e8609970bb8921db8a6e6795d40657faR264)
* Updated `get_checksum` methods in `CellColumns`, `EdgeColumns`, and `NodeColumns` modules to emit warnings or errors (with clear migration guidance) when used, utilizing the new deprecation module and providing one-time warning subroutines. [[1]](diffhunk://#diff-b59a6fd27b7f728bb5826e2f39905d5e8eb82f66d83dbc7a63a88148c68c0ec7R222-R252) [[2]](diffhunk://#diff-db96747636342da7518f61784da27fc29375dc69181c285449a331657250ae17R226-R256) [[3]](diffhunk://#diff-efce5afe51991a52c632d2483de56b4753cc454506aba1aae0bb5f0bb52651f4R254-R284)

### Array API Expansion and Refactoring

* Refactored `atlas_FunctionSpace_module.F90` to a Fypp template (`atlas_FunctionSpace_module.fypp`), and added a family of `checksum_<dtype>_r<rank>` functions, enabling direct checksum computation on arrays of various types and ranks. The generic `checksum` interface is now expanded to include these. [[1]](diffhunk://#diff-f91ced60a69873638b7425506055f7dd62ce72335aade4fa79d543116f969f6fR10) [[2]](diffhunk://#diff-f91ced60a69873638b7425506055f7dd62ce72335aade4fa79d543116f969f6fR64-R68) [[3]](diffhunk://#diff-f91ced60a69873638b7425506055f7dd62ce72335aade4fa79d543116f969f6fL72-R88) [[4]](diffhunk://#diff-f91ced60a69873638b7425506055f7dd62ce72335aade4fa79d543116f969f6fR261-R276) [[5]](diffhunk://#diff-e477fe0af2df1d4e141a99baeedd63d6e8609970bb8921db8a6e6795d40657faL226-R226)

### Testing Improvements

* Added a new test (`test_blockstructuredcolumns_checksum_array_api`) to verify the new array API for checksums, ensuring correct results for various array slices and dimensions.

These changes modernize the Fortran API, encourage migration to new interfaces, and provide robust mechanisms for managing deprecated functionality.

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-389
<!-- STATIC-ANALYSIS_END -->