### PR TITLE
Add FieldBuilder concept with `grid-box-area` builder example

### DIFF
--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -469,6 +469,10 @@ list( APPEND atlas_field_srcs
 field.h
 field/Field.cc
 field/Field.h
+field/FieldBuilder.cc
+field/FieldBuilder.h
+field/builders/GridBoxArea.cc
+field/builders/GridBoxArea.h
 field/FieldCreator.cc
 field/FieldCreator.h
 field/FieldCreatorArraySpec.cc

--- a/src/atlas/field/FieldBuilder.cc
+++ b/src/atlas/field/FieldBuilder.cc
@@ -1,0 +1,36 @@
+/*
+ * (C) Copyright 2026 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "atlas/field/FieldBuilder.h"
+
+#include "atlas/field/builders/GridBoxArea.h"
+
+namespace atlas {
+namespace field {
+
+namespace {
+
+void force_link() {
+    static struct Link {
+        Link() { FieldBuilderFactoryBuilder<builders::GridBoxArea>(); }
+    } link;
+}
+
+}  // namespace
+
+const AbstractFieldBuilder* FieldBuilderFactory::build(const util::Config& config,
+                                                       const util::ObjectHandleBase& object) {
+    force_link();
+    const std::string type = config.getString("type");
+    return get(type)->make(config, object);
+}
+
+}  // namespace field
+}  // namespace atlas

--- a/src/atlas/field/FieldBuilder.h
+++ b/src/atlas/field/FieldBuilder.h
@@ -1,0 +1,74 @@
+/*
+ * (C) Copyright 2026 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "atlas/field/Field.h"
+#include "atlas/util/Config.h"
+#include "atlas/util/Factory.h"
+#include "atlas/util/Object.h"
+#include "atlas/util/ObjectHandle.h"
+
+namespace atlas {
+namespace field {
+
+/// Polymorphic implementation interface for operators that construct a Field.
+/// Implementations retain any source object state needed by the call operator.
+class AbstractFieldBuilder : public util::Object {
+public:
+    virtual Field operator()() const = 0;
+};
+
+/// Registry of named field-builder implementations.
+/// The configuration `type` selects a factory, which receives a generic Atlas object handle and the complete configuration.
+class FieldBuilderFactory : public util::Factory<FieldBuilderFactory> {
+public:
+    static std::string className() { return "FieldBuilderFactory"; }
+
+    static const AbstractFieldBuilder* build(const util::Config& config, const util::ObjectHandleBase& object);
+
+    using Factory::Factory;
+
+private:
+    virtual const AbstractFieldBuilder* make(const util::Config&, const util::ObjectHandleBase&) = 0;
+};
+
+/// Factory adapter that self-registers a concrete field-builder implementation.
+/// ConcreteFieldBuilder must accept `(const util::Config&, const util::ObjectHandleBase&)`.
+template <typename ConcreteFieldBuilder>
+class FieldBuilderFactoryBuilder : public FieldBuilderFactory {
+public:
+    using FieldBuilderFactory::FieldBuilderFactory;
+
+private:
+    const AbstractFieldBuilder* make(const util::Config& config, const util::ObjectHandleBase& object) override {
+        return new ConcreteFieldBuilder(config, object);
+    }
+};
+
+/// Owning public handle for a configured field-building operator.
+/// Construction resolves the implementation through FieldBuilderFactory; invocation returns the newly built Field.
+class FieldBuilder : public util::ObjectHandle<AbstractFieldBuilder> {
+public:
+    using Handle::Handle;
+
+    FieldBuilder(const util::Config& config, const util::ObjectHandleBase& object):
+        Handle(FieldBuilderFactory::build(config, object)) {}
+    FieldBuilder(const std::string& type, const util::ObjectHandleBase& object,
+                 const util::Config& config = util::NoConfig()):
+        Handle(FieldBuilderFactory::build(util::Config("type", type) | config, object)) {}
+
+    Field operator()() const { return get()->operator()(); }
+};
+
+}  // namespace field
+}  // namespace atlas

--- a/src/atlas/field/builders/GridBoxArea.cc
+++ b/src/atlas/field/builders/GridBoxArea.cc
@@ -1,0 +1,144 @@
+/*
+ * (C) Copyright 2026 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "atlas/field/builders/GridBoxArea.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "atlas/array.h"
+#include "atlas/functionspace/StructuredColumns.h"
+#include "atlas/util/Geometry.h"
+
+namespace atlas {
+namespace field {
+namespace builders {
+
+namespace {
+class StructuredColumnsAreaComputer {
+public:
+    StructuredColumnsAreaComputer(const functionspace::StructuredColumns& fs,
+                                  double radius = geometry::Earth().radius());
+
+    double operator()(idx_t point_index) const;
+    void operator()(double area[], std::size_t size) const;
+
+private:
+    double sin_latitude_strip_width(double lat_a, double lat_b) const;
+
+private:
+    const functionspace::StructuredColumns& fs_;
+    double radius_;
+    array::ArrayView<const idx_t, 1> index_i_;
+    array::ArrayView<const idx_t, 1> index_j_;
+    bool projection_in_degrees_;
+};
+
+StructuredColumnsAreaComputer::StructuredColumnsAreaComputer(const functionspace::StructuredColumns& fs,
+                                                             double radius):
+    fs_(fs),
+    radius_(radius),
+    index_i_(array::make_view<const idx_t, 1>(fs.index_i())),
+    index_j_(array::make_view<const idx_t, 1>(fs.index_j())) {
+    auto proj_type = fs_.projection().type();
+    if (proj_type == "rotated_lonlat" || proj_type == "lonlat") {
+        projection_in_degrees_ = true;
+    }
+    else if (fs_.projection().units() == "meters") {
+        projection_in_degrees_ = false;
+    }
+    else {
+        ATLAS_DEBUG("Projection type = " << proj_type);
+        throw_Exception("StructuredColumnsAreaComputer only works for (rotated) lonlat grids or projections in meters",
+                        Here());
+    }
+}
+
+double StructuredColumnsAreaComputer::operator()(idx_t point_index) const {
+    idx_t i          = index_i_(point_index);
+    idx_t j          = index_j_(point_index);
+    PointXY xy       = fs_.compute_xy(i, j);
+    double y         = xy.y();
+    double yN        = 0.5 * (y + fs_.compute_xy(i, j - 1).y());
+    double yS        = 0.5 * (y + fs_.compute_xy(i, j + 1).y());
+    idx_t j_internal = fs_.compute_j(j);
+    const double dx  = fs_.grid().dx(j_internal);
+    if (projection_in_degrees_) {
+        constexpr double deg2rad = M_PI / 180.0;
+        return radius_ * radius_ * dx * deg2rad * sin_latitude_strip_width(yN, yS);
+    }
+    return dx * std::abs(yN - yS);
+}
+
+void StructuredColumnsAreaComputer::operator()(double area[], std::size_t size) const {
+    ATLAS_ASSERT(size == fs_.size());
+    for (idx_t j = fs_.j_begin_halo(); j < fs_.j_end_halo(); ++j) {
+        const idx_t i_begin = fs_.i_begin_halo(j);
+        const idx_t i_end   = fs_.i_end_halo(j);
+        if (i_begin == i_end) {
+            continue;
+        }
+
+        const idx_t first_row_point       = fs_.index(i_begin, j);
+        const double first_row_point_area = operator()(first_row_point);
+
+        for (idx_t i = i_begin; i < i_end; ++i) {
+            area[fs_.index(i, j)] = first_row_point_area;
+        }
+    }
+}
+
+double StructuredColumnsAreaComputer::sin_latitude_strip_width(double lat_a, double lat_b) const {
+    constexpr double deg2rad = M_PI / 180.0;
+    const double lat_max     = std::max(lat_a, lat_b);
+    const double lat_min     = std::min(lat_a, lat_b);
+    if (lat_max > 90. && lat_min < 90.) {
+        return std::abs(std::sin(lat_max * deg2rad) - std::sin(90. * deg2rad)) +
+               std::abs(std::sin(lat_min * deg2rad) - std::sin(90. * deg2rad));
+    }
+    if (lat_min < -90. && lat_max > -90.) {
+        return std::abs(std::sin(lat_max * deg2rad) - std::sin(-90. * deg2rad)) +
+               std::abs(std::sin(lat_min * deg2rad) - std::sin(-90. * deg2rad));
+    }
+    return std::abs(std::sin(lat_max * deg2rad) - std::sin(lat_min * deg2rad));
+}
+
+}  // namespace
+
+static FieldBuilderFactoryBuilder<GridBoxArea> register_grid_box_area("grid-box-area");
+
+GridBoxArea::GridBoxArea(const util::Config& config, const util::ObjectHandleBase& object) {
+    const auto* fs = dynamic_cast<const FunctionSpace*>(&object);
+    if (not fs) {
+        throw_Exception("GridBoxArea requires a FunctionSpace object handle", Here());
+    }
+    fs_ = functionspace::StructuredColumns(*fs);
+    if (not fs_) {
+        throw_Exception("GridBoxArea only works for StructuredColumns function spaces", Here());
+    }
+    field_name_ = config.getString("field_name", "area");
+    radius_     = geometry::Earth().radius();
+    config.get("radius", radius_);
+    if (config.has("geometry")) {
+        const std::string geometry_name = config.getString("geometry");
+        radius_                         = Geometry(geometry_name).radius();
+    }
+}
+
+Field GridBoxArea::operator()() const {
+    Field area = fs_.createField<double>(option::name(field_name_) | option::levels(0));
+    StructuredColumnsAreaComputer area_computer(fs_, radius_);
+    area_computer(array::make_view<double, 1>(area).data(), area.size());
+    return area;
+}
+
+}  // namespace builders
+}  // namespace field
+}  // namespace atlas

--- a/src/atlas/field/builders/GridBoxArea.h
+++ b/src/atlas/field/builders/GridBoxArea.h
@@ -1,0 +1,81 @@
+/*
+ * (C) Copyright 2026 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "atlas/field/FieldBuilder.h"
+#include "atlas/functionspace/StructuredColumns.h"
+
+namespace atlas {
+namespace field {
+namespace builders {
+
+/**
+ * \brief Build a field containing a representative grid-box area in square metres.
+ *
+ * The source object must be a FunctionSpace backed by
+ * functionspace::StructuredColumns. The underlying projection must either be
+ * `lonlat` or `rotated_lonlat`, with coordinates in degrees, or report its
+ * coordinate units as metres. Other function spaces and projection units are
+ * rejected.
+ *
+ * Grid boxes are bounded by the midpoints between neighbouring row and column
+ * coordinates. The algorithm assumes that the longitudinal or projected
+ * x-spacing is constant within each structured row. Consequently, one area is
+ * computed per row and assigned to every local point in that row, including
+ * halo points. Halo rows use StructuredColumns::compute_j() to select the
+ * corresponding internal row spacing and StructuredColumns::compute_xy() to
+ * obtain reflected boundary coordinates.
+ *
+ * For a spherical lon/lat grid, the area between longitudes
+ * \f$\lambda_W,\lambda_E\f$ and latitudes \f$\phi_S,\phi_N\f$ is evaluated by
+ * integrating the spherical surface element:
+ *
+ * \f[
+ * A = \int_{\lambda_W}^{\lambda_E}\int_{\phi_S}^{\phi_N}
+ *     R^2\cos(\phi)\,\mathrm{d}\phi\,\mathrm{d}\lambda
+ *   = R^2\left|\lambda_E-\lambda_W\right|
+ *     \left|\sin(\phi_N)-\sin(\phi_S)\right|.
+ * \f]
+ *
+ * Angular quantities are converted from degrees to radians. A strip crossing
+ * either pole is split at \f$\phi=\pm\frac{\pi}{2}\f$ so mirrored latitude
+ * contributions do not cancel.
+ *
+ * For projections expressed in metres, each grid box is treated as a planar
+ * rectangle:
+ *
+ * \f[
+ * A = \left|x_E-x_W\right|\,\left|y_N-y_S\right|
+ *   = \Delta x\,\left|y_N-y_S\right|.
+ * \f]
+ *
+ * The result is a rank-one double-precision Field with no vertical levels.
+ * Its name defaults to `area` and can be changed with `field_name`. The sphere
+ * radius defaults to geometry::Earth().radius() and can be set with `radius`.
+ * If `geometry` is supplied, its radius takes precedence over `radius`.
+ */
+class GridBoxArea : public AbstractFieldBuilder {
+public:
+    GridBoxArea(const util::Config& config, const util::ObjectHandleBase& object);
+
+    Field operator()() const override;
+
+private:
+    functionspace::StructuredColumns fs_;
+    std::string field_name_;
+    double radius_;
+};
+
+}  // namespace builders
+}  // namespace field
+}  // namespace atlas

