### PR TITLE
Implement atlas_omp_atomic and improve float comparison in EXPECT_APPROX_EQ

### DIFF
--- a/src/atlas/parallel/omp/omp.h
+++ b/src/atlas/parallel/omp/omp.h
@@ -35,6 +35,11 @@ int atlas_omp_get_nested(void);
 #define atlas_omp_for atlas_omp_pragma(omp for) for
 #define atlas_omp_parallel atlas_omp_pragma(omp parallel)
 #define atlas_omp_critical atlas_omp_pragma(omp critical)
+#define atlas_omp_atomic atlas_omp_pragma(omp atomic)
+#define atlas_omp_atomic_update atlas_omp_pragma(omp atomic update)
+#define atlas_omp_atomic_write atlas_omp_pragma(omp atomic write)
+#define atlas_omp_atomic_read atlas_omp_pragma(omp atomic read)
+#define atlas_omp_atomic_capture atlas_omp_pragma(omp atomic capture)
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 template <typename T>

--- a/src/tests/AtlasTestEnvironment.h
+++ b/src/tests/AtlasTestEnvironment.h
@@ -206,6 +206,12 @@ bool approx_eq(const float& v1, const float& v2) {
 bool approx_eq(const float& v1, const float& v2, const float& t) {
     return is_approximately_equal(v1, v2, t);
 }
+bool approx_eq(const float& v1, const float& v2, const double& t) {
+    if (t != 0. && t < std::numeric_limits<float>::denorm_min()) {
+        throw std::underflow_error("Tolerance underflows float precision and will become 0.0");
+    }
+    return is_approximately_equal(v1, v2, static_cast<float>(t));
+}
 bool approx_eq(const double& v1, const double& v2) {
     return is_approximately_equal(v1, v2);
 }


### PR DESCRIPTION
### Description
This pull request introduces improvements to OpenMP macro definitions and enhances the `approx_eq` function overloads for better type safety and error handling in test code.

OpenMP macro enhancements:
* Added new macros for various OpenMP atomic operations (`atlas_omp_atomic`, `atlas_omp_atomic_update`, `atlas_omp_atomic_write`, `atlas_omp_atomic_read`, `atlas_omp_atomic_capture`) to simplify and standardize atomic operation usage in the codebase.

Testing utility improvements:
* Added an overload of the `approx_eq` function to accept a `double` tolerance when comparing `float` values, including a check to prevent underflow below `float` precision, which throws an exception if violated. This improves type safety and prevents subtle bugs in floating-point comparisons during testing.


<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-407
<!-- STATIC-ANALYSIS_END -->