### PR TITLE
Implement Trans::invtrans_vordiv2uv for fields with and without levels

### DIFF
--- a/src/atlas/trans/ifs/TransIFS.cc
+++ b/src/atlas/trans/ifs/TransIFS.cc
@@ -31,6 +31,8 @@
 #include "atlas/trans/detail/TransFactory.h"
 #include "atlas/trans/ifs/TransIFS.h"
 
+#include <vector>
+
 using Topology = atlas::mesh::Nodes::Topology;
 using atlas::Field;
 using atlas::FunctionSpace;
@@ -2239,12 +2241,10 @@ void TransIFS::__invtrans_vordiv2wind(const Spectral& sp, const Field& spvor, co
 
     // Count total number of fields and do sanity checks
     const int nfld = compute_nfld(spvor);
-    if (spdiv.shape(0) != spvor.shape(0)) {
+    if (spdiv.rank() != spvor.rank() || spdiv.shape() != spvor.shape()) {
         throw_Exception("invtrans: vorticity not compatible with divergence.", Here());
     }
-    if (spdiv.shape(1) != spvor.shape(1)) {
-        throw_Exception("invtrans: vorticity not compatible with divergence.", Here());
-    }
+    ATLAS_ASSERT(spvor.rank() == 1 || spvor.rank() == 2, "Only rank-1 and rank-2 spectral fields are supported");
     const int nwindfld = compute_nfld(gpwind);
     if (nwindfld != 2 * nfld && nwindfld != 3 * nfld) {
         throw_Exception("invtrans: wind field is not compatible with vorticity, divergence.", Here());
@@ -2258,8 +2258,6 @@ void TransIFS::__invtrans_vordiv2wind(const Spectral& sp, const Field& spvor, co
         throw_Exception(msg.str(), Here());
     }
 
-    ATLAS_ASSERT(spvor.rank() == 2);
-    ATLAS_ASSERT(spdiv.rank() == 2);
     if (spvor.size() == 0) {
         throw_Exception("invtrans: spectral vorticity field is empty.");
     }
@@ -2311,12 +2309,10 @@ void TransIFS::__invtrans_vordiv2wind(const Spectral& sp, const Field& spvor, co
 
     // Count total number of fields and do sanity checks
     const int nfld = compute_nfld(spvor);
-    if (spdiv.shape(0) != spvor.shape(0)) {
+    if (spdiv.rank() != spvor.rank() || spdiv.shape() != spvor.shape()) {
         throw_Exception("invtrans: vorticity not compatible with divergence.", Here());
     }
-    if (spdiv.shape(1) != spvor.shape(1)) {
-        throw_Exception("invtrans: vorticity not compatible with divergence.", Here());
-    }
+    ATLAS_ASSERT(spvor.rank() == 1 || spvor.rank() == 2, "Only rank-1 and rank-2 spectral fields are supported");
     const int nwindfld = compute_nfld(gpwind);
     if (nwindfld != 2 * nfld && nwindfld != 3 * nfld) {
         throw_Exception("invtrans: wind field is not compatible with vorticity, divergence.", Here());
@@ -2330,8 +2326,6 @@ void TransIFS::__invtrans_vordiv2wind(const Spectral& sp, const Field& spvor, co
         throw_Exception(msg.str(), Here());
     }
 
-    ATLAS_ASSERT(spvor.rank() == 2);
-    ATLAS_ASSERT(spdiv.rank() == 2);
     if (spvor.size() == 0) {
         throw_Exception("invtrans: spectral vorticity field is empty.");
     }

--- a/src/atlas/trans/local/TransLocal.cc
+++ b/src/atlas/trans/local/TransLocal.cc
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <fstream>
+#include <vector>
 
 #include "eckit/config/YAMLConfiguration.h"
 #include "eckit/eckit.h"
@@ -871,8 +872,57 @@ void gp_transpose(const int nb_size, const int nb_fields, const double gp_tmp[],
 void TransLocal::invtrans_vordiv2wind(const Field& spvor, const Field& spdiv, Field& gpwind,
                                       const eckit::Configuration& config) const {
     // VERY PRELIMINARY IMPLEMENTATION WITHOUT ANY GUARANTEES
-    ATLAS_ASSERT(spvor.rank() == 1, "Only rank-1 fields supported at the moment");
-    ATLAS_ASSERT(spdiv.rank() == 1, "Only rank-1 fields supported at the moment");
+    ATLAS_ASSERT(spvor.rank() == spdiv.rank(), "Vorticity and divergence ranks must match");
+    ATLAS_ASSERT(spvor.shape() == spdiv.shape(), "Vorticity and divergence shapes must match");
+    ATLAS_ASSERT(spvor.rank() == 1 || spvor.rank() == 2, "Only rank-1 and rank-2 spectral fields are supported");
+
+    if (spvor.rank() == 2) {
+        // Rank-2 spectral fields require a rank-3 wind field
+        // The wind has dimensions (grid points, levels, 2) -- (2 for u and v)
+        // The spectral fields have dimensions (levels, spectral coefficients)
+
+        // The function invtrans expects:
+        // - vorticity_spectra and divergence_spectra to be of size (levels * spectral coefficients)
+        // - wind to be of layout (2, levels, grid points)
+        // Therefore, we need to transpose the wind data after the inverse transform
+
+        const int nb_vordiv_fields = static_cast<int>(spvor.shape(1));
+
+        ATLAS_ASSERT(gpwind.rank() == 3, "Rank-2 spectral fields require a rank-3 wind field");
+        ATLAS_ASSERT(gpwind.shape(0) == grid().size(), "Wind horizontal dimension must match the grid size");
+        ATLAS_ASSERT(gpwind.shape(1) == nb_vordiv_fields, "Wind levels must match the spectral fields");
+        ATLAS_ASSERT(gpwind.shape(2) == 2, "Wind field must have two components");
+
+        const auto vorticity_spectra  = array::make_view<double, 2>(spvor);
+        const auto divergence_spectra = array::make_view<double, 2>(spdiv);
+        auto gp_fields                = array::make_view<double, 3>(gpwind);
+        const size_t spectral_data_size = 2 * legendre_size(truncation_) * nb_vordiv_fields;
+        ATLAS_ASSERT(vorticity_spectra.size() == spectral_data_size);
+        ATLAS_ASSERT(divergence_spectra.size() == spectral_data_size);
+
+        // The wind data is transposed compared to what invtrans is expecting,
+        // so we need to allocate a temporary array to hold the transformed wind data
+        const idx_t nb_grid_points = grid().size();
+        const idx_t transformed_wind_stride_component = nb_vordiv_fields * nb_grid_points;
+        const idx_t transformed_wind_stride_level = nb_grid_points;
+        std::vector<double> transformed_wind_data(2 * nb_vordiv_fields * nb_grid_points);
+        auto transformed_wind = [&transformed_wind_stride_component, &transformed_wind_stride_level, &transformed_wind_data](idx_t component, idx_t level, idx_t point) {
+            return transformed_wind_data[component * transformed_wind_stride_component + level * transformed_wind_stride_level + point];
+        };
+
+        // Perform the inverse transform to get the wind data in the temporary array
+        invtrans(nb_vordiv_fields, vorticity_spectra.data(), divergence_spectra.data(), transformed_wind_data.data(), config);
+
+        // Transpose the temporary transformed wind data into the gp_fields array
+        for (idx_t point = 0; point < nb_grid_points; ++point) {
+            for (idx_t level = 0; level < nb_vordiv_fields; ++level) {
+                gp_fields(point, level, 0) = transformed_wind(0, level, point);
+                gp_fields(point, level, 1) = transformed_wind(1, level, point);
+            }
+        }
+        return;
+    }
+
     int nb_vordiv_fields          = 1;
     const auto vorticity_spectra  = array::make_view<double, 1>(spvor);
     const auto divergence_spectra = array::make_view<double, 1>(spdiv);
@@ -1528,34 +1578,29 @@ void TransLocal::invtrans(const int nb_scalar_fields, const double scalar_spectr
         // collect all spectral data into one array "all_spectra":
         ATLAS_TRACE("TransLocal::invtrans");
         int nb_vordiv_spec_ext = 2 * legendre_size(truncation_ + 1) * nb_vordiv_fields;
-        std::vector<double> U_ext;
-        std::vector<double> V_ext;
-        std::vector<double> scalar_ext;
-        if (nb_vordiv_fields > 0) {
-            std::vector<double> vorticity_spectra_extended(nb_vordiv_spec_ext);
-            std::vector<double> divergence_spectra_extended(nb_vordiv_spec_ext);
-            U_ext.resize(nb_vordiv_spec_ext);
-            V_ext.resize(nb_vordiv_spec_ext);
+        int nb_scalar_ext      = 2 * legendre_size(truncation_ + 1) * nb_scalar_fields;
+        std::vector<double> U_ext(nb_vordiv_spec_ext);
+        std::vector<double> V_ext(nb_vordiv_spec_ext);
+        std::vector<double> scalar_ext(nb_scalar_ext);
+        std::vector<double> vorticity_spectra_extended(nb_vordiv_spec_ext);
+        std::vector<double> divergence_spectra_extended(nb_vordiv_spec_ext);
 
-            {
-                ATLAS_TRACE("extend vordiv");
-                // increase truncation in vorticity_spectra and divergence_spectra:
-                extend_truncation(truncation_, nb_vordiv_fields, vorticity_spectra, vorticity_spectra_extended.data());
-                extend_truncation(truncation_, nb_vordiv_fields, divergence_spectra,
-                                  divergence_spectra_extended.data());
-            }
+        {
+            ATLAS_TRACE("extend vordiv");
+            // increase truncation in vorticity_spectra and divergence_spectra:
+            extend_truncation(truncation_, nb_vordiv_fields, vorticity_spectra, vorticity_spectra_extended.data());
+            extend_truncation(truncation_, nb_vordiv_fields, divergence_spectra,
+                              divergence_spectra_extended.data());
+        }
 
-            {
-                ATLAS_TRACE("vordiv to UV");
-                // call vd2uv to compute u and v in spectral space
-                trans::VorDivToUV vordiv_to_UV_ext(truncation_ + 1, option::type("local"));
-                vordiv_to_UV_ext.execute(nb_vordiv_spec_ext, nb_vordiv_fields, vorticity_spectra_extended.data(),
-                                         divergence_spectra_extended.data(), U_ext.data(), V_ext.data());
-            }
+        {
+            ATLAS_TRACE("vordiv to UV");
+            // call vd2uv to compute u and v in spectral space
+            trans::VorDivToUV vordiv_to_UV_ext(truncation_ + 1, option::type("local"));
+            vordiv_to_UV_ext.execute(nb_vordiv_spec_ext, nb_vordiv_fields, vorticity_spectra_extended.data(),
+                                     divergence_spectra_extended.data(), U_ext.data(), V_ext.data());
         }
         if (nb_scalar_fields > 0) {
-            int nb_scalar_ext = 2 * legendre_size(truncation_ + 1) * nb_scalar_fields;
-            scalar_ext.resize(nb_scalar_ext);
             extend_truncation(truncation_, nb_scalar_fields, scalar_spectra, scalar_ext.data());
         }
         int nb_all_fields = 2 * nb_vordiv_fields + nb_scalar_fields;

--- a/src/tests/trans/test_trans_localcache.cc
+++ b/src/tests/trans/test_trans_localcache.cc
@@ -8,18 +8,19 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <algorithm>
-#include <iomanip>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
 
+#include "eckit/filesystem/PathName.h"
 #include "eckit/utils/MD5.h"
 
 #include "atlas/grid.h"
 #include "atlas/option.h"
-#include "atlas/parallel/mpi/mpi.h"
 #include "atlas/runtime/Trace.h"
 #include "atlas/trans/LegendreCacheCreator.h"
 #include "atlas/trans/Trans.h"
-#include "atlas/util/Constants.h"
 
 #include "tests/AtlasTestEnvironment.h"
 

--- a/src/tests/trans/test_transgeneral.cc
+++ b/src/tests/trans/test_transgeneral.cc
@@ -1583,6 +1583,59 @@ CASE("test_trans_levels") {
         }
     }
 }
+
+CASE("invtrans_vordiv2wind supports rank-1 and rank-2 spectral fields") {
+    constexpr int truncation = 3;
+    constexpr int levels     = 2;
+    const Grid grid("F2");
+    const functionspace::Spectral spectral(truncation, option::levels(levels));
+    const functionspace::StructuredColumns gridpoints(grid, option::levels(levels));
+    const trans::Trans trans(gridpoints, spectral);
+    const idx_t spectral_coefficients = trans.spectralCoefficients();
+
+    Field spvor = spectral.createField<double>(option::name("vorticity"));
+    Field spdiv = spectral.createField<double>(option::name("divergence"));
+    Field wind  = gridpoints.createField<double>(option::name("wind") | option::variables(2));
+    auto spvor_view = array::make_view<double, 2>(spvor);
+    auto spdiv_view = array::make_view<double, 2>(spdiv);
+    auto wind_view  = array::make_view<double, 3>(wind);
+    spvor_view.assign(0.);
+    spdiv_view.assign(0.);
+
+    spvor_view(8, 0)  = 1.;
+    spdiv_view(10, 0) = 0.5;
+    spvor_view(12, 1) = -0.75;
+    spdiv_view(14, 1) = 1.25;
+
+    trans.invtrans_vordiv2wind(spvor, spdiv, wind);
+
+    const functionspace::Spectral spectral_level(truncation);
+    const functionspace::StructuredColumns gridpoints_level(grid);
+    const trans::Trans trans_level(gridpoints_level, spectral_level);
+
+    for (int level = 0; level < levels; ++level) {
+        Field spvor_level = spectral_level.createField<double>(option::name("vorticity"));
+        Field spdiv_level = spectral_level.createField<double>(option::name("divergence"));
+        Field wind_level =
+            gridpoints_level.createField<double>(option::name("wind") | option::variables(2));
+        auto spvor_level_view = array::make_view<double, 1>(spvor_level);
+        auto spdiv_level_view = array::make_view<double, 1>(spdiv_level);
+        auto wind_level_view  = array::make_view<double, 2>(wind_level);
+
+        for (idx_t coefficient = 0; coefficient < spectral_coefficients; ++coefficient) {
+            spvor_level_view(coefficient) = spvor_view(coefficient, level);
+            spdiv_level_view(coefficient) = spdiv_view(coefficient, level);
+        }
+
+        trans.invtrans_vordiv2wind(spvor_level, spdiv_level, wind_level);
+
+        for (idx_t point = 0; point < gridpoints.size(); ++point) {
+            for (int component = 0; component < 2; ++component) {
+                EXPECT_APPROX_EQ(wind_view(point, level, component), wind_level_view(point, component), 1.e-14);
+            }
+        }
+    }
+}
 #endif
 
 


### PR DESCRIPTION
### Description

This pull request enhances the flexibility and robustness of the `invtrans_vordiv2wind` function in the Atlas library to support both rank-1 and rank-2 spectral fields, improving compatibility with multi-level data. It also introduces new tests to ensure correctness, and refactors several assertions and temporary allocations for clarity and safety.

**Support for rank-1 and rank-2 spectral fields:**

* Updated `TransIFS::invtrans_vordiv2wind` and `TransLocal::invtrans_vordiv2wind` to support both rank-1 and rank-2 spectral fields, with improved shape and rank checks and more informative assertions. 

* In `TransLocal::invtrans_vordiv2wind`, added logic to handle rank-2 input by allocating a temporary buffer for wind data, performing the inverse transform, and transposing the result into the output field.

**Testing improvements:**

* Added a comprehensive test case to `test_transgeneral.cc` to verify that `invtrans_vordiv2wind` produces correct results for both rank-1 and rank-2 spectral fields, including component-wise comparison with single-level transforms.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-408
<!-- STATIC-ANALYSIS_END -->