--- a/src/atlas/functionspace/StructuredColumns.h
+++ b/src/atlas/functionspace/StructuredColumns.h
@@ -78,6 +78,7 @@ public:
     Field index_j() const { return functionspace_->index_j(); }
     Field ghost() const { return functionspace_->ghost(); }
 
+    idx_t compute_j(idx_t j) const { return functionspace_->compute_j(j); }
     void compute_xy(idx_t i, idx_t j, PointXY& xy) const { return functionspace_->compute_xy(i, j, xy); }
     PointXY compute_xy(idx_t i, idx_t j) const { return functionspace_->compute_xy(i, j); }
 

--- a/src/atlas/functionspace/detail/StructuredColumns.cc
+++ b/src/atlas/functionspace/detail/StructuredColumns.cc
@@ -570,18 +570,35 @@ StructuredColumns::StructuredColumns(const Grid& grid, const Vertical& vertical,
 
 // ----------------------------------------------------------------------------
 
-void StructuredColumns::compute_xy(idx_t i, idx_t j, PointXY& xy) const {
-    idx_t jj;
+idx_t StructuredColumns::compute_j(idx_t j) const {
     if (j < 0) {
-        jj     = -j - 1 + north_pole_included_;
-        xy[YY] = 180. - grid_->y(jj);
+        return grid_is_regional_ ? -j : -j - 1 + north_pole_included_;
+    }
+    if (j >= ny_) {
+        return grid_is_regional_ ? 2 * ny_ - j - 2 : 2 * ny_ - j - 1 - south_pole_included_;
+    }
+    return j;
+}
+
+void StructuredColumns::compute_xy(idx_t i, idx_t j, PointXY& xy) const {
+    const idx_t jj = compute_j(j);
+    if (j < 0) {
+        if (grid_is_regional_) {
+            xy[YY] = 2. * grid_->y(0) - grid_->y(jj);
+        }
+        else {
+            xy[YY] = 180. - grid_->y(jj);
+        }
     }
     else if (j >= ny_) {
-        jj     = 2 * ny_ - j - 1 - south_pole_included_;
-        xy[YY] = -180. - grid_->y(jj);
+        if (grid_is_regional_) {
+            xy[YY] = 2. * grid_->y(ny_ - 1) - grid_->y(jj);
+        }
+        else {
+            xy[YY] = -180. - grid_->y(jj);
+        }
     }
     else {
-        jj     = j;
         xy[YY] = grid_->y(jj);
     }
     xy[XX] = grid_->x(i, jj);

--- a/src/atlas/functionspace/detail/StructuredColumns.h
+++ b/src/atlas/functionspace/detail/StructuredColumns.h
@@ -152,6 +152,7 @@ public:
     Field index_j() const { return field_index_j_; }
     Field ghost() const override { return field_ghost_; }
 
+    idx_t compute_j(idx_t j) const;
     void compute_xy(idx_t i, idx_t j, PointXY& xy) const;
     PointXY compute_xy(idx_t i, idx_t j) const {
         PointXY xy;
@@ -306,6 +307,7 @@ private:  // data
 
     idx_t north_pole_included_;
     idx_t south_pole_included_;
+    bool grid_is_regional_;
     idx_t ny_;
 
     idx_t part_;

--- a/src/atlas/functionspace/detail/StructuredColumns_setup.cc
+++ b/src/atlas/functionspace/detail/StructuredColumns_setup.cc
@@ -100,8 +100,9 @@ void StructuredColumns::setup(const grid::Distribution& distribution, const ecki
     const double eps = 1.e-12;
 
     ny_                  = grid_->ny();
-    north_pole_included_ = 90. - grid_->y(0) == 0.;
-    south_pole_included_ = 90. + grid_->y(ny_ - 1) == 0;
+    grid_is_regional_    = regional;
+    north_pole_included_ = (!regional && grid_->projection().units() == "degrees" && 90. - grid_->y(0) == 0.);
+    south_pole_included_ = (!regional && grid_->projection().units() == "degrees" && 90. + grid_->y(ny_ - 1) == 0.);
 
     distribution_ = distribution.type();
 

--- a/src/atlas/interpolation/method/structured/kernels/Cubic3DLimiter.h
+++ b/src/atlas/interpolation/method/structured/kernels/Cubic3DLimiter.h
@@ -83,15 +83,18 @@ public:
         //          x       *------ *        x
         //        x        x        x         x
 
+        //                           k0          k1          k2        k3
+        //  k_interval:    <--  -1   |-----0-----|-----1-----|----2----|    3  -->
+        //
         using Value = typename OutputArray::value_type;
 
-        const idx_t k = stencil.k_interval();
+        const idx_t k_interval = stencil.k_interval();
         idx_t k1, k2;
-        if (k < 1) {
+        if (k_interval < 1) {
             k1 = stencil.k(0);
             k2 = stencil.k(1);
         }
-        else if (k > 1) {
+        else if (k_interval > 1) {
             k1 = stencil.k(2);
             k2 = stencil.k(3);
         }

--- a/src/atlas/util/vector.h
+++ b/src/atlas/util/vector.h
@@ -68,7 +68,7 @@ public:
 
     template <typename idx_t, typename std::enable_if<std::is_integral<idx_t>::value, int>::type = 0>
     T& at(idx_t i) noexcept(false) {
-        if (i >= size_) {
+        if (i >= static_cast<idx_t>(size_)) {
             throw_OutOfRange("atlas::vector", i, size_);
         }
         return data_[i];
@@ -76,7 +76,7 @@ public:
 
     template <typename idx_t, typename std::enable_if<std::is_integral<idx_t>::value, int>::type = 0>
     T const& at(idx_t i) const noexcept(false) {
-        if (i >= size_) {
+        if (i >= static_cast<idx_t>(size_)) {
             throw_OutOfRange("atlas::vector", i, size_);
         }
         return data_[i];

--- a/src/tests/functionspace/CMakeLists.txt
+++ b/src/tests/functionspace/CMakeLists.txt
@@ -102,6 +102,12 @@ ecbuild_add_test( TARGET atlas_test_structuredcolumns
   CONDITION eckit_HAVE_MPI AND MPI_SLOTS GREATER_EQUAL 5
 )
 
+ecbuild_add_test( TARGET atlas_test_structuredcolumns_area
+  SOURCES  test_structuredcolumns_area.cc
+  LIBS     atlas
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
+
 ecbuild_add_test( TARGET atlas_test_blockstructuredcolumns
   MPI        3
   SOURCES  test_blockstructuredcolumns.cc

--- a/src/tests/functionspace/test_structuredcolumns_area.cc
+++ b/src/tests/functionspace/test_structuredcolumns_area.cc
@@ -1,0 +1,147 @@
+/*
+ * (C) Copyright 2026 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "atlas/array.h"
+#include "atlas/field/FieldBuilder.h"
+#include "atlas/field/Field.h"
+#include "atlas/functionspace/StructuredColumns.h"
+#include "atlas/grid/Grid.h"
+#include "atlas/grid/StructuredGrid.h"
+#include "atlas/util/Config.h"
+#include "atlas/util/Geometry.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+namespace atlas {
+namespace test {
+
+namespace {
+
+void validate_build_area_field(const Grid& grid) {
+    const double one_square_metre = 1.e6;
+    functionspace::StructuredColumns fs(grid, option::halo(1));
+
+    field::FieldBuilder build_area_field{"grid-box-area", fs};
+    Field area_field = build_area_field();
+    auto area         = array::make_view<double, 1>(area_field);
+
+    EXPECT_EQ(area_field.name(), "area");
+    EXPECT_EQ(area_field.shape(0), fs.size());
+
+    idx_t checked_rows = 0;
+    for (idx_t j = fs.j_begin_halo(); j < fs.j_end_halo(); ++j) {
+        const idx_t i_begin = fs.i_begin_halo(j);
+        const idx_t i_end   = fs.i_end_halo(j);
+        if (i_begin == i_end) {
+            continue;
+        }
+
+        const double row_area = area(fs.index(i_begin, j));
+
+        Log::info() << "Row " << j << " representative area = " << row_area / 1.e6 << " km^2" << std::endl;
+        EXPECT(std::isfinite(row_area));
+        EXPECT(row_area >= one_square_metre);
+        ++checked_rows;
+
+        for (idx_t i = i_begin; i < i_end; ++i) {
+            const idx_t point_index = fs.index(i, j);
+            EXPECT_EQ(area(point_index), row_area);
+        }
+    }
+    EXPECT(checked_rows > 0);
+}
+
+Grid rotated_o32() {
+    return Grid("O32", Projection(option::type("rotated_lonlat") |
+                                  util::Config("north_pole", {-176., 40.})));
+}
+
+Grid regional_lonlat() {
+    const int Nx = 8, Ny = 8;
+    const double xmin = +20, xmax = +60, ymin = +20, ymax = +60;
+
+    StructuredGrid::XSpace xspace(util::Config("type", "linear")("N", Nx)("start", xmin)("end", xmax));
+    StructuredGrid::YSpace yspace(util::Config("type", "linear")("N", Ny)("start", ymin)("end", ymax));
+
+    return StructuredGrid(xspace, yspace);
+}
+
+Grid regional_lambert() {
+    util::Config gridspec;
+    gridspec.set("type", "regional");
+    gridspec.set("nx", 21);
+    gridspec.set("ny", 31);
+    gridspec.set("dx", 8000.);
+    gridspec.set("dy", 9000.);
+    gridspec.set("lonlat(centre)", {9.9, 56.3});
+    gridspec.set("projection", [] {
+        util::Config projection;
+        projection.set("type", "lambert_conformal_conic");
+        projection.set("longitude0", 0.);
+        projection.set("latitude0", 56.3);
+        return projection;
+    }());
+    return Grid(gridspec);
+}
+
+
+}  // namespace
+
+CASE("test Grid(O32) area field") {
+    validate_build_area_field(Grid("O32"));
+}
+
+CASE("test global regular lonlat 5 degree area field") {
+    validate_build_area_field(Grid("L72x37"));
+}
+
+CASE("test rotated Grid(O32) area field") {
+    validate_build_area_field(rotated_o32());
+}
+
+CASE("test regional lonlat area field") {
+    validate_build_area_field(regional_lonlat());
+}
+
+CASE("test regional lambert area field") {
+    validate_build_area_field(regional_lambert());
+}
+
+CASE("test grid-box-area configuration") {
+    functionspace::StructuredColumns fs(Grid("O32"), option::halo(1));
+    const idx_t point_index = fs.index(fs.i_begin(fs.j_begin()), fs.j_begin());
+
+    Field default_area = field::FieldBuilder("grid-box-area", fs)();
+    Field named_area = field::FieldBuilder("grid-box-area", fs, util::Config("field_name", "cell_area"))();
+    Field radius_area = field::FieldBuilder("grid-box-area", fs, util::Config("radius", 2.))();
+    Field unit_sphere_area = field::FieldBuilder("grid-box-area", fs, util::Config("geometry", "UnitSphere"))();
+    Field geometry_overrides_radius = field::FieldBuilder("grid-box-area", fs, util::Config("radius", 2.)("geometry", "UnitSphere"))();
+
+    const auto default_view = array::make_view<double, 1>(default_area);
+    const auto radius_view = array::make_view<double, 1>(radius_area);
+    const auto unit_sphere_view = array::make_view<double, 1>(unit_sphere_area);
+    const auto override_view = array::make_view<double, 1>(geometry_overrides_radius);
+
+    EXPECT_EQ(default_area.name(), "area");
+    EXPECT_EQ(named_area.name(), "cell_area");
+
+    const double earth_radius = geometry::Earth().radius();
+    EXPECT_APPROX_EQ(radius_view(point_index) / default_view(point_index), 4. / (earth_radius * earth_radius), 1.e-14);
+    EXPECT_APPROX_EQ(unit_sphere_view(point_index) / default_view(point_index),
+                     1. / (earth_radius * earth_radius), 1.e-14);
+    EXPECT_EQ(override_view(point_index), unit_sphere_view(point_index));
+}
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}

--- a/src/tests/functionspace/test_structuredcolumns_regional.cc
+++ b/src/tests/functionspace/test_structuredcolumns_regional.cc
@@ -36,6 +36,28 @@ namespace test {
 
 //-----------------------------------------------------------------------------
 
+CASE("regional compute_xy reflects halo rows") {
+    const int Nx = 8, Ny = 8;
+    StructuredGrid::XSpace xspace(Config("type", "linear")("N", Nx)("start", 20.)("end", 60.));
+    StructuredGrid::YSpace yspace(Config("type", "linear")("N", Ny)("start", 20.)("end", 60.));
+    StructuredGrid grid(xspace, yspace);
+    functionspace::StructuredColumns fs(grid, grid::Partitioner("checkerboard"), Config("halo", 2));
+
+    const idx_t i = 0;
+
+    const idx_t north_jj    = 2;
+    const PointXY north_halo = fs.compute_xy(i, -2);
+    EXPECT_EQ(north_halo.x(), grid.x(i, north_jj));
+    EXPECT_EQ(north_halo.y(), 2. * grid.y(0) - grid.y(north_jj));
+
+    const idx_t south_jj    = Ny - 3;
+    const PointXY south_halo = fs.compute_xy(i, Ny + 1);
+    EXPECT_EQ(south_halo.x(), grid.x(i, south_jj));
+    EXPECT_EQ(south_halo.y(), 2. * grid.y(Ny - 1) - grid.y(south_jj));
+}
+
+//-----------------------------------------------------------------------------
+
 CASE("regional lonlat") {
     const int Nx = 8, Ny = 8;
     const double xmin = +20, xmax = +60, ymin = +20, ymax = +60;


### PR DESCRIPTION
This pull request introduces a new extensible framework for constructing fields via a `FieldBuilder` interface and provides an initial implementation for calculating grid-box areas for structured grids. It also includes supporting changes in the function space API, minor bug fixes, and a new test to verify the grid-box area computation.

**Field construction framework:**

* Added a generic `FieldBuilder` interface and factory system (`FieldBuilder.h`, `FieldBuilder.cc`) for constructing fields based on runtime configuration and source objects. This enables extensible, polymorphic field creation.
* Implemented the `GridBoxArea` field builder, which computes representative grid-box areas for structured grids, handling both spherical and planar projections. This builder is registered with the new factory system. 
**Function space API enhancements:**

* Added `compute_j(idx_t j)` to `StructuredColumns` and its implementation, which provides correct row indexing for both global and regional grids, and refactored `compute_xy` to use it. 
* Fix `compute_xy(idx_t i, idx_t j)` in `StructuredColumns` to allow for halo extension.

**Testing and bug fixes:**

* Added a new test target `atlas_test_structuredcolumns_area` to verify the area calculation logic.
* Fixed type handling in the `atlas::vector` bounds-checked accessors to prevent unsigned/signed comparison warnings.
* Improved variable naming in the cubic limiter kernel for clarity.


<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-396
<!-- STATIC-ANALYSIS_END -->