### PR TITLE
Add a weighted space-filling-curve-based partitioner

### DIFF
--- a/src/apps/atlas-meshgen.cc
+++ b/src/apps/atlas-meshgen.cc
@@ -20,6 +20,7 @@
 #include "atlas/functionspace/EdgeColumns.h"
 #include "atlas/functionspace/NodeColumns.h"
 #include "atlas/grid.h"
+#include "atlas/grid/detail/partitioner/SpaceFillingCurvePartitioner.h"  // for the --weighted demonstration
 #include "atlas/library.h"
 #include "atlas/mesh/Mesh.h"
 #include "atlas/mesh/Nodes.h"
@@ -106,6 +107,33 @@ Partitioner make_partitioner(const Grid& grid, const AtlasTool::Args& args) {
     if (args.has("partitions")) {
         config.set("partitions", args.getInt("partitions"));
     }
+
+    // ---------------------------------------------------------------------
+    // Demonstration of the Hilbert partitioner's opt-in weighting. The weight
+    // interface is deliberately not part of the string/config factory (real
+    // weights come from data, e.g. observation density), so we build the concrete
+    // partitioner here, set an illustrative weight, and wrap it in a Partitioner
+    // handle (which takes ownership). This lets users explore how weighting
+    // reshapes the partition without wiring up a data source.
+    if (args.getBool("weighted", false)) {
+        using grid::detail::partitioner::SpaceFillingCurvePartitioner;
+        std::string type;
+        config.get("type", type);
+        if (type == "hilbert") {
+            const double heavy = args.getDouble("weight-factor", 8.0);
+            auto* concrete     = new SpaceFillingCurvePartitioner(config);
+            // Northern-hemisphere-heavy demo weight (proxy for observation
+            // density): northern points cost `heavy` x southern points, so the
+            // curve is cut into segments of equal total weight, giving northern
+            // partitions proportionally fewer points.
+            concrete->set_weight_function(
+                [heavy](gidx_t, const PointXY& p) { return p.y() > 0. ? heavy : 1.0; });
+            return Partitioner{concrete};
+        }
+        Log::warning() << "--weighted ignored: only supported for --partitioner=hilbert" << std::endl;
+    }
+    // ---------------------------------------------------------------------
+
     return Partitioner{config};
 }
 
