### PR TITLE
Specify eigen version in downstream-ci-hpc configuration

### DIFF
--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -7,7 +7,7 @@ mpi_on:
     modules:
       - ninja
     modules_package:
-      - atlas:fftw,eigen,qhull,python3/3.12,openmpi
+      - atlas:fftw,eigen/3.4.1,qhull,python3/3.12,openmpi
       - fckit:python3/3.12,openmpi
       - eckit:openmpi
     dependencies:
@@ -24,7 +24,7 @@ mpi_off:
     modules:
       - ninja
     modules_package:
-      - atlas:fftw,eigen,qhull,python3/3.12
+      - atlas:fftw,eigen/3.4.1,qhull,python3/3.12
       - fckit:python3/3.12
     dependencies:
       - ecmwf/ecbuild@develop


### PR DESCRIPTION

### Description

The rollback from default eigen (5.0.0) to (3.4.1) should hopefully fix the current incompatibility for the Intel classic compiler (icpc) with eigen 5.0.0 A fix has been merged to Eigen upstream (https://gitlab.com/libeigen/eigen/-/merge_requests/2650) which will allow Intel classic compiler (icpc) to be used.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-393
<!-- STATIC-ANALYSIS_END -->