### PR TITLE
Fix ambiguity for mpi::Scope (see #402)

### DIFF
--- a/src/atlas/parallel/mpi/mpi.cc
+++ b/src/atlas/parallel/mpi/mpi.cc
@@ -168,7 +168,7 @@ void scope::push(std::string_view name) {
     ScopeStack::instance().push(name);
 }
 
-void scope::push(const Comm& comm) {
+void scope::detail::push(const Comm& comm) {
     ScopeStack::instance().push(comm);
 }
 

--- a/src/atlas/parallel/mpi/mpi.h
+++ b/src/atlas/parallel/mpi/mpi.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <string_view>
+#include <type_traits>
 
 #include "eckit/mpi/Comm.h"
 #include "atlas/parallel/mpi/Statistics.h"
@@ -63,7 +64,8 @@ namespace scope {
 struct Scope {
     Scope() { scope::push(); }
     Scope(std::string_view name) { scope::push(name); }
-    Scope(const Comm& comm) { scope::push(comm); };
+    template <typename CommT, std::enable_if_t<std::is_same_v<std::decay_t<CommT>, Comm>, int> = 0>
+    Scope(CommT&& comm) { scope::push(comm); };
     /// @brief Constructor using integer value. If the given communicator is not already registered, it will be registered with a generated name "int.<communicator>" for the duration of the scope, and unregistered when the scope is destructed.
     /// @param communicator The integer value of the MPI communicator to use for the scope
     Scope(int communicator) { scope::push(communicator); }

--- a/src/atlas/parallel/mpi/mpi.h
+++ b/src/atlas/parallel/mpi/mpi.h
@@ -47,12 +47,16 @@ void finalize();
 void finalise();
 
 namespace scope {
+    namespace detail {
+        void push(const Comm& comm);
+    }
     /// @brief Push a new scope for MPI communicators. The current default communicator is restored when the scope is destructed using pop()
     void push();
     /// @brief Push a new scope for MPI communicators. The given communicator is set as the default communicator for the duration of the scope. The previous default communicator is restored when the scope is destructed using pop()
     void push(std::string_view name);
     /// @brief Push a new scope for MPI communicators. The given communicator is set as the default communicator for the duration of the scope. The previous default communicator is restored when the scope is destructed using pop()
-    void push(const Comm& comm);
+    template <typename CommT, std::enable_if_t<std::is_same_v<std::decay_t<CommT>, Comm>, int> = 0>
+    void push(CommT&& comm) { detail::push(comm); }
     /// @brief Push a new scope for MPI communicators. The given communicator is set as the default communicator for the duration of the scope. The previous default communicator is restored when the scope is destructed using pop()
     /// If the given communicator is not already registered, it will be registered with a generated name "int.<communicator>" for the duration of the scope, and unregistered when the scope is destructed.
     void push(int communicator);

--- a/src/tests/parallel/test_mpi_scope.cc
+++ b/src/tests/parallel/test_mpi_scope.cc
@@ -42,6 +42,13 @@ CASE("test_mpi_scope") {
     EXPECT_EQ( mpi::comm().name(), "comm1" );
 
     {
+        mpi::scope::push(mpi::comm("self"));
+        EXPECT_EQ( mpi::comm().name(), "self" );
+        mpi::scope::pop();
+    }
+    EXPECT_EQ( mpi::comm().name(), "comm1" );
+
+    {
         // Use RAII style scope management using atlas::mpi::Scope with Comm argument
         mpi::Scope scope(mpi::comm("self"));
         EXPECT_EQ( mpi::comm().name(), "self" );


### PR DESCRIPTION
### Description

The main change is to make the mpi::Scope constructor that takes a `std::string` less ambiguous using SFINAE.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-405
<!-- STATIC-ANALYSIS_END -->