### PR TITLE
Make the SphericalHarmonic function thread-safe

### DIFF
--- a/src/atlas/util/function/SphericalHarmonic.cc
+++ b/src/atlas/util/function/SphericalHarmonic.cc
@@ -8,19 +8,19 @@
  * nor does it submit to any jurisdiction.
  */
 
+#include "atlas/util/function/SphericalHarmonic.h"
+
+#include <atomic>
 #include <cmath>
-#include <map>
+#include <cstdint>
+#include <mutex>
+#include <unordered_map>
+#include <utility>
 
 #include "atlas/runtime/Exception.h"
 #include "atlas/util/Constants.h"
-#include "atlas/util/function/SphericalHarmonic.h"
 
-namespace atlas {
-
-namespace util {
-
-namespace function {
-
+namespace atlas::util::function {
 
 namespace {
 static double factorial(double v) {
@@ -65,78 +65,119 @@ static double K(const int n, const int m) {
     //When m is less than 0, multiply - 1 to pass in
     return std::sqrt(((2 * n + 1) * factorial(n - m)) / (4 * M_PI * factorial(n + m)));
 }
-}  // namespace
+
+template <typename Key, typename Compute>
+static double cached(const Key& key, const double argument, Compute&& compute) {
+    struct LastValue {
+        bool initialized{};
+        Key key{};
+        double argument{};
+        double value{};
+    };
+    static thread_local LastValue last;
+
+    if (last.initialized && last.key == key && last.argument == argument) {
+        return last.value;
+    }
+
+    const double value = compute();
+    last = {true, key, argument, value};
+    return last.value;
+}
+
+static double P_cos_COLAT(const int n, const int abs_m, const double lat) {
+    return cached(std::make_pair(n, abs_m), lat, [&] {
+        const double colat_rad = (90. - lat) * Constants::degreesToRadians();
+        return P(n, abs_m, std::cos(colat_rad));
+    });
+}
+
+}  // namespace function
+
+struct SphericalHarmonic::Cache {
+    explicit Cache(const std::uint64_t id): id(id) {}
+
+    std::uint64_t id;
+    std::unordered_map<double, double> values;
+    std::mutex mutex;
+};
+
+double SphericalHarmonic::P_cos_COLAT(const double lat) const {
+    struct LastValue {
+        std::uint64_t cache_id{};
+        double lat{};
+        double value{};
+    };
+    static thread_local LastValue last;
+
+    if (last.cache_id == cache_->id && last.lat == lat) {
+        return last.value;
+    }
+
+    std::lock_guard<std::mutex> lock(cache_->mutex);
+    const auto cached_value = cache_->values.find(lat);
+    if (cached_value != cache_->values.end()) {
+        last = {cache_->id, lat, cached_value->second};
+        return last.value;
+    }
+
+    const double colat_rad = (90. - lat) * Constants::degreesToRadians();
+    const double value     = P(n_, abs_m_, std::cos(colat_rad));
+    cache_->values.emplace(lat, value);
+    last = {cache_->id, lat, value};
+    return last.value;
+}
 
 double spherical_harmonic(int n, int m, double lon, double lat) {
     const int abs_m = std::abs(m);
 
     ATLAS_ASSERT(n >= abs_m);
 
-    double colat = (90. - lat) * Constants::degreesToRadians();
+    if (m == 0) {
+        return K(n, 0) * P_cos_COLAT(n, 0, lat);
+    }
+    auto K_SQRT2 = [](int n, int abs_m) {
+        struct LastValue {
+            int n{-1}; // Always initialize to invalid value to avoid false cache hits
+            int abs_m{};
+            double value{};
+        };
+        static thread_local LastValue last;
+        if (not (last.n == n && last.abs_m == abs_m)) {
+            last = {n, abs_m, K(n, abs_m) * M_SQRT2};
+        }
+        return last.value;
+    };
     lon *= Constants::degreesToRadians();
 
-    if (m == 0) {
-        return (K(n, 0) * P(n, 0, std::cos(colat)));
-    }
-
     if (m > 0) {
-        return (M_SQRT2 * K(n, m) * std::cos(m * lon) * P(n, m, std::cos(colat)));
+        return (K_SQRT2(n, abs_m) * std::cos(abs_m * lon) * P_cos_COLAT(n, abs_m, lat));
     }
-
-    // When m is less than 0, multiply - 1 in advance and send it to K
-    return (M_SQRT2 * K(n, abs_m) * std::sin(abs_m * lon) * P(n, abs_m, std::cos(colat)));
+    else { // m < 0
+        // When m is less than 0, multiply - 1 in advance and send it to K
+        return (K_SQRT2(n, abs_m) * std::sin(abs_m * lon) * P_cos_COLAT(n, abs_m, lat));
+    }
 }
 
-SphericalHarmonic::SphericalHarmonic(int n, int m, bool caching) {
-    const int abs_m = std::abs(m);
+SphericalHarmonic::SphericalHarmonic(const int n, const int m): n_(n), m_(m), abs_m_(std::abs(m)) {
+    ATLAS_ASSERT(n_ >= abs_m_);
 
-    ATLAS_ASSERT(n >= abs_m);
-
-    const double Knm                  = K(n, abs_m);
-    std::function<double(double)> Pnm = [n, abs_m](double x) { return P(n, abs_m, x); };
-
-    if (caching) {
-        // Computation of associated legendre polynomials is
-        // very expensive. With this trick (off by default),
-        // we can cache repeated values, useful for structured
-        // grids with constant latitude.
-        Pnm = [Pnm](double x) {
-            static std::map<double, double> memo;
-
-            auto it = memo.find(x);
-            if (it != memo.end()) {
-                return it->second;
-            }
-            auto result = Pnm(x);
-            memo[x]     = result;
-            return result;
-        };
-    }
-
-    if (m == 0) {
-        Y_ = [Knm, Pnm](double lon, double colat) { return Knm * Pnm(std::cos(colat)); };
-    }
-    else if (m > 0) {
-        Y_ = [m, Knm, Pnm](double lon, double colat) {
-            return M_SQRT2 * Knm * std::cos(m * lon) * Pnm(std::cos(colat));
-        };
-    }
-    else {
-        Y_ = [m, Knm, Pnm](double lon, double colat) {
-            return M_SQRT2 * Knm * std::sin(-m * lon) * Pnm(std::cos(colat));
-        };
-    }
+    static std::atomic<std::uint64_t> next_cache_id{1};
+    cache_ = std::make_shared<Cache>(next_cache_id.fetch_add(1, std::memory_order_relaxed));
+    Knm_  = K(n_, abs_m_) * (m_ == 0 ? 1. : M_SQRT2);
 }
 
 double SphericalHarmonic::operator()(double lon, double lat) const {
-    double colat = (90. - lat) * Constants::degreesToRadians();
+    if (m_ == 0) {
+        return Knm_ * P_cos_COLAT(lat);
+    }
+
     lon *= Constants::degreesToRadians();
-    return Y_(lon, colat);
+    if (m_ > 0) {
+        return Knm_ * std::cos(m_ * lon) * P_cos_COLAT(lat);
+    }
+    return Knm_ * std::sin(-m_ * lon) * P_cos_COLAT(lat);
 }
 
 
-}  // namespace function
-
-}  // namespace util
-
-}  // namespace atlas
+}  // namespace atlas::util::function

--- a/src/atlas/util/function/SphericalHarmonic.h
+++ b/src/atlas/util/function/SphericalHarmonic.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <functional>
+#include <memory>
 
 namespace atlas {
 
@@ -35,15 +35,21 @@ public:
     ///
     /// \param n          Total wave number
     /// \param m          Zonal wave number
-    /// \param caching    When true, internally cache the results of Associated Legendre Polynomials
-    ///                   in a map. Warning: this is not thread-safe
-    SphericalHarmonic(int n, int m, bool caching = false);
+    SphericalHarmonic(int n, int m);
 
     /// \brief Evaluate the spherical harmonic function for given longitude and latitude
     double operator()(double lon, double lat) const;
 
 private:
-    std::function<double(double, double)> Y_;
+    struct Cache;
+
+    double P_cos_COLAT(double lat) const;
+
+    int n_;
+    int m_;
+    int abs_m_;
+    double Knm_{};
+    std::shared_ptr<Cache> cache_;
 };
 
 }  // namespace function

