### PR TITLE
Add ArrayView and LocalView method extent(Int) as in mdspan

### DIFF
--- a/src/atlas/array/LocalView.h
+++ b/src/atlas/array/LocalView.h
@@ -192,6 +192,13 @@ public:
         return shape_[idx];
     }
 
+    /// @brief Return number of values in dimension idx, equivalent to shape(idx)
+    template <typename Int>
+    ATLAS_HOST_DEVICE
+    idx_t extent(Int idx) const {
+        return shape(idx);
+    }
+
     template <typename Int>
     idx_t stride(Int idx) const {
         return strides_[idx];

--- a/src/atlas/array/native/NativeArrayView.h
+++ b/src/atlas/array/native/NativeArrayView.h
@@ -273,6 +273,13 @@ public:
         return shape_[idx];
     }
 
+    /// @brief Return number of values in dimension idx, equivalent to shape(idx)
+    template <typename Int>
+    ATLAS_HOST_DEVICE
+    idx_t extent(Int idx) const {
+        return shape(idx);
+    }
+
     /// @brief Return stride for values in dimension idx
     template <typename Int>
     ATLAS_HOST_DEVICE


### PR DESCRIPTION
This pull request introduces a new convenience method, `extent`, to both the `LocalView` and `ArrayView` classes. The `extent` method is a simple alias for the existing `shape` method, providing a more intuitive way to query the size of a specific array dimension.

API enhancements for array views:

* Added the `extent(Int idx)` method to `LocalView`, which returns the number of values in the specified dimension and is equivalent to calling `shape(idx)` (`src/atlas/array/LocalView.h`).
* Added the `extent(Int idx)` method to `ArrayView`, also as an alias for `shape(idx)`, improving consistency and usability (`src/atlas/array/native/NativeArrayView.h`).


<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-390
<!-- STATIC-ANALYSIS_END -->