### PR TITLE
[Fortran] Add constructor for atlas_UnstructuredGrid(x,y) and atlas_Mesh(grid)

### DIFF
--- a/src/atlas/grid/detail/grid/Unstructured.cc
+++ b/src/atlas/grid/detail/grid/Unstructured.cc
@@ -283,6 +283,10 @@ const Unstructured* atlas__grid__Unstructured__points(const double xy[], int sha
     return new Unstructured(std::move(points));
 }
 
+const Unstructured* atlas__grid__Unstructured__x_y(size_t size, const double x[], const double y[], size_t xstride, size_t ystride) {
+    return new Unstructured(size, x, y, xstride, ystride);
+}
+
 const Unstructured* atlas__grid__Unstructured__config(util::Config* conf) {
     ATLAS_ASSERT(conf != nullptr);
     const Unstructured* grid = dynamic_cast<const Unstructured*>(Grid::create(*conf));

--- a/src/atlas/grid/detail/grid/Unstructured.h
+++ b/src/atlas/grid/detail/grid/Unstructured.h
@@ -239,6 +239,7 @@ protected:
 
 extern "C" {
 const Unstructured* atlas__grid__Unstructured__points(const double lonlat[], int shapef[], int stridesf[]);
+const Unstructured* atlas__grid__Unstructured__x_y(size_t size, const double x[], const double y[], size_t xstride, size_t ystride);
 const Unstructured* atlas__grid__Unstructured__config(util::Config* conf);
 }
 

--- a/src/atlas/mesh/detail/MeshIntf.cc
+++ b/src/atlas/mesh/detail/MeshIntf.cc
@@ -8,6 +8,8 @@
  * nor does it submit to any jurisdiction.
  */
 
+#include "atlas/grid/Grid.h"
+#include "atlas/grid/detail/grid/Grid.h"
 #include "atlas/mesh/detail/MeshIntf.h"
 #include "atlas/mesh/Nodes.h"
 #include "atlas/runtime/Exception.h"
@@ -20,6 +22,18 @@ namespace mesh {
 
 Mesh::Implementation* atlas__Mesh__new() {
     return new Mesh::Implementation();
+}
+
+Mesh::Implementation* atlas__Mesh__new_grid(Grid::Implementation* grid) {
+    Mesh::Implementation* mesh;
+    {
+        Grid g(grid);
+        Mesh m{Grid{grid}};
+        mesh = m.get();
+        mesh->attach();
+    }
+    mesh->detach();
+    return mesh;
 }
 
 void atlas__Mesh__delete(Mesh::Implementation* This) {

--- a/src/atlas/mesh/detail/MeshIntf.h
+++ b/src/atlas/mesh/detail/MeshIntf.h
@@ -20,6 +20,7 @@ namespace mesh {
 // C wrapper interfaces to C++ routines
 extern "C" {
 Mesh::Implementation* atlas__Mesh__new();
+Mesh::Implementation* atlas__Mesh__new_grid(Grid::Implementation* grid);
 void atlas__Mesh__delete(Mesh::Implementation* This);
 Nodes* atlas__Mesh__nodes(Mesh::Implementation* This);
 Edges* atlas__Mesh__edges(Mesh::Implementation* This);

--- a/src/atlas_f/grid/atlas_Grid_module.F90
+++ b/src/atlas_f/grid/atlas_Grid_module.F90
@@ -96,6 +96,7 @@ END TYPE atlas_UnstructuredGrid
 
 interface atlas_UnstructuredGrid
   module procedure atlas_UnstructuredGrid__ctor_points
+  module procedure atlas_UnstructuredGrid__ctor_xy
   module procedure atlas_UnstructuredGrid__ctor_config
   module procedure atlas_UnstructuredGrid__ctor_cptr
 end interface
@@ -563,6 +564,28 @@ function atlas_UnstructuredGrid__ctor_points( xy ) result(this)
   shapef = shape(xy)
   stridesf = array_strides(xy)
   call this%reset_c_ptr( atlas__grid__Unstructured__points( xy1d, shapef, stridesf ) )
+  call this%return()
+end function
+
+function atlas_UnstructuredGrid__ctor_xy(x, y) result(this)
+  use, intrinsic :: iso_c_binding, only : c_double, c_size_t
+  use atlas_grid_unstructured_c_binding
+  type(atlas_UnstructuredGrid) :: this
+  real(c_double), intent(in) :: x(:)
+  real(c_double), intent(in) :: y(:)
+  integer(c_size_t) :: xstride
+  integer(c_size_t) :: ystride
+
+  integer(c_size_t) :: n
+  n = size(x, kind=c_size_t)
+  if (n /= size(y, kind=c_size_t)) then
+    error stop 'atlas_UnstructuredGrid(x,y): x and y must have the same size'
+  end if
+
+  xstride = 1_c_size_t
+  ystride = 1_c_size_t
+
+  call this%reset_c_ptr( atlas__grid__Unstructured__x_y(n, x, y, xstride, ystride) )
   call this%return()
 end function
 

--- a/src/atlas_f/mesh/atlas_Mesh_module.F90
+++ b/src/atlas_f/mesh/atlas_Mesh_module.F90
@@ -14,6 +14,7 @@ use fckit_owned_object_module, only: fckit_owned_object
 use atlas_mesh_Cells_module, only: atlas_mesh_Cells
 use atlas_mesh_Nodes_module, only: atlas_mesh_Nodes
 use atlas_mesh_Edges_module, only: atlas_mesh_Edges
+use atlas_Grid_module, only: atlas_Grid
 use, intrinsic :: iso_c_binding, only : c_size_t, c_ptr
 
 implicit none
@@ -66,6 +67,7 @@ END TYPE atlas_Mesh
 interface atlas_Mesh
   module procedure atlas_Mesh__cptr
   module procedure atlas_Mesh__ctor
+  module procedure atlas_Mesh__ctor_grid
 end interface
 
 !========================================================
@@ -88,6 +90,16 @@ function atlas_Mesh__ctor() result(this)
   call this%reset_c_ptr( atlas__Mesh__new() )
   call this%return()
 end function atlas_Mesh__ctor
+
+!-------------------------------------------------------------------------------
+
+function atlas_Mesh__ctor_grid(grid) result(this)
+  use atlas_mesh_c_binding
+  type(atlas_Mesh) :: this
+  class(atlas_Grid), intent(in) :: grid
+  call this%reset_c_ptr( atlas__Mesh__new_grid(grid%c_ptr()) )
+  call this%return()
+end function atlas_Mesh__ctor_grid
 
 !-------------------------------------------------------------------------------
 

--- a/src/tests/grid/fctest_unstructuredgrid.F90
+++ b/src/tests/grid/fctest_unstructuredgrid.F90
@@ -13,34 +13,15 @@
 
 ! -----------------------------------------------------------------------------
 
-TESTSUITE(fctest_unstructuredgrid)
-
-! -----------------------------------------------------------------------------
-
-TESTSUITE_INIT
-  use atlas_module
-  call atlas_library%initialise()
-END_TESTSUITE_INIT
-
-! -----------------------------------------------------------------------------
-
-TESTSUITE_FINALIZE
-  use atlas_module
-  call atlas_library%finalise()
-END_TESTSUITE_FINALIZE
-
-! ----------------------------------------------------------------------------
-
-TEST( test_unstructuredgrid )
-  use, intrinsic :: iso_c_binding
-  use atlas_module
+module fixture_unstructuredgrid
+  use, intrinsic :: iso_c_binding, only : c_double
   implicit none
-  type(atlas_UnstructuredGrid) :: grid
-  type(atlas_Mesh) :: mesh
-  type(atlas_Output) :: gmsh
-  type(atlas_MeshGenerator) :: meshgenerator
 
   real(c_double) :: xy(2,173)
+
+contains
+
+subroutine init_xy()
   xy(:,1) = [180,0]
   xy(:,2) = [90,0]
   xy(:,3) = [-90,0]
@@ -214,6 +195,38 @@ TEST( test_unstructuredgrid )
   xy(:,171) = [44.2448,-15.2529]
   xy(:,172) = [73.9368,-14.4869]
   xy(:,173) = [60.5478,-11.7037]
+end subroutine
+
+end module
+
+! -----------------------------------------------------------------------------
+
+TESTSUITE_WITH_FIXTURE(fctest_unstructuredgrid, fixture_unstructuredgrid)
+
+! -----------------------------------------------------------------------------
+
+TESTSUITE_INIT
+  use atlas_module
+  call atlas_library%initialise()
+  call init_xy()
+END_TESTSUITE_INIT
+
+! -----------------------------------------------------------------------------
+
+TESTSUITE_FINALIZE
+  use atlas_module
+  call atlas_library%finalise()
+END_TESTSUITE_FINALIZE
+
+! ----------------------------------------------------------------------------
+
+TEST( test_unstructuredgrid )
+  use atlas_module
+  implicit none
+  type(atlas_UnstructuredGrid) :: grid
+  type(atlas_Mesh) :: mesh
+  type(atlas_Output) :: gmsh
+  type(atlas_MeshGenerator) :: meshgenerator
 
   grid = atlas_UnstructuredGrid(xy)
 
@@ -234,6 +247,48 @@ TEST( test_unstructuredgrid )
   call gmsh%final()
   call grid%final()
   call meshgenerator%final()
+END_TEST
+
+! -----------------------------------------------------------------------------
+
+TEST( test_unstructuredgrid_x_and_y_mesh_constructor )
+  use, intrinsic :: iso_c_binding
+  use atlas_module
+  implicit none
+  type(atlas_UnstructuredGrid) :: grid
+  type(atlas_Mesh) :: mesh
+  type(atlas_mesh_Nodes) :: nodes
+  type(atlas_Field) :: lonlat
+  real(c_double), allocatable :: x(:), y(:)
+  real(c_double), pointer :: lonlat_view(:,:)
+  integer(c_int) :: grid_size
+
+  grid_size = size(xy,2)
+  x = xy(1,:)
+  y = xy(2,:)
+
+  grid = atlas_UnstructuredGrid(x, y)
+
+  FCTEST_CHECK_EQUAL( int(grid%size(), c_int), grid_size )
+  FCTEST_CHECK_EQUAL( grid%owners(), 1 )
+
+  mesh = atlas_Mesh(grid)
+
+  nodes = mesh%nodes()
+  lonlat = nodes%lonlat()
+  call lonlat%data(lonlat_view)
+
+  FCTEST_CHECK_EQUAL( mesh%owners(), 1 )
+  FCTEST_CHECK_EQUAL( grid%owners(), 2 )
+  FCTEST_CHECK_EQUAL( int(nodes%size(), c_int), grid_size )
+  FCTEST_CHECK_CLOSE( lonlat_view(1,:), x, 1.e-12_c_double )
+  FCTEST_CHECK_CLOSE( lonlat_view(2,:), y, 1.e-12_c_double )
+
+  call lonlat%final()
+  call nodes%final()
+  call mesh%final()
+  FCTEST_CHECK_EQUAL( grid%owners(), 1 )
+  call grid%final()
 END_TEST
 
 ! -----------------------------------------------------------------------------


### PR DESCRIPTION
### Description
This pull request introduces new constructors and interfaces for creating unstructured grids and meshes from separate `x` and `y` coordinate arrays.

* Added a new C++ function `atlas__grid__Unstructured__x_y` and corresponding Fortran interface to construct an `Unstructured` grid from separate `x` and `y` arrays, including support for strides.
* Added a new C++ and Fortran interface for constructing a `Mesh` directly from a `Grid`, with the function `atlas__Mesh__new_grid` and the Fortran procedure `atlas_Mesh__ctor_grid`. 
* Added a new test (`test_unstructuredgrid_x_and_y_mesh_constructor`) to verify the new grid and mesh constructors using separate `x` and `y` arrays, including checks for memory ownership and data correctness.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-398
<!-- STATIC-ANALYSIS_END -->