--- a/src/sandbox/interpolation/atlas-conservative-interpolation.cc
+++ b/src/sandbox/interpolation/atlas-conservative-interpolation.cc
@@ -137,8 +137,7 @@ std::function<double(const PointLonLat&)> get_init(const eckit::LocalConfigurati
         args.get("spherical_harmonic.n", n);
         args.get("spherical_harmonic.m", m);
 
-        bool caching = true;  // true -> warning not thread-safe
-        util::function::SphericalHarmonic Y(n, m, caching);
+        util::function::SphericalHarmonic Y(n, m);
         return [Y](const PointLonLat& p) { return Y(p.lon(), p.lat()); };
     }
     else if (init == "constant") {
@@ -242,7 +241,7 @@ int AtlasParallelInterpolation::execute(const AtlasTool::Args& args) {\
         const auto lonlat = array::make_view<double, 2>(src_functionspace.lonlat());
         auto src_view     = array::make_view<double, 1>(src_field);
         auto f            = get_init(config);
-        for (idx_t n = 0; n < lonlat.shape(0); ++n) {
+        atlas_omp_parallel_for (idx_t n = 0; n < lonlat.shape(0); ++n) {
             src_view(n) = f(PointLonLat{lonlat(n, LON), lonlat(n, LAT)});
         }
         src_field.set_dirty(true);

--- a/src/tests/util/CMakeLists.txt
+++ b/src/tests/util/CMakeLists.txt
@@ -67,6 +67,12 @@ ecbuild_add_test( TARGET atlas_test_vector
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )
 
+ecbuild_add_test( TARGET atlas_test_spherical_harmonics
+  SOURCES  test_spherical_harmonics.cc
+  LIBS     atlas
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
+
 ecbuild_add_test( TARGET atlas_test_metadata
   MPI        4
   CONDITION  eckit_HAVE_MPI AND MPI_SLOTS GREATER_EQUAL 4

--- a/src/tests/util/test_spherical_harmonics.cc
+++ b/src/tests/util/test_spherical_harmonics.cc
@@ -1,0 +1,131 @@
+/*
+ * (C) Copyright 2013 ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "atlas/util/function/SphericalHarmonic.h"
+
+#include <atomic>
+#include <cmath>
+#include <thread>
+#include <vector>
+
+#include "tests/AtlasTestEnvironment.h"
+
+namespace atlas::test {
+
+namespace {
+
+double expected(int n, int m, double lon, double lat) {
+    constexpr double pi      = M_PI;
+    lon *= pi / 180.;
+    lat *= pi / 180.;
+
+    if (n == 0 && m == 0) {
+        return 1. / std::sqrt(4. * pi);
+    }
+    if (n == 1 && m == 0) {
+        return std::sqrt(3. / (4. * pi)) * std::sin(lat);
+    }
+    if (n == 1 && m == 1) {
+        return -std::sqrt(3. / (4. * pi)) * std::cos(lat) * std::cos(lon);
+    }
+    if (n == 1 && m == -1) {
+        return -std::sqrt(3. / (4. * pi)) * std::cos(lat) * std::sin(lon);
+    }
+    if (n == 2 && m == 1) {
+        return -3. * std::sqrt(5. / (12. * pi)) * std::sin(lat) * std::cos(lat) *
+               std::cos(lon);
+    }
+    if (n == 2 && m == -1) {
+        return -3. * std::sqrt(5. / (12. * pi)) * std::sin(lat) * std::cos(lat) *
+               std::sin(lon);
+    }
+    ATLAS_NOTIMPLEMENTED;
+}
+
+void expect_harmonic(int n, int m, double lon, double lat) {
+    const double value = expected(n, m, lon, lat);
+    EXPECT_APPROX_EQ(util::function::spherical_harmonic(n, m, lon, lat), value, 1.e-14);
+    EXPECT_APPROX_EQ(util::function::SphericalHarmonic(n, m)(lon, lat), value, 1.e-14);
+}
+
+}  // namespace
+
+CASE("spherical harmonic function and class match analytic values") {
+    expect_harmonic(0, 0, 0., 0.);
+    expect_harmonic(1, 0, 45., 30.);
+    expect_harmonic(1, 1, 35., -20.);
+    expect_harmonic(1, -1, 35., -20.);
+    expect_harmonic(2, 1, -70., 25.);
+    expect_harmonic(2, -1, -70., 25.);
+}
+
+CASE("spherical harmonic caches handle latitude reuse and pair changes") {
+    const util::function::SphericalHarmonic first(1, 1);
+    const util::function::SphericalHarmonic second(2, 1);
+
+    for (const double lat : {20., -35., 20.}) {
+        EXPECT_APPROX_EQ(first(40., lat), expected(1, 1, 40., lat), 1.e-14);
+        EXPECT_APPROX_EQ(util::function::spherical_harmonic(1, 1, 40., lat), expected(1, 1, 40., lat), 1.e-14);
+    }
+
+    for (int iteration = 0; iteration < 3; ++iteration) {
+        EXPECT_APPROX_EQ(first(40., 20.), expected(1, 1, 40., 20.), 1.e-14);
+        EXPECT_APPROX_EQ(second(40., 20.), expected(2, 1, 40., 20.), 1.e-14);
+        EXPECT_APPROX_EQ(first(40., 20.), expected(1, 1, 40., 20.), 1.e-14);
+    }
+}
+
+CASE("spherical harmonic rejects invalid wave numbers") {
+    EXPECT_THROWS(util::function::spherical_harmonic(2, 3, 0., 0.));
+    EXPECT_THROWS(util::function::SphericalHarmonic(2, 3));
+}
+
+CASE("spherical harmonic caches are thread safe") {
+    constexpr int thread_count = 8;
+    const util::function::SphericalHarmonic first(1, 1);
+    const util::function::SphericalHarmonic second(2, -1);
+    std::atomic<bool> start{false};
+    std::vector<int> failures(thread_count, 0);
+    std::vector<std::thread> threads;
+    threads.reserve(thread_count);
+
+    for (int thread = 0; thread < thread_count; ++thread) {
+        threads.emplace_back([thread, &first, &second, &start, &failures]() {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            for (int iteration = 0; iteration < 100; ++iteration) {
+                const double lon = -150. + 7. * thread + iteration;
+                const double lat = -60. + 5. * thread + (iteration % 5) * 11.;
+                failures[thread] += std::abs(first(lon, lat) - expected(1, 1, lon, lat)) > 1.e-14;
+                failures[thread] += std::abs(second(lon, lat) - expected(2, -1, lon, lat)) > 1.e-14;
+                failures[thread] +=
+                    std::abs(util::function::spherical_harmonic(1, -1, lon, lat) - expected(1, -1, lon, lat)) >
+                    1.e-14;
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    for (const int failure_count : failures) {
+        EXPECT_EQ(failure_count, 0);
+    }
+}
+
+}  // namespace atlas::test
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}


### PR DESCRIPTION
This pull request refactors and improves the function to compute a `SphericalHarmonic` in gridpoint space.
It is now thread safety, has better performance, and better code clarity. 
Additionally, a new test for spherical harmonics has been added.

### Spherical Harmonic Caching and Thread Safety

* The `SphericalHarmonic` class now uses a thread-safe, per-instance cache for computed values, replacing the previous static map which was not thread-safe.
* Removed the `caching` parameter from the `SphericalHarmonic` constructor; caching is now always enabled and thread-safe. 
### API and Implementation Simplification

* The internal implementation of `SphericalHarmonic` has been simplified: the function call operator now directly computes results using cached values, and the class no longer uses `std::function` members
* The header file now includes only necessary headers, removing unused includes like `<functional>`.

### Usage and Testing Updates

* All usages of `SphericalHarmonic` in the codebase have been updated to use the new constructor signature (without the `caching` argument).
* The loop initializing the source field in the interpolation sandbox is now parallelized using `atlas_omp_parallel_for` for improved performance.
* Added a new test for spherical harmonics: `atlas_test_spherical_harmonics` in the test suite.

<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-406
<!-- STATIC-ANALYSIS_END -->