@@ -172,6 +200,16 @@ Meshgen2Gmsh::Meshgen2Gmsh(int argc, char** argv): AtlasTool(argc, argv) {
 
     add_option(new Separator("Options for `--partitioner=checkerboard`"));
     add_option(new SimpleOption<bool>("regular", "regular checkerboard partitioner"));
+
+    add_option(new Separator("Options for `--partitioner=hilbert` (visualisation / weighting demo)"));
+    add_option(new SimpleOption<bool>("weighted",
+                                      "Apply a demo northern-hemisphere-heavy weight to the hilbert partitioner"));
+    add_option(new SimpleOption<double>("weight-factor",
+                                        "Weight of northern vs southern points for --weighted (default = 8)"));
+    add_option(new SimpleOption<bool>(
+        "partition-points",
+        "Write a single-process python scatter plot (partition_points.py) of the whole-grid partition assignment. "
+        "Needs no MPI; use --partitions to set the number of partitions."));
 
     add_option(new Separator("Advanced"));
     add_option(new SimpleOption<long>("halo", "Halo size"));
@@ -286,6 +324,65 @@ int Meshgen2Gmsh::execute(const Args& args) {
 
     auto meshgenerator = make_meshgenerator(grid, args);
     auto partitioner   = make_partitioner(grid, args);
+
+    // ---------------------------------------------------------------------
+    // Write a python scatter plot of the whole-grid partition assignment. Unlike
+    // --partition-polygons, this needs no MPI and does not rely on partition-boundary
+    // polygon merging, so it works for any partitioner, including space-filling-curve
+    // partitions (whose 2D footprint need not be a single connected polygon).
+    // Runs single-process; set the partition count with --partitions.
+    if (args.getBool("partition-points", false)) {
+        const idx_t npts = grid.size();
+        std::vector<int> part(npts);
+        partitioner.partition(grid, part.data());
+
+        const bool weighted = args.getBool("weighted", false);
+        const double heavy  = args.getDouble("weight-factor", 8.0);
+
+        const std::string fname = "partition_points.py";
+        std::ofstream f(fname.c_str());
+        f << "import matplotlib\nmatplotlib.use('Agg')\nimport matplotlib.pyplot as plt\n";
+        f << "lon = [";
+        for (const auto& ll : grid.lonlat()) {
+            f << ll[0] << ",";
+        }
+        f << "]\nlat = [";
+        for (const auto& ll : grid.lonlat()) {
+            f << ll[1] << ",";
+        }
+        f << "]\npart = [";
+        for (idx_t i = 0; i < npts; ++i) {
+            f << part[i] << ",";
+        }
+        f << "]\n";
+        if (weighted) {
+            f << "weight = [";
+            for (const auto& ll : grid.lonlat()) {
+                f << (ll[1] > 0. ? heavy : 1.0) << ",";
+            }
+            f << "]\nsizes = [4.0 * w for w in weight]\n";
+        }
+        else {
+            f << "sizes = 6\n";
+        }
+        f << "from matplotlib.colors import BoundaryNorm\n";
+        f << "nparts = max(part) + 1\n";
+        f << "cmap = plt.get_cmap('tab20', nparts)\n";
+        f << "norm = BoundaryNorm(range(nparts + 1), nparts)\n";
+        f << "plt.figure(figsize=(12, 6))\n";
+        f << "sc = plt.scatter(lon, lat, c=part, s=sizes, cmap=cmap, norm=norm, linewidths=0)\n";
+        f << "cbar = plt.colorbar(sc, label='partition', ticks=[i + 0.5 for i in range(nparts)])\n";
+        f << "cbar.ax.set_yticklabels([str(i) for i in range(nparts)])\n";
+        f << "plt.xlabel('longitude'); plt.ylabel('latitude')\n";
+        f << "plt.title('" << partitioner.type() << " partition, nb_parts=" << partitioner.nb_partitions()
+          << (weighted ? " (weighted)" : "") << "')\n";
+        f << "plt.tight_layout()\nplt.savefig('partition_points.png', dpi=150)\n";
+        f << "print('wrote partition_points.png')\n";
+        f.close();
+        Log::info() << "Wrote " << fname << "  (render with: python3 " << fname << ")" << std::endl;
+        return success();
+    }
+    // ---------------------------------------------------------------------
 
     Mesh mesh;
     try {

--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -268,6 +268,9 @@ grid/Vertical.cc
 
 list( APPEND atlas_grid_partitioning_srcs
 
+grid/SpaceFillingCurve.h
+grid/SpaceFillingCurve.cc
+
 grid/StructuredPartitionPolygon.h
 grid/StructuredPartitionPolygon.cc
 
@@ -321,6 +324,8 @@ grid/detail/partitioner/RegularBandsPartitioner.cc
 grid/detail/partitioner/RegularBandsPartitioner.h
 grid/detail/partitioner/SerialPartitioner.cc
 grid/detail/partitioner/SerialPartitioner.h
+grid/detail/partitioner/SpaceFillingCurvePartitioner.cc
+grid/detail/partitioner/SpaceFillingCurvePartitioner.h
 )
 
 if( atlas_HAVE_ECTRANS )

--- a/src/atlas/grid/SpaceFillingCurve.cc
+++ b/src/atlas/grid/SpaceFillingCurve.cc
@@ -1,0 +1,147 @@
+/*
+ * (C) Copyright 2013 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "atlas/grid/SpaceFillingCurve.h"
+
+#include <cmath>
+#include <limits>
+
+namespace atlas {
+namespace grid {
+
+// -------------------------------------------------------------------------------------
+
+HilbertCurve::HilbertCurve(const Domain& domain, idx_t levels): domain_{domain}, max_level_(levels) {
+    nb_keys_2_ = gidx_t(std::pow(gidx_t(4), gidx_t(max_level_)));
+    nb_keys_   = nb_keys_2_ * 2;
+}
+
+gidx_t HilbertCurve::operator()(const PointXY& point) const {
+    box_t box;
+    box[A]            = {domain_.xmin(), domain_.ymax()};
+    box[B]            = {domain_.xmin(), domain_.ymin()};
+    box[C]            = {domain_.xmax(), domain_.ymin()};
+    box[D]            = {domain_.xmax(), domain_.ymax()};
+    const double xmid = (domain_.xmin() + domain_.xmax()) * 0.5;
+    if (point.x() < xmid) {
+        box[C].x() = xmid;
+        box[D].x() = xmid;
+        return recursive_algorithm(point, box, 0);
+    }
+    else {
+        box[A].x() = xmid;
+        box[B].x() = xmid;
+        return recursive_algorithm(point, box, 0) + nb_keys_2_;
+    }
+}
+
+gidx_t HilbertCurve::recursive_algorithm(const PointXY& p, const box_t& box, idx_t level) const {
+    if (level == max_level_) {
+        return 0;
+    }
+
+    double min_distance = std::numeric_limits<double>::max();
+
+    auto compute_distance2 = [](const PointXY& p1, const PointXY& p2) {
+        // workaround because of eckit 1.3.2 issue with constness in KPoint
+        double d = 0;
+        for (size_t i = 0; i < 2; i++) {
+            double dx = p1[i] - p2[i];
+            d += dx * dx;
+        }
+        return d;
+    };
+
+    auto compute_average = [](const PointXY& p1, const PointXY& p2) {
+        // workaround because of eckit 1.3.2 issue with constness in KPoint
+        PointXY avg;
+        avg.x() = p1.x() + p2.x();
+        avg.x() *= 0.5;
+        avg.y() = p1.y() + p2.y();
+        avg.y() *= 0.5;
+        return avg;
+    };
+
+    idx_t quadrant{0};
+    for (idx_t idx = 0; idx < 4; ++idx) {
+        // double distance = box[idx].distance2( p );  // does not compile with eckit 1.3.2
+        double distance = compute_distance2(p, box[idx]);  // workaround
+        if (distance < min_distance) {
+            quadrant     = idx;
+            min_distance = distance;
+        }
+    }
+
+    box_t box_quadrant;
+    switch (quadrant) {
+        case A:
+            box_quadrant[A] = box[A];
+            box_quadrant[B] = compute_average(box[A], box[D]);  // workaround
+            box_quadrant[C] = compute_average(box[A], box[C]);  // workaround
+            box_quadrant[D] = compute_average(box[A], box[B]);  // workaround
+            break;
+        case B:
+            box_quadrant[B] = box[B];
+            box_quadrant[A] = compute_average(box[B], box[A]);  // workaround
+            box_quadrant[C] = compute_average(box[B], box[C]);  // workaround
+            box_quadrant[D] = compute_average(box[B], box[D]);  // workaround
+            break;
+        case C:
+            box_quadrant[C] = box[C];
+            box_quadrant[A] = compute_average(box[C], box[A]);  // workaround
+            box_quadrant[B] = compute_average(box[C], box[B]);  // workaround
+            box_quadrant[D] = compute_average(box[C], box[D]);  // workaround
+            break;
+        case D:
+            box_quadrant[D] = box[D];
+            box_quadrant[A] = compute_average(box[D], box[C]);  // workaround
+            box_quadrant[B] = compute_average(box[D], box[B]);  // workaround
+            box_quadrant[C] = compute_average(box[D], box[A]);  // workaround
+            break;
+    }
+
+    // The key has 4 possible values per recursion (1 for each quadrant),
+    // which can be represented by 2 bits per recursion
+    //   A --> 00
+    //   B --> 01
+    //   C --> 10
+    //   D --> 11
+    // Trailing zero-bits are added depending on the level:
+    //   level max_level_-1 --> none
+    //   level max_level_-2 --> 00
+    //   level max_level_-2 --> 0000
+    //   level max_level_-3 --> 000000
+    gidx_t key = 0;
+    auto index = (max_level_ - level) * 2 - 1;
+    gidx_t mask;
+
+    // Create a mask value with all trailing bits for leftmost bit (of 2)
+    mask = gidx_t(1) << index;
+
+    // Add mask to key
+    if (quadrant == C || quadrant == D) {
+        key |= mask;
+    }
+
+    // Create a mask value with all trailing bits for rightmost bit (of 2)
+    mask = gidx_t(1) << (index - 1);
+
+    // Add mask to key
+    if (quadrant == B || quadrant == D) {
+        key |= mask;
+    }
+
+    return recursive_algorithm(p, box_quadrant, level + 1) + key;
+}
+
+// -------------------------------------------------------------------------------------
+
+}  // namespace grid
+}  // namespace atlas

--- a/src/atlas/grid/SpaceFillingCurve.h
+++ b/src/atlas/grid/SpaceFillingCurve.h
@@ -1,0 +1,89 @@
+/*
+ * (C) Copyright 2013 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#pragma once
+
+#include <array>
+
+#include "atlas/domain/Domain.h"
+#include "atlas/library/config.h"
+#include "atlas/util/Point.h"
+
+namespace atlas {
+namespace grid {
+
+// -------------------------------------------------------------------------------------
+
+/// @brief Class to compute a global index given a coordinate, based on the
+/// Hilbert Spacefilling Curve.
+///
+/// This algorithm is based on:
+/// - John J. Bartholdi and Paul Goldsman "Vertex-Labeling Algorithms for the Hilbert Spacefilling Curve"\n
+/// It is adapted to return contiguous numbers of the gidx_t type, instead of a double [0,1]
+///
+/// Given a bounding box and number of hilbert recursions, the bounding box can be divided in
+/// 2^(dim*levels) equally spaced cells. A given coordinate falling inside one of these cells, is assigned
+/// the 1-dimensional Hilbert-index of this cell. To make sure that 1 coordinate corresponds to only 1
+/// Hilbert index, the number of levels have to be increased.
+/// In 2D, the recursion cannot be higher than 15, if you want the indices to fit in "unsigned int" type of 32bit.
+/// In 2D, the recursion cannot be higher than 30, if you want the indices to fit in "unsigned int" type of 64bit.
+///
+///
+/// No attempt is made to provide the most efficient algorithm. There exist other open-source
+/// libraries with more efficient algorithms, such as libhilbert, but its LGPL license
+/// is not compatible with this licence.
+///
+/// @author Willem Deconinck
+class HilbertCurve {
+public:
+    /// Constructor
+    /// Initializes the hilbert space filling curve with a given "space" and "levels"
+    HilbertCurve(const Domain& domain, idx_t levels);
+
+    /// Compute the hilbert code for a given point in 2D
+    gidx_t operator()(const PointXY& point) const;
+
+    /// Return the maximum hilbert code possible with the initialized levels
+    ///
+    /// Care has to be taken that this number is not larger than the precision of the type storing
+    /// the hilbert codes.
+    gidx_t nb_keys() const { return nb_keys_; }
+
+private:  // functions
+    using box_t = std::array<PointXY, 4>;
+
+    /// @brief Recursive algorithm
+    gidx_t recursive_algorithm(const PointXY& p, const box_t& box, idx_t level) const;
+
+private:  // data
+    /// Vertex label type (4 vertices in 2D)
+    enum VertexLabel
+    {
+        A = 0,
+        B = 1,
+        C = 2,
+        D = 3
+    };
+
+    /// Bounding box, defining the space to be filled
+    const RectangularDomain domain_;
+
+    /// maximum recursion level of the Hilbert space filling curve
+    idx_t max_level_;
+
+    /// maximum number of unique codes, computed by max_level
+    gidx_t nb_keys_;
+    gidx_t nb_keys_2_;
+};
+
+// -------------------------------------------------------------------------------------
+
+}  // namespace grid
+}  // namespace atlas

--- a/src/atlas/grid/detail/partitioner/Partitioner.cc
+++ b/src/atlas/grid/detail/partitioner/Partitioner.cc
@@ -34,6 +34,7 @@
 #include "atlas/grid/detail/partitioner/MatchingMeshPartitionerSphericalPolygon.h"
 #include "atlas/grid/detail/partitioner/RegularBandsPartitioner.h"
 #include "atlas/grid/detail/partitioner/SerialPartitioner.h"
+#include "atlas/grid/detail/partitioner/SpaceFillingCurvePartitioner.h"
 #include "atlas/library/config.h"
 #include "atlas/parallel/mpi/mpi.h"
 #include "atlas/runtime/Exception.h"
@@ -128,6 +129,7 @@ struct force_link {
         load_builder<EqualBandsPartitioner>();
         load_builder<RegularBandsPartitioner>();
         load_builder<SerialPartitioner>();
+        load_builder<SpaceFillingCurvePartitioner>();
 #if ATLAS_HAVE_TRANS
         load_builder<TransPartitioner>();
 #endif

--- a/src/atlas/grid/detail/partitioner/SpaceFillingCurvePartitioner.cc
+++ b/src/atlas/grid/detail/partitioner/SpaceFillingCurvePartitioner.cc
@@ -1,0 +1,150 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ *
+ */
+
+#include "atlas/grid/detail/partitioner/SpaceFillingCurvePartitioner.h"
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+#include <vector>
+
+#include "atlas/domain/Domain.h"
+#include "atlas/grid/Grid.h"
+#include "atlas/grid/Iterator.h"
+#include "atlas/grid/SpaceFillingCurve.h"
+#include "atlas/runtime/Exception.h"
+#include "atlas/runtime/Trace.h"
+#include "atlas/util/Point.h"
+
+namespace atlas {
+namespace grid {
+namespace detail {
+namespace partitioner {
+
+SpaceFillingCurvePartitioner::SpaceFillingCurvePartitioner(): Partitioner() {}
+
+SpaceFillingCurvePartitioner::SpaceFillingCurvePartitioner(int N, const eckit::Parametrisation& config):
+    Partitioner(N, config) {
+    setup(config);
+}
+
+SpaceFillingCurvePartitioner::SpaceFillingCurvePartitioner(const eckit::Parametrisation& config): Partitioner(config) {
+    setup(config);
+}
+
+void SpaceFillingCurvePartitioner::setup(const eckit::Parametrisation& config) {
+    config.get("recursion", recursion_);
+    ATLAS_ASSERT(recursion_ > 0, "SpaceFillingCurvePartitioner: 'recursion' must be strictly positive");
+}
+
+void SpaceFillingCurvePartitioner::partition(const Grid& grid, int part[]) const {
+    const int nb_parts     = static_cast<int>(nb_partitions());
+    const gidx_t nb_points = grid.size();
+
+    if (nb_parts == 1) {  // trivial solution, so much faster
+        for (gidx_t j = 0; j < nb_points; ++j) {
+            part[j] = 0;
+        }
+        return;
+    }
+
+    ATLAS_TRACE("SpaceFillingCurvePartitioner::partition");
+
+    ATLAS_ASSERT(nb_parts <= nb_points,
+                 "SpaceFillingCurvePartitioner: cannot partition a grid into more parts than it has points");
+
+    // Gather all point coordinates and compute the global bounding box in a single
+    // pass. This is done locally and identically on every MPI rank, so the resulting
+    // partition is deterministic and reproducible regardless of rank count.
+    std::vector<PointXY> points;
+    points.reserve(nb_points);
+    double xmin = std::numeric_limits<double>::max();
+    double xmax = -std::numeric_limits<double>::max();
+    double ymin = std::numeric_limits<double>::max();
+    double ymax = -std::numeric_limits<double>::max();
+    for (const auto& p : grid.lonlat()) {
+        points.emplace_back(p[0], p[1]);
+        xmin = std::min(xmin, p[0]);
+        xmax = std::max(xmax, p[0]);
+        ymin = std::min(ymin, p[1]);
+        ymax = std::max(ymax, p[1]);
+    }
+    // Guard against a degenerate (zero-width) bounding box.
+    if (!(xmax > xmin)) {
+        xmax = xmin + 1.;
+    }
+    if (!(ymax > ymin)) {
+        ymax = ymin + 1.;
+    }
+
+    HilbertCurve hilbert{RectangularDomain{{xmin, xmax}, {ymin, ymax}}, recursion_};
+
+    // (hilbert key, original grid index)
+    std::vector<std::pair<gidx_t, gidx_t>> sfc;
+    sfc.reserve(nb_points);
+    ATLAS_TRACE_SCOPE("compute hilbert keys") {
+        for (gidx_t n = 0; n < nb_points; ++n) {
+            sfc.emplace_back(hilbert(points[n]), n);
+        }
+    }
+
+    ATLAS_TRACE_SCOPE("sort") {
+        std::sort(sfc.begin(), sfc.end());
+    }
+
+    // Per-point weights (default: unit weight => equal-count cut). When a weight
+    // function is supplied, negative weights are clamped to zero; if the total
+    // weight is non-positive (e.g. every point masked out) we fall back to unit
+    // weights so the partition is still well-defined.
+    std::vector<double> weights;
+    double total_weight = static_cast<double>(nb_points);
+    if (weight_) {
+        weights.resize(nb_points);
+        total_weight = 0.;
+        for (gidx_t n = 0; n < nb_points; ++n) {
+            double w = weight_(n, points[n]);
+            if (!(w > 0.)) {
+                w = 0.;
+            }
+            weights[n] = w;
+            total_weight += w;
+        }
+        if (!(total_weight > 0.)) {
+            std::fill(weights.begin(), weights.end(), 1.);
+            total_weight = static_cast<double>(nb_points);
+        }
+    }
+
+    // Cut the sorted curve into nb_parts contiguous segments of (near-)equal total
+    // weight. The boundary test is written in the scaled form
+    //     accumulated * nb_parts >= (p+1) * total_weight
+    // rather than accumulating a running target, so that it introduces no
+    // floating-point drift. In particular, with unit weights the accumulated value
+    // and total_weight are exact integers, making this reduce *exactly* to an
+    // equal-count partition where each partition receives floor(N/P) or ceil(N/P)
+    // points. Each point is assigned to the current partition first; once the
+    // accumulated weight reaches the target, subsequent points advance to the next
+    // partition, so the overshoot at every boundary is bounded by one point's weight.
+    double accumulated = 0.;
+    int p              = 0;
+    for (gidx_t k = 0; k < nb_points; ++k) {
+        const gidx_t index = sfc[k].second;
+        part[index]        = p;
+        accumulated += weights.empty() ? 1. : weights[index];
+        while (p < nb_parts - 1 && accumulated * nb_parts >= static_cast<double>(p + 1) * total_weight) {
+            ++p;
+        }
+    }
+}
+
+}  // namespace partitioner
+}  // namespace detail
+}  // namespace grid
+}  // namespace atlas
+
+namespace {
+atlas::grid::detail::partitioner::PartitionerBuilder<atlas::grid::detail::partitioner::SpaceFillingCurvePartitioner>
+    __SpaceFillingCurve("hilbert");
+}

--- a/src/atlas/grid/detail/partitioner/SpaceFillingCurvePartitioner.h
+++ b/src/atlas/grid/detail/partitioner/SpaceFillingCurvePartitioner.h
@@ -1,0 +1,96 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ *
+ */
+
+#pragma once
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "atlas/grid/detail/partitioner/Partitioner.h"
+#include "atlas/util/Point.h"
+
+namespace atlas {
+namespace grid {
+namespace detail {
+namespace partitioner {
+
+/// @brief Partitioner that distributes grid points along a Hilbert space-filling curve.
+///
+/// All grid points are sorted by their Hilbert-curve index (computed over the
+/// grid bounding box) and the resulting one-dimensional ordering is cut into
+/// @c nb_partitions contiguous segments. Because the Hilbert curve preserves
+/// spatial locality, each segment corresponds to a compact, contiguous
+/// sub-domain, which keeps halo/communication volume low.
+///
+/// The partition is computed identically and independently on every MPI rank
+/// (no communication), so it is fully deterministic and reproducible.
+///
+/// By default each grid point carries unit weight, so the curve is cut into
+/// segments of (near-)equal point count. A user-supplied weight function can
+/// instead balance an arbitrary, spatially-varying cost per point (for example
+/// observation density, variable-resolution work, or masked/inactive points):
+/// the curve is then cut into contiguous segments of (near-)equal total weight.
+/// The unit-weight default exactly reproduces the equal-count behaviour, so the
+/// weighting is a strict, opt-in generalisation.
+///
+/// Configuration options:
+///   - "recursion" : <int> (default=30)  // Hilbert-curve recursion depth. Must be
+///                                        // large enough to give each grid point a
+///                                        // unique index (30 => 64-bit indices).
+///
+/// The weight function is not part of the (string/config-driven) factory
+/// interface; it must be set programmatically via set_weight_function() (analytical
+/// weights) or set_weights() (a precomputed per-point array) on a concrete instance.
+/// This keeps the generic Partitioner API unchanged while still allowing callers
+/// that know about weighting to opt in.
+class SpaceFillingCurvePartitioner : public Partitioner {
+public:
+    /// @brief Weight function mapping a grid point (its global index in grid-iteration
+    /// order, and its (lon,lat) coordinates in degrees) to a non-negative weight.
+    /// Negative results are clamped to zero. The index makes it straightforward to
+    /// look up a precomputed per-point array; the coordinate supports analytical
+    /// weights. Either argument may be ignored.
+    using WeightFunction = std::function<double(gidx_t index, const PointXY& lonlat)>;
+
+    SpaceFillingCurvePartitioner();
+
+    SpaceFillingCurvePartitioner(int N, const eckit::Parametrisation&);
+
+    SpaceFillingCurvePartitioner(const eckit::Parametrisation&);
+
+    using Partitioner::partition;
+    void partition(const Grid&, int part[]) const override;
+
+    std::string type() const override { return "hilbert"; }
+
+    /// @brief Set a per-point weight function. When set, the curve is cut into
+    /// segments of (near-)equal total weight rather than equal point count.
+    /// Passing an empty function (the default) restores unit-weight behaviour.
+    void set_weight_function(WeightFunction weight) { weight_ = std::move(weight); }
+
+    /// @brief Set precomputed per-point weights, indexed in grid-iteration order
+    /// (i.e. weights[n] is the weight of the n-th point of grid.lonlat()). The
+    /// container must have exactly grid.size() entries; this is checked at
+    /// partition() time. This is a convenience wrapper around set_weight_function()
+    /// for the common case of a weight array (e.g. observation counts per point).
+    void set_weights(std::vector<double> weights) {
+        weight_ = [w = std::move(weights)](gidx_t index, const PointXY&) -> double { return w.at(index); };
+    }
+
+    /// @brief Whether a (non-empty) weight function has been set.
+    bool has_weight_function() const { return static_cast<bool>(weight_); }
+
+private:
+    void setup(const eckit::Parametrisation&);
+
+    idx_t recursion_{30};
+    WeightFunction weight_;
+};
+
+}  // namespace partitioner
+}  // namespace detail
+}  // namespace grid
+}  // namespace atlas

--- a/src/atlas/mesh/actions/ReorderHilbert.cc
+++ b/src/atlas/mesh/actions/ReorderHilbert.cc
@@ -8,14 +8,13 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <array>
-#include <bitset>
 #include <utility>
 #include <vector>
 
 #include "atlas/array.h"
 #include "atlas/domain/Domain.h"
 #include "atlas/grid/Grid.h"
+#include "atlas/grid/SpaceFillingCurve.h"
 #include "atlas/mesh/Elements.h"
 #include "atlas/mesh/HybridElements.h"
 #include "atlas/mesh/Mesh.h"
@@ -34,211 +33,10 @@ namespace actions {
 
 // -------------------------------------------------------------------------------------
 
-/// @brief Class to compute a global index given a coordinate, based on the
-/// Hilbert Spacefilling Curve.
-///
-/// This algorithm is based on:
-/// - John J. Bartholdi and Paul Goldsman "Vertex-Labeling Algorithms for the Hilbert Spacefilling Curve"\n
-/// It is adapted to return contiguous numbers of the gidx_t type, instead of a double [0,1]
-///
-/// Given a bounding box and number of hilbert recursions, the bounding box can be divided in
-/// 2^(dim*levels) equally spaced cells. A given coordinate falling inside one of these cells, is assigned
-/// the 1-dimensional Hilbert-index of this cell. To make sure that 1 coordinate corresponds to only 1
-/// Hilbert index, the number of levels have to be increased.
-/// In 2D, the recursion cannot be higher than 15, if you want the indices to fit in "unsigned int" type of 32bit.
-/// In 2D, the recursion cannot be higher than 30, if you want the indices to fit in "unsigned int" type of 64bit.
-///
-///
-/// No attempt is made to provide the most efficient algorithm. There exist other open-source
-/// libraries with more efficient algorithms, such as libhilbert, but its LGPL license
-/// is not compatible with this licence.
-///
-/// @author Willem Deconinck
-class Hilbert {
-public:
-    /// Constructor
-    /// Initializes the hilbert space filling curve with a given "space" and "levels"
-    Hilbert(const Domain& domain, idx_t levels);
-
-    /// Compute the hilbert code for a given point in 2D
-    gidx_t operator()(const PointXY& point);
-
-    /// Compute the hilbert code for a given point in 2D
-    /// @param [out] relative_tolerance  cell-size of smallest level divided by bounding-box size
-    gidx_t operator()(const PointXY& point, double& relative_tolerance);
-
-    /// Return the maximum hilbert code possible with the initialized levels
-    ///
-    /// Care has to be taken that this number is not larger than the precision of the type storing
-    /// the hilbert codes.
-    gidx_t nb_keys() const { return nb_keys_; }
-
-private:  // functions
-    using box_t = std::array<PointXY, 4>;
-
-    /// @brief Recursive algorithm
-    gidx_t recursive_algorithm(const PointXY& p, const box_t& box, idx_t level);
-
-private:  // data
-    /// Vertex label type (4 vertices in 2D)
-    enum VertexLabel
-    {
-        A = 0,
-        B = 1,
-        C = 2,
-        D = 3
-    };
-
-    /// Bounding box, defining the space to be filled
-    const RectangularDomain domain_;
-
-    /// maximum recursion level of the Hilbert space filling curve
-    idx_t max_level_;
-
-    /// maximum number of unique codes, computed by max_level
-    gidx_t nb_keys_;
-    gidx_t nb_keys_2_;
-};
-
-// -------------------------------------------------------------------------------------
-
-Hilbert::Hilbert(const Domain& domain, idx_t levels): domain_{domain}, max_level_(levels) {
-    nb_keys_2_ = gidx_t(std::pow(gidx_t(4), gidx_t(max_level_)));
-    nb_keys_   = nb_keys_2_ * 2;
-}
-
-
-gidx_t Hilbert::operator()(const PointXY& point) {
-    box_t box;
-    box[A]            = {domain_.xmin(), domain_.ymax()};
-    box[B]            = {domain_.xmin(), domain_.ymin()};
-    box[C]            = {domain_.xmax(), domain_.ymin()};
-    box[D]            = {domain_.xmax(), domain_.ymax()};
-    const double xmid = (domain_.xmin() + domain_.xmax()) * 0.5;
-    if (point.x() < xmid) {
-        box[C].x() = xmid;
-        box[D].x() = xmid;
-        return recursive_algorithm(point, box, 0);
-    }
-    else {
-        box[A].x() = xmid;
-        box[B].x() = xmid;
-        return recursive_algorithm(point, box, 0) + nb_keys_2_;
-    }
-}
-
-gidx_t Hilbert::recursive_algorithm(const PointXY& p, const box_t& box, idx_t level) {
-    if (level == max_level_) {
-        return 0;
-    }
-
-    double min_distance = std::numeric_limits<double>::max();
-
-    auto compute_distance2 = [](const PointXY& p1, const PointXY& p2) {
-        // workaround because of eckit 1.3.2 issue with constness in KPoint
-        double d = 0;
-        for (size_t i = 0; i < 2; i++) {
-            double dx = p1[i] - p2[i];
-            d += dx * dx;
-        }
-        return d;
-    };
-
-    auto compute_average = [](const PointXY& p1, const PointXY& p2) {
-        // workaround because of eckit 1.3.2 issue with constness in KPoint
-        PointXY avg;
-        avg.x() = p1.x() + p2.x();
-        avg.x() *= 0.5;
-        avg.y() = p1.y() + p2.y();
-        avg.y() *= 0.5;
-        return avg;
-    };
-
-    idx_t quadrant{0};
-    for (idx_t idx = 0; idx < 4; ++idx) {
-        // double distance = box[idx].distance2( p );  // does not compile with eckit 1.3.2
-        double distance = compute_distance2(p, box[idx]);  // workaround
-        if (distance < min_distance) {
-            quadrant     = idx;
-            min_distance = distance;
-        }
-    }
-
-    box_t box_quadrant;
-    switch (quadrant) {
-        case A:
-            box_quadrant[A] = box[A];
-            // box_quadrant[B] = ( box[A] + box[D] ) * 0.5;  // does not compile with eckit 1.3.2
-            // box_quadrant[C] = ( box[A] + box[C] ) * 0.5;  // does not compile with eckit 1.3.2
-            // box_quadrant[D] = ( box[A] + box[B] ) * 0.5;  // does not compile with eckit 1.3.2
-            box_quadrant[B] = compute_average(box[A], box[D]);  // workaround
-            box_quadrant[C] = compute_average(box[A], box[C]);  // workaround
-            box_quadrant[D] = compute_average(box[A], box[B]);  // workaround
-            break;
-        case B:
-            // box_quadrant[A] = ( box[B] + box[A] ) * 0.5;  // does not compile with eckit 1.3.2
-            box_quadrant[B] = box[B];
-            // box_quadrant[C] = ( box[B] + box[C] ) * 0.5;  // does not compile with eckit 1.3.2
-            // box_quadrant[D] = ( box[B] + box[D] ) * 0.5;  // does not compile with eckit 1.3.2
-            box_quadrant[A] = compute_average(box[B], box[A]);  // workaround
-            box_quadrant[C] = compute_average(box[B], box[C]);  // workaround
-            box_quadrant[D] = compute_average(box[B], box[D]);  // workaround
-            break;
-        case C:
-            // box_quadrant[A] = ( box[C] + box[A] ) * 0.5;  // does not compile with eckit 1.3.2
-            // box_quadrant[B] = ( box[C] + box[B] ) * 0.5;  // does not compile with eckit 1.3.2
-            box_quadrant[C] = box[C];
-            // box_quadrant[D] = ( box[C] + box[D] ) * 0.5;  // does not compile with eckit 1.3.2
-            box_quadrant[A] = compute_average(box[C], box[A]);  // workaround
-            box_quadrant[B] = compute_average(box[C], box[B]);  // workaround
-            box_quadrant[D] = compute_average(box[C], box[D]);  // workaround
-
-            break;
-        case D:
-            // box_quadrant[A] = ( box[D] + box[C] ) * 0.5;  // does not compile with eckit 1.3.2
-            // box_quadrant[B] = ( box[D] + box[B] ) * 0.5;  // does not compile with eckit 1.3.2
-            // box_quadrant[C] = ( box[D] + box[A] ) * 0.5;  // does not compile with eckit 1.3.2
-            box_quadrant[D] = box[D];
-            box_quadrant[A] = compute_average(box[D], box[C]);  // workaround
-            box_quadrant[B] = compute_average(box[D], box[B]);  // workaround
-            box_quadrant[C] = compute_average(box[D], box[A]);  // workaround
-
-            break;
-    }
-
-    // The key has 4 possible values per recursion (1 for each quadrant),
-    // which can be represented by 2 bits per recursion
-    //   A --> 00
-    //   B --> 01
-    //   C --> 10
-    //   D --> 11
-    // Trailing zero-bits are added depending on the level:
-    //   level max_level_-1 --> none
-    //   level max_level_-2 --> 00
-    //   level max_level_-2 --> 0000
-    //   level max_level_-3 --> 000000
-    gidx_t key = 0;
-    auto index = (max_level_ - level) * 2 - 1;
-    gidx_t mask;
-
-    // Create a mask value with all trailing bits for leftmost bit (of 2)
-    mask = gidx_t(1) << index;
-
-    // Add mask to key
-    if (quadrant == C || quadrant == D) {
-        key |= mask;
-    }
-
-    // Create a mask value with all trailing bits for rightmost bit (of 2)
-    mask = gidx_t(1) << (index - 1);
-
-    // Add mask to key
-    if (quadrant == B || quadrant == D) {
-        key |= mask;
-    }
-
-    return recursive_algorithm(p, box_quadrant, level + 1) + key;
-}
+// The Hilbert space-filling curve implementation has been moved to a reusable
+// component: atlas::grid::HilbertCurve (atlas/grid/SpaceFillingCurve.h), so that
+// it can be shared with the space-filling-curve grid partitioner.
+using Hilbert = grid::HilbertCurve;
 
 // ------------------------------------------------------------------
 

--- a/src/tests/grid/CMakeLists.txt
+++ b/src/tests/grid/CMakeLists.txt
@@ -31,6 +31,7 @@ foreach(test
         test_spacing
         test_largegrid
         test_grid_hash
+        test_partitioner_spacefilling
         )
     ecbuild_add_test( TARGET atlas_${test} SOURCES ${test}.cc LIBS atlas ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )
 endforeach()

--- a/src/tests/grid/test_partitioner_spacefilling.cc
+++ b/src/tests/grid/test_partitioner_spacefilling.cc
@@ -1,0 +1,312 @@
+/*
+ * (C) British Crown Copyright 2026 Met Office
+ *
+ */
+
+#include <algorithm>
+#include <vector>
+
+#include "atlas/grid/Distribution.h"
+#include "atlas/grid/Grid.h"
+#include "atlas/grid/Iterator.h"
+#include "atlas/grid/Partitioner.h"
+#include "atlas/grid/detail/partitioner/SpaceFillingCurvePartitioner.h"
+#include "atlas/util/Config.h"
+#include "atlas/util/Point.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+namespace atlas {
+namespace test {
+
+using grid::detail::partitioner::SpaceFillingCurvePartitioner;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// Helper: every point is assigned to a valid partition in [0, nb_parts).
+void check_valid_partitions(const grid::Distribution& d, int nb_parts) {
+    for (gidx_t n = 0; n < d.size(); ++n) {
+        const int p = d.partition(n);
+        EXPECT(p >= 0);
+        EXPECT(p < nb_parts);
+    }
+}
+
+// Helper: partition sizes differ by at most 1 (equal-count balancing).
+void check_balanced(const grid::Distribution& d, int nb_parts) {
+    const auto& counts = d.nb_pts();
+    EXPECT_EQ(static_cast<int>(counts.size()), nb_parts);
+
+    const gidx_t size      = d.size();
+    const idx_t floor_size = static_cast<idx_t>(size / nb_parts);
+    const idx_t ceil_size  = floor_size + (size % nb_parts != 0 ? 1 : 0);
+
+    idx_t total = 0;
+    for (idx_t c : counts) {
+        EXPECT(c >= floor_size);
+        EXPECT(c <= ceil_size);
+        total += c;
+    }
+    EXPECT_EQ(total, static_cast<idx_t>(size));
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+CASE("hilbert partitioner is registered") {
+    EXPECT(grid::Partitioner::exists("hilbert"));
+}
+
+CASE("single partition assigns everything to rank 0") {
+    Grid grid("O32");
+    grid::Partitioner partitioner("hilbert", 1);
+    auto d = partitioner.partition(grid);
+
+    EXPECT_EQ(d.nb_partitions(), 1);
+    for (gidx_t n = 0; n < d.size(); ++n) {
+        EXPECT_EQ(d.partition(n), 0);
+    }
+}
+
+CASE("all points assigned and partitions balanced") {
+    Grid grid("O32");
+    for (int nb_parts : {2, 3, 4, 7, 16}) {
+        grid::Partitioner partitioner("hilbert", nb_parts);
+        auto d = partitioner.partition(grid);
+
+        EXPECT_EQ(d.nb_partitions(), nb_parts);
+        EXPECT_EQ(d.size(), static_cast<gidx_t>(grid.size()));
+        check_valid_partitions(d, nb_parts);
+        check_balanced(d, nb_parts);
+    }
+}
+
+CASE("partition is deterministic / reproducible") {
+    Grid grid("O32");
+    grid::Partitioner p1("hilbert", 5);
+    grid::Partitioner p2("hilbert", 5);
+    auto d1 = p1.partition(grid);
+    auto d2 = p2.partition(grid);
+
+    EXPECT_EQ(d1.size(), d2.size());
+    for (gidx_t n = 0; n < d1.size(); ++n) {
+        EXPECT_EQ(d1.partition(n), d2.partition(n));
+    }
+}
+
+CASE("recursion configuration option is honoured") {
+    Grid grid("O32");
+    util::Config config;
+    config.set("partitions", 4);
+    config.set("recursion", 20);
+    grid::Partitioner partitioner("hilbert", config);
+    auto d = partitioner.partition(grid);
+
+    EXPECT_EQ(d.nb_partitions(), 4);
+    check_valid_partitions(d, 4);
+    check_balanced(d, 4);
+}
+
+CASE("regional grid (non-global bounding box) partitions correctly") {
+    // A regional lon-lat grid: the bounding box is a sub-region of the sphere,
+    // exercising the general (non-global) bounding-box path.
+    Grid grid(util::Config("type", "regional")("nx", 40)("ny", 30)("north", 60.)("south", 20.)("east", 40.)(
+        "west", -20.));
+
+    const int nb_parts = 6;
+    grid::Partitioner partitioner("hilbert", nb_parts);
+    auto d = partitioner.partition(grid);
+
+    EXPECT_EQ(d.nb_partitions(), nb_parts);
+    EXPECT_EQ(d.size(), static_cast<gidx_t>(grid.size()));
+    check_valid_partitions(d, nb_parts);
+    check_balanced(d, nb_parts);
+}
+
+CASE("space-filling curve preserves locality") {
+    // Rough locality check: the mean squared distance between consecutive
+    // grid points along the Hilbert ordering should be much smaller than
+    // between random pairs. Here we verify a weaker but robust property:
+    // each partition forms a spatially compact cluster, i.e. its bounding-box
+    // area is significantly smaller than the whole-grid bounding-box area.
+    Grid grid("O48");
+    const int nb_parts = 8;
+    grid::Partitioner partitioner("hilbert", nb_parts);
+    auto d = partitioner.partition(grid);
+
+    std::vector<double> xmin(nb_parts, 1e30), xmax(nb_parts, -1e30);
+    std::vector<double> ymin(nb_parts, 1e30), ymax(nb_parts, -1e30);
+    double gxmin = 1e30, gxmax = -1e30, gymin = 1e30, gymax = -1e30;
+
+    gidx_t n = 0;
+    for (const auto& ll : grid.lonlat()) {
+        const int p = d.partition(n++);
+        xmin[p]     = std::min(xmin[p], ll[0]);
+        xmax[p]     = std::max(xmax[p], ll[0]);
+        ymin[p]     = std::min(ymin[p], ll[1]);
+        ymax[p]     = std::max(ymax[p], ll[1]);
+        gxmin       = std::min(gxmin, ll[0]);
+        gxmax       = std::max(gxmax, ll[0]);
+        gymin       = std::min(gymin, ll[1]);
+        gymax       = std::max(gymax, ll[1]);
+    }
+
+    const double global_area = (gxmax - gxmin) * (gymax - gymin);
+    double sum_area          = 0.;
+    for (int p = 0; p < nb_parts; ++p) {
+        sum_area += (xmax[p] - xmin[p]) * (ymax[p] - ymin[p]);
+    }
+    // If partitions were spatially compact, the sum of their bounding-box areas
+    // is at most a small multiple of the global area. A naive banded/round-robin
+    // assignment would make each partition span the whole domain, giving
+    // sum_area ~ nb_parts * global_area.
+    EXPECT(sum_area < 2.0 * global_area);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Weighted variant
+//----------------------------------------------------------------------------------------------------------------------
+
+CASE("unit weight function reproduces the unweighted partition (neutral default)") {
+    Grid grid("O32");
+    const int nb_parts = 4;
+
+    SpaceFillingCurvePartitioner unweighted(nb_parts, util::NoConfig());
+    SpaceFillingCurvePartitioner uniform(nb_parts, util::NoConfig());
+    uniform.set_weight_function([](gidx_t, const PointXY&) { return 1.0; });
+
+    EXPECT(not unweighted.has_weight_function());
+    EXPECT(uniform.has_weight_function());
+
+    std::vector<int> part_a(grid.size());
+    std::vector<int> part_b(grid.size());
+    unweighted.partition(grid, part_a.data());
+    uniform.partition(grid, part_b.data());
+
+    for (gidx_t n = 0; n < static_cast<gidx_t>(grid.size()); ++n) {
+        EXPECT_EQ(part_a[n], part_b[n]);
+    }
+}
+
+CASE("weighted partition balances total weight, not point count") {
+    Grid grid("O48");
+    const int nb_parts = 8;
+
+    // A simple spatially-varying weight: northern-hemisphere points are 4x as
+    // costly as southern-hemisphere points. This mimics an observation-density
+    // imbalance concentrated in one region.
+    const double heavy = 4.0;
+    const double light = 1.0;
+    auto weight        = [heavy, light](gidx_t, const PointXY& p) { return p.y() > 0. ? heavy : light; };
+
+    SpaceFillingCurvePartitioner partitioner(nb_parts, util::NoConfig());
+    partitioner.set_weight_function(weight);
+
+    std::vector<int> part(grid.size());
+    partitioner.partition(grid, part.data());
+
+    // Accumulate per-partition weight and point count.
+    std::vector<double> part_weight(nb_parts, 0.);
+    std::vector<int> part_count(nb_parts, 0);
+    double max_point_weight = 0.;
+    gidx_t n                = 0;
+    for (const auto& ll : grid.lonlat()) {
+        const PointXY p{ll[0], ll[1]};
+        const int pp = part[n++];
+        EXPECT(pp >= 0);
+        EXPECT(pp < nb_parts);
+        const double w = (p.y() > 0. ? heavy : light);
+        part_weight[pp] += w;
+        part_count[pp] += 1;
+        max_point_weight = std::max(max_point_weight, w);
+    }
+
+    const double w_min = *std::min_element(part_weight.begin(), part_weight.end());
+    const double w_max = *std::max_element(part_weight.begin(), part_weight.end());
+    const int c_min    = *std::min_element(part_count.begin(), part_count.end());
+    const int c_max    = *std::max_element(part_count.begin(), part_count.end());
+
+    // (a) Total weight is balanced: a greedy contiguous cut leaves each partition
+    //     within one point's weight of the target on either side, so the spread is
+    //     bounded by twice the heaviest point weight.
+    EXPECT(w_max - w_min <= 2.0 * max_point_weight + 1.e-9);
+
+    // (b) The weighting genuinely changed the balance away from equal point count:
+    //     heavier (northern) regions get proportionally fewer points, so the point
+    //     counts are now clearly unequal (unlike the unweighted case, where they
+    //     differ by at most one).
+    EXPECT(c_max > c_min + 1);
+    EXPECT(c_max >= 2 * c_min);
+}
+
+CASE("masked (all-zero) weights fall back to a valid equal-count partition") {
+    Grid grid("O32");
+    const int nb_parts = 5;
+
+    SpaceFillingCurvePartitioner partitioner(nb_parts, util::NoConfig());
+    partitioner.set_weight_function([](gidx_t, const PointXY&) { return 0.0; });
+
+    std::vector<int> part(grid.size());
+    partitioner.partition(grid, part.data());
+
+    std::vector<int> count(nb_parts, 0);
+    for (gidx_t n = 0; n < static_cast<gidx_t>(grid.size()); ++n) {
+        EXPECT(part[n] >= 0);
+        EXPECT(part[n] < nb_parts);
+        count[part[n]] += 1;
+    }
+    const int size       = static_cast<int>(grid.size());
+    const int floor_size = size / nb_parts;
+    const int ceil_size  = floor_size + (size % nb_parts != 0 ? 1 : 0);
+    for (int c : count) {
+        EXPECT(c >= floor_size);
+        EXPECT(c <= ceil_size);
+    }
+}
+
+CASE("weights can be supplied as a precomputed array (grid-order indexed)") {
+    Grid grid("O48");
+    const int nb_parts     = 8;
+    const gidx_t nb_points = grid.size();
+
+    // Build a precomputed weight array in grid-iteration order, equivalent to the
+    // analytical northern-heavy weighting but expressed as raw per-point values -
+    // e.g. an observation count per grid point.
+    const double heavy = 4.0;
+    const double light = 1.0;
+    std::vector<double> weights(nb_points);
+    {
+        gidx_t n = 0;
+        for (const auto& ll : grid.lonlat()) {
+            weights[n++] = (ll[1] > 0. ? heavy : light);
+        }
+    }
+
+    // Partition once via the analytical function and once via the array; the two
+    // must produce identical partitions, demonstrating the array path is a faithful
+    // alternative to the functional path.
+    SpaceFillingCurvePartitioner by_function(nb_parts, util::NoConfig());
+    by_function.set_weight_function([heavy, light](gidx_t, const PointXY& p) { return p.y() > 0. ? heavy : light; });
+
+    SpaceFillingCurvePartitioner by_array(nb_parts, util::NoConfig());
+    by_array.set_weights(weights);
+
+    EXPECT(by_array.has_weight_function());
+
+    std::vector<int> part_fn(nb_points);
+    std::vector<int> part_arr(nb_points);
+    by_function.partition(grid, part_fn.data());
+    by_array.partition(grid, part_arr.data());
+
+    for (gidx_t n = 0; n < nb_points; ++n) {
+        EXPECT_EQ(part_fn[n], part_arr[n]);
+    }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}


### PR DESCRIPTION
### Description

Add a Hilbert space-filling-curve partitioner to atlas ("hilbert"), with optional per-point weighting.

Atlas' geometric partitioners balance point count across latitude bands. For grids where cost is spatially non-uniform (e.g. ORCA ocean grids where observations cluster in the northern hemisphere and vanish over land), this leaves MPI ranks badly imbalanced.

This adds a "hilbert" partitioner: points are sorted along a Hilbert curve and the 1-D ordering is cut into contiguous segments. The curve's spatial locality keeps each segment compact (low halo volume). By default the cut is equal-count and bit-identical to the existing equal-count result; an opt-in weight function (analytical, or a precomputed per-point array) instead balances total weight, so it's a strict generalisation.

### Issue Addessed

Fixes #394

### Summary of Changes

 *  The existing Hilbert-curve code is factored out of ReorderHilbert into a reusable grid::HilbertCurve helper (no algorithm change)
 *  atlas-meshgen gains --partition-points (a polygon-free, MPI-free scatter plot of the partition, useful for any partitioner) and a --weighted switch demonstrating the weight API.
 * Unit tests cover the equal-count invariant, the weight-balance property, the unit-weight (neutral) default, and the array-weight path.

### Testing

I have added unit tests, along with testing with the adapted `atlas-meshgen` executable.

With the O48 grid and the hilbert partitioner for 8 processors:

<img width="1800" height="900" alt="partition_points_unweighted" src="https://github.com/user-attachments/assets/53db4d9e-52fe-494d-aeda-3492ee6e368d" />

With the example 8x weight on northern hemisphere points, where the point size denotes the weight of each point:

<img width="1800" height="900" alt="partition_points_weighted" src="https://github.com/user-attachments/assets/b02747a8-6ce1-4b46-b8c5-292c32594afd" />

#### Ocean-specific testing

I setup a prototype partitioning of the extended ORCA025_T grid, using a weight distribution from *in-situ* observations in a testing branch of atlas-orca.

The weights are read from a simple 1-degree regular grid file:

<img width="1500" height="1350" alt="partition_weights_weights" src="https://github.com/user-attachments/assets/772d0a53-7392-4c29-a592-de52d8d90c76" />

This is used in the weighted Hilbert space-filling curve partitioner to produce:

<img width="1364" height="661" alt="image" src="https://github.com/user-attachments/assets/8d6c0017-0664-45c5-883e-c34a5507173a" />


### Known limitations

 * May produce spatially discontinuous partitions. 
   * Unlike the equal-area/band partitioners, a space-filling-curve partition (especially when weighted, or across the periodic seam/poles) is not guaranteed to be a single connected region per rank.
   * Partition distributions and halo build/exchange do not require contiguity and are unaffected, but anything that relies on building a single simply-connected partition polygon can fail. e.g the lon/lat-polygon matching-mesh partitioner and polygon-based point location used by some interpolation setups.
   * Whether discontinuous partitions are acceptable everywhere across Atlas has not been exhaustively verified.
 * Not yet exercised in production. 
   * The partitioner has unit-test coverage but is not yet used by any downstream mesh/model, so it has not been validated across the full range of Atlas grids and mesh generators.
 * No HPC performance evaluation yet.
   * The load-balancing benefit for the motivating case (observation-driven imbalance) has not been measured.
 * Weighting is opt-in and caller-supplied.
   * Weights are set programmatically (not via the string/config factory), so config-driven runs get the equal-count behaviour only. 
   * This is intentional (the balancing logic stays domain-agnostic; the caller owns where weights come from), but it means weighting can't currently be enabled purely from YAML/CLI.
 * Partitioning is computed independently on every rank.
   * Each rank sorts the full point set (O(N log N), no communication). This matches the other geometric partitioners and keeps results deterministic.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
