### PR TITLE
Enhance Fortran BlockStructuredColumns and FunctionSpace accessors

### DIFF
--- a/src/atlas/functionspace/detail/FunctionSpaceInterface.cc
+++ b/src/atlas/functionspace/detail/FunctionSpaceInterface.cc
@@ -75,6 +75,41 @@ field::FieldImpl* atlas__FunctionSpace__create_field_template(const FunctionSpac
 
 //------------------------------------------------------------------------------
 
+field::FieldImpl* atlas__FunctionSpace__lonlat(const FunctionSpaceImpl* This) {
+    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_FunctionSpace");
+    return This->lonlat().get();
+}
+
+//------------------------------------------------------------------------------
+
+field::FieldImpl* atlas__FunctionSpace__ghost(const FunctionSpaceImpl* This) {
+    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_FunctionSpace");
+    return This->ghost().get();
+}
+
+//------------------------------------------------------------------------------
+
+field::FieldImpl* atlas__FunctionSpace__global_index(const FunctionSpaceImpl* This) {
+    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_FunctionSpace");
+    return This->global_index().get();
+}
+
+//------------------------------------------------------------------------------
+
+field::FieldImpl* atlas__FunctionSpace__remote_index(const FunctionSpaceImpl* This) {
+    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_FunctionSpace");
+    return This->remote_index().get();
+}
+
+//------------------------------------------------------------------------------
+
+field::FieldImpl* atlas__FunctionSpace__partition(const FunctionSpaceImpl* This) {
+    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_FunctionSpace");
+    return This->partition().get();
+}
+
+//------------------------------------------------------------------------------
+
 void atlas__FunctionSpace__halo_exchange_field(const FunctionSpaceImpl* This, field::FieldImpl* field) {
     ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_FunctionSpace");
     ATLAS_ASSERT(field != nullptr, "Cannot access uninitialised atlas_Field");

--- a/src/atlas/functionspace/detail/FunctionSpaceInterface.h
+++ b/src/atlas/functionspace/detail/FunctionSpaceInterface.h
@@ -37,6 +37,11 @@ field::FieldImpl* atlas__FunctionSpace__create_field(const FunctionSpaceImpl* Th
 field::FieldImpl* atlas__FunctionSpace__create_field_template(const FunctionSpaceImpl* This,
                                                               const field::FieldImpl* field_template,
                                                               const eckit::Configuration* options);
+field::FieldImpl* atlas__FunctionSpace__lonlat(const FunctionSpaceImpl* This);
+field::FieldImpl* atlas__FunctionSpace__ghost(const FunctionSpaceImpl* This);
+field::FieldImpl* atlas__FunctionSpace__global_index(const FunctionSpaceImpl* This);
+field::FieldImpl* atlas__FunctionSpace__remote_index(const FunctionSpaceImpl* This);
+field::FieldImpl* atlas__FunctionSpace__partition(const FunctionSpaceImpl* This);
 void atlas__FunctionSpace__halo_exchange_field(const FunctionSpaceImpl* This, field::FieldImpl* field);
 void atlas__FunctionSpace__halo_exchange_fieldset(const FunctionSpaceImpl* This, field::FieldSetImpl* fieldset);
 void atlas__FunctionSpace__adjoint_halo_exchange_field(const FunctionSpaceImpl* This, field::FieldImpl* field);

--- a/src/atlas/util/ObjectHandle.cc
+++ b/src/atlas/util/ObjectHandle.cc
@@ -8,11 +8,12 @@
  * nor does it submit to any jurisdiction.
  */
 
+#include "atlas/util/ObjectHandle.h"
+
 #include <ostream>
 
 #include "atlas/runtime/Log.h"
 #include "atlas/util/Object.h"
-#include "atlas/util/ObjectHandle.h"
 
 namespace atlas {
 namespace util {

--- a/src/atlas_f/functionspace/atlas_FunctionSpace_module.fypp
+++ b/src/atlas_f/functionspace/atlas_FunctionSpace_module.fypp
@@ -47,6 +47,11 @@ TYPE, extends(fckit_owned_object) :: atlas_FunctionSpace
 !------------------------------------------------------------------------------
 contains
   procedure, public :: name => atlas_FunctionSpace__name
+  procedure, public :: lonlat
+  procedure, public :: ghost
+  procedure, public :: global_index
+  procedure, public :: remote_index
+  procedure, public :: partition
 
   procedure, private :: create_field_args
   procedure, private :: create_field_template
@@ -120,6 +125,46 @@ function atlas_FunctionSpace__name(this) result(name)
   call atlas__FunctionSpace__name(this%c_ptr(), name_c_str, size )
   name = c_ptr_to_string(name_c_str)
   call c_ptr_free(name_c_str)
+end function
+
+function lonlat(this) result(field)
+  use atlas_functionspace_c_binding
+  type(atlas_Field) :: field
+  class(atlas_Functionspace), intent(in) :: this
+  field = atlas_Field( atlas__FunctionSpace__lonlat(this%c_ptr()) )
+  call field%return()
+end function
+
+function ghost(this) result(field)
+  use atlas_functionspace_c_binding
+  type(atlas_Field) :: field
+  class(atlas_Functionspace), intent(in) :: this
+  field = atlas_Field( atlas__FunctionSpace__ghost(this%c_ptr()) )
+  call field%return()
+end function
+
+function global_index(this) result(field)
+  use atlas_functionspace_c_binding
+  type(atlas_Field) :: field
+  class(atlas_Functionspace), intent(in) :: this
+  field = atlas_Field( atlas__FunctionSpace__global_index(this%c_ptr()) )
+  call field%return()
+end function
+
+function remote_index(this) result(field)
+  use atlas_functionspace_c_binding
+  type(atlas_Field) :: field
+  class(atlas_Functionspace), intent(in) :: this
+  field = atlas_Field( atlas__FunctionSpace__remote_index(this%c_ptr()) )
+  call field%return()
+end function
+
+function partition(this) result(field)
+  use atlas_functionspace_c_binding
+  type(atlas_Field) :: field
+  class(atlas_Functionspace), intent(in) :: this
+  field = atlas_Field( atlas__FunctionSpace__partition(this%c_ptr()) )
+  call field%return()
 end function
 
 

--- a/src/atlas_f/functionspace/atlas_functionspace_BlockStructuredColumns_module.F90
+++ b/src/atlas_f/functionspace/atlas_functionspace_BlockStructuredColumns_module.F90
@@ -152,13 +152,13 @@ function empty_config() result(config)
   call config%return()
 end function
 
-function ctor_grid(grid, halo, nproma, levels) result(this)
+function ctor_grid(grid, nproma, halo, levels) result(this)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   type(atlas_functionspace_BlockStructuredColumns) :: this
   class(atlas_Grid), intent(in) :: grid
-  integer, optional :: halo
-  integer, optional :: nproma
-  integer, optional :: levels
+  integer, optional, intent(in) :: nproma
+  integer, optional, intent(in) :: halo
+  integer, optional, intent(in) :: levels
   type(atlas_Config) :: config
   config = empty_config() ! Due to PGI compiler bug, we have to do this instead of "config = atlas_Config()""
   if( present(halo) )   call config%set("halo",halo)
@@ -183,15 +183,17 @@ function ctor_grid_config(grid, config) result(this)
   call this%return()
 end function
 
-function ctor_grid_dist(grid, distribution, halo, levels) result(this)
+function ctor_grid_dist(grid, distribution, nproma, halo, levels) result(this)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   type(atlas_functionspace_BlockStructuredColumns) :: this
   class(atlas_Grid), intent(in) :: grid
   type(atlas_griddistribution), intent(in) :: distribution
-  integer, optional :: halo
-  integer, optional :: levels
+  integer, optional, intent(in) :: halo
+  integer, optional, intent(in) :: nproma
+  integer, optional, intent(in) :: levels
   type(atlas_Config) :: config
   config = empty_config() ! Due to PGI compiler bug, we have to do this instead of "config = atlas_Config()""
+  if( present(nproma) ) call config%set("nproma",nproma)
   if( present(halo) )   call config%set("halo",halo)
   if( present(levels) ) call config%set("levels",levels)
   call this%reset_c_ptr( atlas__functionspace__BStructuredColumns__new__grid_dist( &
@@ -201,17 +203,19 @@ function ctor_grid_dist(grid, distribution, halo, levels) result(this)
   call this%return()
 end function
 
-function ctor_grid_dist_levels(grid, distribution, levels, halo) result(this)
+function ctor_grid_dist_levels(grid, distribution, levels, nproma, halo) result(this)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   type(atlas_functionspace_BlockStructuredColumns) :: this
   class(atlas_Grid), intent(in) :: grid
   type(atlas_griddistribution), intent(in) :: distribution
-  integer, optional :: halo
-  real(c_double) :: levels(:)
+  integer, optional, intent(in) :: halo
+  integer, optional, intent(in) :: nproma
+  real(c_double), intent(in) :: levels(:)
   type(atlas_Config) :: config
   type(atlas_Vertical) :: vertical
   config = empty_config() ! Due to PGI compiler bug, we have to do this insted of "config = atlas_Config()""
   if( present(halo) )   call config%set("halo",halo)
+  if( present(nproma) ) call config%set("nproma",nproma)
   call config%set("levels",size(levels))
   vertical = atlas_Vertical(levels)
   call this%reset_c_ptr( atlas__functionspace__BStructuredColumns__new__grid_dist_vert( &
@@ -223,16 +227,18 @@ function ctor_grid_dist_levels(grid, distribution, levels, halo) result(this)
   call this%return()
 end function
 
-function ctor_grid_dist_vertical(grid, distribution, vertical, halo) result(this)
+function ctor_grid_dist_vertical(grid, distribution, vertical, nproma, halo) result(this)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   type(atlas_functionspace_BlockStructuredColumns) :: this
   class(atlas_Grid), intent(in) :: grid
   type(atlas_griddistribution), intent(in) :: distribution
-  integer, optional :: halo
-  type(atlas_Vertical) :: vertical
+  integer, optional, intent(in) :: halo
+  integer, optional, intent(in) :: nproma
+  type(atlas_Vertical), intent(in) :: vertical
   type(atlas_Config) :: config
   config = empty_config() ! Due to PGI compiler bug, we have to do this insted of "config = atlas_Config()""
   if( present(halo) )   call config%set("halo",halo)
+  if( present(nproma) ) call config%set("nproma",nproma)
   call config%set("levels",vertical%size())
   call this%reset_c_ptr( atlas__functionspace__BStructuredColumns__new__grid_dist_vert( &
       & grid%c_ptr(), distribution%c_ptr(), vertical%c_ptr(), &
@@ -256,16 +262,18 @@ function ctor_grid_dist_config(grid, distribution, config) result(this)
 end function
 
 
-function ctor_grid_part(grid, partitioner, halo, levels) result(this)
+function ctor_grid_part(grid, partitioner, halo, nproma, levels) result(this)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   type(atlas_functionspace_BlockStructuredColumns) :: this
   class(atlas_Grid), intent(in) :: grid
   type(atlas_Partitioner), intent(in) :: partitioner
-  integer, optional :: halo
-  integer, optional :: levels
+  integer, optional, intent(in) :: halo
+  integer, optional, intent(in) :: nproma
+  integer, optional, intent(in) :: levels
   type(atlas_Config) :: config
   config = empty_config() ! Due to PGI compiler bug, we have to do this instead of "config = atlas_Config()""
   if( present(halo) )   call config%set("halo",halo)
+  if( present(nproma) ) call config%set("nproma",nproma)
   if( present(levels) ) call config%set("levels",levels)
   call this%reset_c_ptr( atlas__functionspace__BStructuredColumns__new__grid_part( &
       & grid%c_ptr(), partitioner%c_ptr(), config%c_ptr() ) )
@@ -274,17 +282,19 @@ function ctor_grid_part(grid, partitioner, halo, levels) result(this)
   call this%return()
 end function
 
-function ctor_grid_part_levels(grid, partitioner, levels, halo) result(this)
+function ctor_grid_part_levels(grid, partitioner, levels, nproma, halo) result(this)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   type(atlas_functionspace_BlockStructuredColumns) :: this
   class(atlas_Grid), intent(in) :: grid
   type(atlas_Partitioner), intent(in) :: partitioner
-  integer, optional :: halo
-  real(c_double) :: levels(:)
+  integer, optional, intent(in) :: halo
+  integer, optional, intent(in) :: nproma
+  real(c_double), intent(in) :: levels(:)
   type(atlas_Config) :: config
   type(atlas_Vertical) :: vertical
   config = empty_config() ! Due to PGI compiler bug, we have to do this insted of "config = atlas_Config()""
   if( present(halo) )   call config%set("halo",halo)
+  if( present(nproma) ) call config%set("nproma",nproma)
   call config%set("levels",size(levels))
   vertical = atlas_Vertical(levels)
   call this%reset_c_ptr( atlas__functionspace__BStructuredColumns__new__grid_part_vert( &
@@ -296,15 +306,17 @@ function ctor_grid_part_levels(grid, partitioner, levels, halo) result(this)
   call this%return()
 end function
 
-function ctor_grid_part_vertical(grid, partitioner, vertical, halo) result(this)
+function ctor_grid_part_vertical(grid, partitioner, vertical, nproma, halo) result(this)
   use atlas_functionspace_BlockStructuredColumns_c_binding
   type(atlas_functionspace_BlockStructuredColumns) :: this
   class(atlas_Grid), intent(in) :: grid
   type(atlas_Partitioner), intent(in) :: partitioner
-  integer, optional :: halo
+  integer, optional, intent(in) :: nproma
+  integer, optional, intent(in) :: halo
   type(atlas_Vertical) :: vertical
   type(atlas_Config) :: config
   config = empty_config() ! Due to PGI compiler bug, we have to do this insted of "config = atlas_Config()""
+  if( present(nproma) ) call config%set("nproma",nproma)
   if( present(halo) )   call config%set("halo",halo)
   call config%set("levels",vertical%size())
   call this%reset_c_ptr( atlas__functionspace__BStructuredColumns__new__grid_part_vert( &


### PR DESCRIPTION
This pull request introduces new Fortran interface methods for accessing key fields from `FunctionSpace` objects, and updates the BlockStructuredColumns functionspace constructors to support the `nproma` parameter. It also includes minor code organization improvements. The most important changes are grouped below:

### New Fortran interface methods for `FunctionSpace` fields

* Added new Fortran interface functions (`lonlat`, `ghost`, `global_index`, `remote_index`, `partition`) to the `atlas_FunctionSpace` type, allowing direct access to commonly used fields from Fortran. [[1]](diffhunk://#diff-f91ced60a69873638b7425506055f7dd62ce72335aade4fa79d543116f969f6fR50-R54) [[2]](diffhunk://#diff-f91ced60a69873638b7425506055f7dd62ce72335aade4fa79d543116f969f6fR130-R169)
* Implemented the corresponding C++ interface functions in `FunctionSpaceInterface.cc` and declared them in the header, enabling the new Fortran methods to retrieve the underlying fields. [[1]](diffhunk://#diff-3362e1f625d44db9a2b4d8f86e72782fb21cd918dc3135c52f55c5eea8a22985R78-R112) [[2]](diffhunk://#diff-b7dd607356c1a6f717728a4bafc17326f8cadd2f0d39e6357a624f838b94218aR40-R44)

### BlockStructuredColumns functionspace enhancements

* Updated all BlockStructuredColumns Fortran constructors to accept an optional `nproma` argument, passing it into the configuration if provided. This change makes it easier to control the blocking parameter from Fortran. [[1]](diffhunk://#diff-0c3890e5a030dc809c0326123af22e4839f991bfc2344a6e011a597de85b908aL155-R161) [[2]](diffhunk://#diff-0c3890e5a030dc809c0326123af22e4839f991bfc2344a6e011a597de85b908aL186-R196) [[3]](diffhunk://#diff-0c3890e5a030dc809c0326123af22e4839f991bfc2344a6e011a597de85b908aL204-R218) [[4]](diffhunk://#diff-0c3890e5a030dc809c0326123af22e4839f991bfc2344a6e011a597de85b908aL226-R241) [[5]](diffhunk://#diff-0c3890e5a030dc809c0326123af22e4839f991bfc2344a6e011a597de85b908aL259-R276) [[6]](diffhunk://#diff-0c3890e5a030dc809c0326123af22e4839f991bfc2344a6e011a597de85b908aL277-R297) [[7]](diffhunk://#diff-0c3890e5a030dc809c0326123af22e4839f991bfc2344a6e011a597de85b908aL299-R319)


<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-391
<!-- STATIC-ANALYSIS_END -->