### PR TITLE
Add atlas_Grid type function and Mesh constructors with distribution and partitioner

### DIFF
--- a/src/atlas/grid/Partitioner.cc
+++ b/src/atlas/grid/Partitioner.cc
@@ -10,11 +10,13 @@
 
 #include "atlas/grid/Partitioner.h"
 #include "atlas/functionspace/FunctionSpace.h"
+#include "atlas/functionspace/detail/FunctionSpaceImpl.h"
 #include "atlas/grid/Distribution.h"
 #include "atlas/grid/Grid.h"
 #include "atlas/grid/detail/distribution/DistributionImpl.h"
 #include "atlas/grid/detail/partitioner/Partitioner.h"
 #include "atlas/mesh/Mesh.h"
+#include "atlas/mesh/detail/MeshImpl.h"
 #include "atlas/option.h"
 #include "atlas/parallel/mpi/mpi.h"
 #include "atlas/runtime/Exception.h"
@@ -155,6 +157,17 @@ detail::partitioner::Partitioner* atlas__grid__MatchingFunctionSpacePartitioner_
     }
     p->detach();
     return p;
+}
+
+detail::partitioner::Partitioner* atlas__grid__MatchingPartitioner__new(const util::Object* object,
+                                                                        const Partitioner::Config* config) {
+    if (const auto* mesh = dynamic_cast<const Mesh::Implementation*>(object)) {
+        return atlas__grid__MatchingMeshPartitioner__new(mesh, config);
+    }
+    if (const auto* functionspace = dynamic_cast<const FunctionSpace::Implementation*>(object)) {
+        return atlas__grid__MatchingFunctionSpacePartitioner__new(functionspace, config);
+    }
+    ATLAS_THROW_EXCEPTION("MatchingPartitioner requires a Mesh or FunctionSpace");
 }
 
 Distribution::Implementation* atlas__grid__Partitioner__partition(const Partitioner::Implementation* This,

--- a/src/atlas/grid/Partitioner.h
+++ b/src/atlas/grid/Partitioner.h
@@ -126,6 +126,8 @@ Partitioner::Implementation* atlas__grid__Partitioner__new(const Partitioner::Co
 
 Partitioner::Implementation* atlas__grid__Partitioner__new_type(const char* type);
 
+Partitioner::Implementation* atlas__grid__MatchingPartitioner__new(const util::Object* object,
+                                                                   const Partitioner::Config* config);
 Partitioner::Implementation* atlas__grid__MatchingMeshPartitioner__new(const mesh::detail::MeshImpl* mesh,
                                                                        const Partitioner::Config* config);
 Partitioner::Implementation* atlas__grid__MatchingFunctionSpacePartitioner__new(

--- a/src/atlas/grid/detail/grid/Grid.cc
+++ b/src/atlas/grid/detail/grid/Grid.cc
@@ -188,6 +188,14 @@ void atlas__grid__Grid__name(const Grid* This, char*& name, int& size) {
     std::strncpy(name, s.c_str(), size + 1);
 }
 
+void atlas__grid__Grid__type(const Grid* This, char*& type, int& size) {
+    ATLAS_ASSERT(This != nullptr, "Cannot access uninitialised atlas_Grid");
+    std::string s = This->type();
+    size          = static_cast<int>(s.size());
+    type          = new char[size + 1];
+    std::strncpy(type, s.c_str(), size + 1);
+}
+
 Grid::Domain::Implementation* atlas__grid__Grid__lonlat_bounding_box(const Grid* This) {
     Grid::Domain::Implementation* lonlatboundingbox;
     {

--- a/src/atlas/grid/detail/grid/Grid.h
+++ b/src/atlas/grid/detail/grid/Grid.h
@@ -187,6 +187,7 @@ const Grid* atlas__grid__Grid(const char* identifier);
 const Grid* atlas__grid__Grid__config(util::Config* conf);
 void atlas__grid__Grid__delete(Grid* This);
 void atlas__grid__Grid__name(const Grid* This, char*& uid, int& size);
+void atlas__grid__Grid__type(const Grid* This, char*& type, int& size);
 idx_t atlas__grid__Grid__size(Grid* This);
 Grid::Spec* atlas__grid__Grid__spec(Grid* This);
 void atlas__grid__Grid__uid(const Grid* This, char*& uid, int& size);

--- a/src/atlas/mesh/detail/MeshIntf.cc
+++ b/src/atlas/mesh/detail/MeshIntf.cc
@@ -9,10 +9,13 @@
  */
 
 #include "atlas/grid/Grid.h"
+#include "atlas/grid/Distribution.h"
+#include "atlas/grid/Partitioner.h"
 #include "atlas/grid/detail/grid/Grid.h"
 #include "atlas/mesh/detail/MeshIntf.h"
 #include "atlas/mesh/Nodes.h"
 #include "atlas/runtime/Exception.h"
+#include "atlas/util/Config.h"
 
 namespace atlas {
 namespace mesh {
@@ -29,6 +32,34 @@ Mesh::Implementation* atlas__Mesh__new_grid(Grid::Implementation* grid) {
     {
         Grid g(grid);
         Mesh m{Grid{grid}};
+        mesh = m.get();
+        mesh->attach();
+    }
+    mesh->detach();
+    return mesh;
+}
+
+Mesh::Implementation* atlas__Mesh__new_grid_distribution(Grid::Implementation* grid,
+                                                         grid::Distribution::Implementation* distribution,
+                                                         const util::Config* config) {
+    ATLAS_ASSERT(config != nullptr, "Cannot access uninitialised atlas_Config");
+    Mesh::Implementation* mesh;
+    {
+        Mesh m{Grid{grid}, grid::Distribution{distribution}, *config};
+        mesh = m.get();
+        mesh->attach();
+    }
+    mesh->detach();
+    return mesh;
+}
+
+Mesh::Implementation* atlas__Mesh__new_grid_partitioner(Grid::Implementation* grid,
+                                                        grid::Partitioner::Implementation* partitioner,
+                                                        const util::Config* config) {
+    ATLAS_ASSERT(config != nullptr, "Cannot access uninitialised atlas_Config");
+    Mesh::Implementation* mesh;
+    {
+        Mesh m{Grid{grid}, grid::Partitioner{partitioner}, *config};
         mesh = m.get();
         mesh->attach();
     }

--- a/src/atlas/mesh/detail/MeshIntf.h
+++ b/src/atlas/mesh/detail/MeshIntf.h
@@ -21,6 +21,12 @@ namespace mesh {
 extern "C" {
 Mesh::Implementation* atlas__Mesh__new();
 Mesh::Implementation* atlas__Mesh__new_grid(Grid::Implementation* grid);
+Mesh::Implementation* atlas__Mesh__new_grid_distribution(Grid::Implementation* grid,
+                                                         grid::Distribution::Implementation* distribution,
+                                                         const util::Config* config);
+Mesh::Implementation* atlas__Mesh__new_grid_partitioner(Grid::Implementation* grid,
+                                                        grid::Partitioner::Implementation* partitioner,
+                                                        const util::Config* config);
 void atlas__Mesh__delete(Mesh::Implementation* This);
 Nodes* atlas__Mesh__nodes(Mesh::Implementation* This);
 Edges* atlas__Mesh__edges(Mesh::Implementation* This);

--- a/src/atlas_f/grid/atlas_Grid_module.F90
+++ b/src/atlas_f/grid/atlas_Grid_module.F90
@@ -55,6 +55,7 @@ TYPE, extends(fckit_owned_object) :: atlas_Grid
 !------------------------------------------------------------------------------
 contains
   procedure :: name => atlas_Grid__name
+  procedure :: type => atlas_Grid__type
   procedure :: size => atlas_Grid__size
   procedure :: spec => atlas_Grid__spec
   procedure :: uid
@@ -785,6 +786,19 @@ function atlas_Grid__name(this) result(name)
   call atlas__grid__Grid__name(this%c_ptr(), name_c_str, size )
   name = c_ptr_to_string(name_c_str)
   call c_ptr_free(name_c_str)
+end function
+
+function atlas_Grid__type(this) result(type)
+  use atlas_grid_Grid_c_binding
+  use fckit_c_interop_module, only : c_ptr_to_string, c_ptr_free
+  use, intrinsic :: iso_c_binding, only : c_ptr
+  class(atlas_Grid), intent(in) :: this
+  character(len=:), allocatable :: type
+  type(c_ptr) :: type_c_str
+  integer :: size
+  call atlas__grid__Grid__type(this%c_ptr(), type_c_str, size )
+  type = c_ptr_to_string(type_c_str)
+  call c_ptr_free(type_c_str)
 end function
 
 function atlas_Grid__size(this) result(npts)

--- a/src/atlas_f/grid/atlas_Partitioner_module.F90
+++ b/src/atlas_f/grid/atlas_Partitioner_module.F90
@@ -59,12 +59,11 @@ interface atlas_Partitioner
 end interface
 
 interface atlas_MatchingPartitioner
-  module procedure atlas_MatchingMeshPartitioner__ctor
-  module procedure atlas_MatchingFunctionSpacePartitioner__ctor
+  module procedure atlas_MatchingPartitioner__ctor
 end interface
 
 interface atlas_MatchingMeshPartitioner
-  module procedure atlas_MatchingMeshPartitioner__ctor
+  module procedure atlas_MatchingPartitioner__ctor
 end interface
 
 !========================================================
@@ -93,46 +92,24 @@ function atlas_Partitioner__ctor_type( type ) result(this)
   call this%return()
 end function
 
-function atlas_MatchingMeshPartitioner__ctor( mesh, config ) result(this)
-  use atlas_mesh_module, only : atlas_Mesh
+function atlas_MatchingPartitioner__ctor( object, config ) result(this)
   use atlas_config_module, only : atlas_Config
   use atlas_partitioner_c_binding
   type(atlas_Partitioner) :: this
-  type(atlas_Mesh)  , intent(in) :: mesh
+  class(fckit_owned_object), intent(in) :: object
   type(atlas_Config), intent(in), optional :: config
   type(atlas_Config) :: opt_config
   if( present(config) ) then
-    call this%reset_c_ptr( atlas__grid__MatchingMeshPartitioner__new( &
-      mesh%c_ptr(), config%c_ptr() ) )
+    call this%reset_c_ptr( atlas__grid__MatchingPartitioner__new( &
+      object%c_ptr(), config%c_ptr() ) )
   else
     opt_config = atlas_Config()
-    call this%reset_c_ptr( atlas__grid__MatchingMeshPartitioner__new( &
-      mesh%c_ptr(), opt_config%c_ptr() ) )
+    call this%reset_c_ptr( atlas__grid__MatchingPartitioner__new( &
+      object%c_ptr(), opt_config%c_ptr() ) )
     call opt_config%final()
   endif
   call this%return()
-end function
-
-
-function atlas_MatchingFunctionSpacePartitioner__ctor( functionspace, config ) result(this)
-  use atlas_functionspace_module, only : atlas_FunctionSpace
-  use atlas_config_module, only : atlas_Config
-  use atlas_partitioner_c_binding
-  type(atlas_Partitioner) :: this
-  class(atlas_FunctionSpace)  , intent(in) :: functionspace
-  type(atlas_Config), intent(in), optional :: config
-  type(atlas_Config) :: opt_config
-  if( present(config) ) then
-    call this%reset_c_ptr( atlas__grid__MatchingFunctionSpacePartitioner__new( &
-      functionspace%c_ptr(), config%c_ptr() ) )
-  else
-    opt_config = atlas_Config()
-    call this%reset_c_ptr( atlas__grid__MatchingFunctionSpacePartitioner__new( &
-      functionspace%c_ptr(), opt_config%c_ptr() ) )
-    call opt_config%final()
-  endif
-  call this%return()
-end function
+end function atlas_MatchingPartitioner__ctor
 
 function partition(this,grid) result(distribution)
   use atlas_partitioner_c_binding

--- a/src/atlas_f/mesh/atlas_Mesh_module.F90
+++ b/src/atlas_f/mesh/atlas_Mesh_module.F90
@@ -15,6 +15,9 @@ use atlas_mesh_Cells_module, only: atlas_mesh_Cells
 use atlas_mesh_Nodes_module, only: atlas_mesh_Nodes
 use atlas_mesh_Edges_module, only: atlas_mesh_Edges
 use atlas_Grid_module, only: atlas_Grid
+use atlas_GridDistribution_module, only: atlas_GridDistribution
+use atlas_Partitioner_module, only: atlas_Partitioner
+use atlas_Config_module, only: atlas_Config
 use, intrinsic :: iso_c_binding, only : c_size_t, c_ptr
 
 implicit none
@@ -23,6 +26,9 @@ private :: fckit_owned_object
 private :: atlas_mesh_Cells
 private :: atlas_mesh_Nodes
 private :: atlas_mesh_Edges
+private :: atlas_GridDistribution
+private :: atlas_Partitioner
+private :: atlas_Config
 private :: c_size_t
 private :: c_ptr
 
@@ -68,6 +74,8 @@ interface atlas_Mesh
   module procedure atlas_Mesh__cptr
   module procedure atlas_Mesh__ctor
   module procedure atlas_Mesh__ctor_grid
+  module procedure atlas_Mesh__ctor_grid_distribution
+  module procedure atlas_Mesh__ctor_grid_partitioner
 end interface
 
 !========================================================
@@ -100,6 +108,48 @@ function atlas_Mesh__ctor_grid(grid) result(this)
   call this%reset_c_ptr( atlas__Mesh__new_grid(grid%c_ptr()) )
   call this%return()
 end function atlas_Mesh__ctor_grid
+
+!-------------------------------------------------------------------------------
+
+function atlas_Mesh__ctor_grid_distribution(grid, distribution, config) result(this)
+  use atlas_mesh_c_binding
+  type(atlas_Mesh) :: this
+  class(atlas_Grid), intent(in) :: grid
+  class(atlas_GridDistribution), intent(in) :: distribution
+  type(atlas_Config), intent(in), optional :: config
+  type(atlas_Config) :: opt_config
+  if (present(config)) then
+    call this%reset_c_ptr( atlas__Mesh__new_grid_distribution( &
+      grid%c_ptr(), distribution%c_ptr(), config%c_ptr()) )
+  else
+    opt_config = atlas_Config()
+    call this%reset_c_ptr( atlas__Mesh__new_grid_distribution( &
+      grid%c_ptr(), distribution%c_ptr(), opt_config%c_ptr()) )
+    call opt_config%final()
+  endif
+  call this%return()
+end function atlas_Mesh__ctor_grid_distribution
+
+!-------------------------------------------------------------------------------
+
+function atlas_Mesh__ctor_grid_partitioner(grid, partitioner, config) result(this)
+  use atlas_mesh_c_binding
+  type(atlas_Mesh) :: this
+  class(atlas_Grid), intent(in) :: grid
+  class(atlas_Partitioner), intent(in) :: partitioner
+  type(atlas_Config), intent(in), optional :: config
+  type(atlas_Config) :: opt_config
+  if (present(config)) then
+    call this%reset_c_ptr( atlas__Mesh__new_grid_partitioner( &
+      grid%c_ptr(), partitioner%c_ptr(), config%c_ptr()) )
+  else
+    opt_config = atlas_Config()
+    call this%reset_c_ptr( atlas__Mesh__new_grid_partitioner( &
+      grid%c_ptr(), partitioner%c_ptr(), opt_config%c_ptr()) )
+    call opt_config%final()
+  endif
+  call this%return()
+end function atlas_Mesh__ctor_grid_partitioner
 
 !-------------------------------------------------------------------------------
 

--- a/src/tests/grid/fctest_grids.F90
+++ b/src/tests/grid/fctest_grids.F90
@@ -59,6 +59,7 @@ TEST( test_spec )
   character(:), allocatable :: json_sorted, json_ordered, json
 
   grid = atlas_Grid ("O32")
+  FCTEST_CHECK_EQUAL( grid%type(), "structured" )
   spec = grid%spec()
 
   FCTEST_CHECK_EQUAL( spec%owners(), 1 )

--- a/src/tests/mesh/fctest_mesh.F90
+++ b/src/tests/mesh/fctest_mesh.F90
@@ -46,7 +46,7 @@ implicit none
   type(atlas_mesh_Nodes) :: nodes
   integer(c_int) :: nb_nodes
 
-  write(*,*) "test_function_space starting"
+  call atlas_log%info( "--- test_mesh_nodes" )
   mesh = atlas_Mesh()
   nodes = mesh%nodes()
   nb_nodes = nodes%size()
@@ -62,6 +62,127 @@ implicit none
 
   call mesh%final()
   call nodes%final()
+END_TEST
+
+TEST( test_mesh_grid_distribution )
+implicit none
+
+  type(atlas_Grid) :: grid
+  type(atlas_GridDistribution) :: distribution
+  type(atlas_Partitioner) :: partitioner
+  type(atlas_Mesh) :: mixed_mesh
+  type(atlas_mesh_Nodes) :: mixed_nodes
+  type(atlas_mesh_Cells) :: mixed_cells
+  type(atlas_Elements) :: mixed_quads, mixed_triangles
+  type(atlas_ElementType) :: element_type
+
+  call atlas_log%info( "--- test_mesh_grid_distribution" )
+
+  grid = atlas_Grid("N16")
+  partitioner = atlas_Partitioner("serial")
+  distribution = atlas_GridDistribution(grid, partitioner)
+
+  mixed_mesh = atlas_Mesh(grid, distribution)
+
+  mixed_nodes = mixed_mesh%nodes()
+  FCTEST_CHECK( mixed_nodes%size() > 0 )
+
+  mixed_cells = mixed_mesh%cells()
+  FCTEST_CHECK_EQUAL( mixed_cells%nb_types(), 2 )
+  mixed_quads = mixed_cells%elements(1)
+  mixed_triangles = mixed_cells%elements(2)
+  FCTEST_CHECK_EQUAL( mixed_nodes%size(), 1720 )
+  FCTEST_CHECK_EQUAL( mixed_quads%size(), 1080 )
+  FCTEST_CHECK_EQUAL( mixed_triangles%size(), 1212 )
+  FCTEST_CHECK( mixed_quads%size() > 0 )
+  FCTEST_CHECK( mixed_triangles%size() > 0 )
+  element_type = mixed_quads%element_type()
+  FCTEST_CHECK_EQUAL( element_type%name(), "Quadrilateral" )
+  call element_type%final()
+  element_type = mixed_triangles%element_type()
+  FCTEST_CHECK_EQUAL( element_type%name(), "Triangle" )
+  call element_type%final()
+
+  call mixed_quads%final()
+  call mixed_triangles%final()
+  call mixed_cells%final()
+  call mixed_nodes%final()
+  call mixed_mesh%final()
+  call distribution%final()
+  call partitioner%final()
+  call grid%final()
+END_TEST
+
+TEST( test_mesh_grid_partitioner_config )
+implicit none
+
+  type(atlas_Grid) :: grid
+  type(atlas_Partitioner) :: partitioner
+  type(atlas_Config) :: config
+  type(atlas_Mesh) :: triangular_mesh
+  type(atlas_mesh_Nodes) :: triangular_nodes
+  type(atlas_mesh_Cells) :: triangular_cells
+  type(atlas_Elements) :: triangular_quads, triangular_triangles
+  type(atlas_ElementType) :: element_type
+
+  call atlas_log%info( "--- test_mesh_grid_partitioner_config" )
+
+  grid = atlas_Grid("N16")
+  partitioner = atlas_Partitioner("serial")
+  config = atlas_Config()
+  call config%set("triangulate", .true.)
+
+  triangular_mesh = atlas_Mesh(grid, partitioner, config)
+
+  triangular_nodes = triangular_mesh%nodes()
+  FCTEST_CHECK( triangular_nodes%size() > 0 )
+
+  triangular_cells = triangular_mesh%cells()
+  FCTEST_CHECK_EQUAL( triangular_cells%nb_types(), 2 )
+  triangular_quads = triangular_cells%elements(1)
+  triangular_triangles = triangular_cells%elements(2)
+  FCTEST_CHECK_EQUAL( triangular_nodes%size(), 1720 )
+  FCTEST_CHECK_EQUAL( triangular_triangles%size(), 3372 )
+  FCTEST_CHECK_EQUAL( triangular_quads%size(), 0 )
+  FCTEST_CHECK( triangular_triangles%size() > 0 )
+  element_type = triangular_triangles%element_type()
+  FCTEST_CHECK_EQUAL( element_type%name(), "Triangle" )
+  call element_type%final()
+
+  call triangular_quads%final()
+  call triangular_triangles%final()
+  call triangular_cells%final()
+  call triangular_nodes%final()
+  call triangular_mesh%final()
+  call config%final()
+  call partitioner%final()
+  call grid%final()
+END_TEST
+
+TEST( test_matching_partitioner )
+implicit none
+
+  type(atlas_Grid) :: grid
+  type(atlas_Partitioner) :: partitioner, matching_partitioner
+  type(atlas_Mesh) :: mesh
+  type(atlas_FunctionSpace) :: functionspace
+
+  call atlas_log%info( "--- test_matching_partitioner" )
+
+  grid = atlas_Grid("N16")
+  partitioner = atlas_Partitioner("serial")
+  mesh = atlas_Mesh(grid, partitioner)
+
+  matching_partitioner = atlas_MatchingPartitioner(mesh)
+  call matching_partitioner%final()
+  functionspace = atlas_functionspace_StructuredColumns(grid, partitioner)
+  matching_partitioner = atlas_MatchingPartitioner(functionspace)
+
+  call matching_partitioner%final()
+  call functionspace%final()
+  call mesh%final()
+  call partitioner%final()
+  call grid%final()
 END_TEST
 
 


### PR DESCRIPTION
This pull request introduces several new features and improvements to the Atlas grid and mesh interface, primarily focusing on enhancing the flexibility of mesh construction and partitioning, as well as improving Fortran interoperability and test coverage. The most significant changes are the addition of new mesh constructors that accept grid distributions and partitioners, a generalized matching partitioner interface, and the exposure of the grid type in the Fortran API. Comprehensive tests have also been added to verify these new capabilities.

**Key changes:**

#### Mesh Construction Enhancements

* Added new constructors to `atlas_Mesh` in Fortran to allow creating a `Mesh` directly from a `Grid` and a `Distribution` or `Partitioner`, with optional configuration. This enables more flexible mesh generation workflows.

#### Partitioner Interface Improvements

* Introduced a generalized Fortran interface and implementation for `atlas_MatchingPartitioner`, allowing construction from either a `Mesh` or a `FunctionSpace` object, simplifying and unifying the API. This was also needed to avoid a circular dependency between atlas_mesh_module and atlas_partitioner_module

#### Fortran API Extensions

* Exposed the grid type string to the Fortran API via `atlas_Grid__type`, and added a corresponding test to check the grid type. 

#### Test Coverage

* Added new Fortran tests to verify mesh construction with grid distributions and partitioners, including tests for mixed element types and triangulation options, as well as tests for the new matching partitioner interface.


<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-404
<!-- STATIC-ANALYSIS_END -->