### PR TITLE
Use pluto memory pool in TransLocal and TransIFS temporary buffers

### DIFF
--- a/src/atlas/trans/ifs/TransIFS.cc
+++ b/src/atlas/trans/ifs/TransIFS.cc
@@ -17,6 +17,8 @@
 #include "transi/trans.h"
 #endif
 
+#include "pluto/pluto.h"
+
 #include "atlas/array.h"
 #include "atlas/field/FieldSet.h"
 #include "atlas/functionspace/NodeColumns.h"
@@ -30,8 +32,6 @@
 #include "atlas/trans/Trans.h"
 #include "atlas/trans/detail/TransFactory.h"
 #include "atlas/trans/ifs/TransIFS.h"
-
-#include <vector>
 
 using Topology = atlas::mesh::Nodes::Topology;
 using atlas::Field;
@@ -51,6 +51,33 @@ namespace trans {
 namespace {
 static TransBuilderGrid<TransIFS> builder_ifs("ifs", "ifs");  // deprecated
 static TransBuilderGrid<TransIFS> builder_ectrans("ectrans", "ectrans");
+
+template <typename Value>
+class PooledBuffer {
+public:
+    explicit PooledBuffer(const std::size_t size): size_(size), allocator_(pluto::host_pool_resource()), data_(nullptr) {
+        if (size_) {
+            data_ = allocator_.allocate(size_);
+        }
+    }
+
+    ~PooledBuffer() {
+        if (data_) {
+            allocator_.deallocate(data_, size_);
+        }
+    }
+
+    PooledBuffer(const PooledBuffer&)            = delete;
+    PooledBuffer& operator=(const PooledBuffer&) = delete;
+
+    Value* data() { return data_; }
+    Value& operator[](const std::size_t index) { return data_[index]; }
+
+private:
+    std::size_t size_;
+    pluto::allocator<Value> allocator_;
+    Value* data_{nullptr};
+};
 }  // namespace
 
 class TransParameters {
@@ -1171,7 +1198,7 @@ void TransIFS::ctor(const Grid& grid, long truncation, const eckit::Configuratio
 
 void TransIFS::ctor_rgg(const long nlat, const idx_t pl[], long truncation, const eckit::Configuration& config) {
     TransParameters p(*this, config);
-    std::vector<int> nloen(nlat);
+    PooledBuffer<int> nloen(nlat);
     for (long jlat = 0; jlat < nlat; ++jlat) {
         nloen[jlat] = pl[jlat];
     }
@@ -1262,8 +1289,8 @@ void TransIFS::__dirtrans(const StructuredColumns& gp, const Field& gpfield, con
     const int nfld = compute_nfld(gpfield);
 
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -1319,8 +1346,8 @@ void TransIFS::__dirtrans(const StructuredColumns& gp, const FieldSet& gpfields,
         throw_Exception("dirtrans: different number of gridpoint fields than spectral fields", Here());
     }
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -1366,8 +1393,8 @@ void TransIFS::__dirtrans(const functionspace::NodeColumns& gp, const FieldSet& 
     }
 
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -1433,9 +1460,9 @@ void TransIFS::__dirtrans_wind2vordiv(const functionspace::StructuredColumns& gp
     }
 
     // Arrays Trans expects
-    std::vector<double> rgp(2 * nfld * ngptot());
-    std::vector<double> rspvor(nspec2() * nfld);
-    std::vector<double> rspdiv(nspec2() * nfld);
+    PooledBuffer<double> rgp(2 * nfld * ngptot());
+    PooledBuffer<double> rspvor(nspec2() * nfld);
+    PooledBuffer<double> rspdiv(nspec2() * nfld);
     auto rgpview    = LocalView<double, 2>(rgp.data(), make_shape(2 * nfld, ngptot()));
     auto rspvorview = LocalView<double, 2>(rspvor.data(), make_shape(nspec2(), nfld));
     auto rspdivview = LocalView<double, 2>(rspdiv.data(), make_shape(nspec2(), nfld));
@@ -1502,9 +1529,9 @@ void TransIFS::__dirtrans_wind2vordiv(const functionspace::NodeColumns& gp, cons
     }
 
     // Arrays Trans expects
-    std::vector<double> rgp(2 * nfld * ngptot());
-    std::vector<double> rspvor(nspec2() * nfld);
-    std::vector<double> rspdiv(nspec2() * nfld);
+    PooledBuffer<double> rgp(2 * nfld * ngptot());
+    PooledBuffer<double> rspvor(nspec2() * nfld);
+    PooledBuffer<double> rspdiv(nspec2() * nfld);
     auto rgpview    = LocalView<double, 2>(rgp.data(), make_shape(2 * nfld, ngptot()));
     auto rspvorview = LocalView<double, 2>(rspvor.data(), make_shape(nspec2(), nfld));
     auto rspdivview = LocalView<double, 2>(rspdiv.data(), make_shape(nspec2(), nfld));
@@ -1557,8 +1584,8 @@ void TransIFS::__dirtrans_adj(const Spectral& sp, const FieldSet& spfields,
         throw_Exception("dirtrans_adj: different number of gridpoint fields than spectral fields", Here());
     }
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -1612,8 +1639,8 @@ void TransIFS::__dirtrans_adj( const Spectral& sp, const Field& spfield,
     const int nfld = compute_nfld(gpfield);
 
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -1662,8 +1689,8 @@ void TransIFS::__dirtrans_adj( const Spectral& sp, const Field& spfield,
     const int nfld = compute_nfld(gpfield);
 
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -1714,8 +1741,8 @@ void TransIFS::__dirtrans_adj(const Spectral& sp, const FieldSet& spfields,
         throw_Exception("dirtrans_adj: different number of gridpoint fields than spectral fields", Here());
     }
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -1786,9 +1813,9 @@ void TransIFS::__dirtrans_wind2vordiv_adj(const Spectral& sp, const Field& spvor
     }
 
     // Arrays Trans expects
-    std::vector<double> rgp(2 * nfld * ngptot());
-    std::vector<double> rspvor(nspec2() * nfld);
-    std::vector<double> rspdiv(nspec2() * nfld);
+    PooledBuffer<double> rgp(2 * nfld * ngptot());
+    PooledBuffer<double> rspvor(nspec2() * nfld);
+    PooledBuffer<double> rspdiv(nspec2() * nfld);
     auto rgpview    = LocalView<double, 2>(rgp.data(), make_shape(2 * nfld, ngptot()));
     auto rspvorview = LocalView<double, 2>(rspvor.data(), make_shape(nspec2(), nfld));
     auto rspdivview = LocalView<double, 2>(rspdiv.data(), make_shape(nspec2(), nfld));
@@ -1860,9 +1887,9 @@ void TransIFS::__dirtrans_wind2vordiv_adj(const Spectral& sp, const Field& spvor
     }
 
     // Arrays Trans expects
-    std::vector<double> rgp(2 * nfld * ngptot());
-    std::vector<double> rspvor(nspec2() * nfld);
-    std::vector<double> rspdiv(nspec2() * nfld);
+    PooledBuffer<double> rgp(2 * nfld * ngptot());
+    PooledBuffer<double> rspvor(nspec2() * nfld);
+    PooledBuffer<double> rspdiv(nspec2() * nfld);
     auto rgpview    = LocalView<double, 2>(rgp.data(), make_shape(2 * nfld, ngptot()));
     auto rspvorview = LocalView<double, 2>(rspvor.data(), make_shape(nspec2(), nfld));
     auto rspdivview = LocalView<double, 2>(rspdiv.data(), make_shape(nspec2(), nfld));
@@ -1917,8 +1944,8 @@ void TransIFS::__invtrans(const functionspace::Spectral& sp, const Field& spfiel
     const int nfld = compute_nfld(gpfield);
 
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -1979,8 +2006,8 @@ void TransIFS::__invtrans(const functionspace::Spectral& sp, const FieldSet& spf
     }
 
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -2027,8 +2054,8 @@ void TransIFS::__invtrans(const Spectral& sp, const FieldSet& spfields, const fu
     }
 
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -2099,8 +2126,8 @@ void TransIFS::__invtrans_grad(const Spectral& sp, const FieldSet& spfields, con
 
     // Arrays Trans expects
     // Allocate space for
-    std::vector<double> rgp(3 * nfld * ngptot());  // (scalars) + (NS ders) + (EW ders)
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(3 * nfld * ngptot());  // (scalars) + (NS ders) + (EW ders)
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(3 * nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -2170,8 +2197,8 @@ void TransIFS::__invtrans_grad(const Spectral& sp, const FieldSet& spfields, con
 
     // Arrays Trans expects
     // Allocate space for
-    std::vector<double> rgp(3 * nfld * ngptot());  // (scalars) + (NS ders) + (EW ders)
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(3 * nfld * ngptot());  // (scalars) + (NS ders) + (EW ders)
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(3 * nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -2266,9 +2293,9 @@ void TransIFS::__invtrans_vordiv2wind(const Spectral& sp, const Field& spvor, co
     }
 
     // Arrays Trans expects
-    std::vector<double> rgp(2 * nfld * ngptot());
-    std::vector<double> rspvor(nspec2() * nfld);
-    std::vector<double> rspdiv(nspec2() * nfld);
+    PooledBuffer<double> rgp(2 * nfld * ngptot());
+    PooledBuffer<double> rspvor(nspec2() * nfld);
+    PooledBuffer<double> rspdiv(nspec2() * nfld);
     auto rgpview    = LocalView<double, 2>(rgp.data(), make_shape(2 * nfld, ngptot()));
     auto rspvorview = LocalView<double, 2>(rspvor.data(), make_shape(nspec2(), nfld));
     auto rspdivview = LocalView<double, 2>(rspdiv.data(), make_shape(nspec2(), nfld));
@@ -2334,9 +2361,9 @@ void TransIFS::__invtrans_vordiv2wind(const Spectral& sp, const Field& spvor, co
     }
 
     // Arrays Trans expects
-    std::vector<double> rgp(2 * nfld * ngptot());
-    std::vector<double> rspvor(nspec2() * nfld);
-    std::vector<double> rspdiv(nspec2() * nfld);
+    PooledBuffer<double> rgp(2 * nfld * ngptot());
+    PooledBuffer<double> rspvor(nspec2() * nfld);
+    PooledBuffer<double> rspdiv(nspec2() * nfld);
     auto rgpview    = LocalView<double, 2>(rgp.data(), make_shape(2 * nfld, ngptot()));
     auto rspvorview = LocalView<double, 2>(rspvor.data(), make_shape(nspec2(), nfld));
     auto rspdivview = LocalView<double, 2>(rspdiv.data(), make_shape(nspec2(), nfld));
@@ -2389,8 +2416,8 @@ void TransIFS::__invtrans_adj(const functionspace::Spectral& sp, Field& spfield,
     const int nfld = compute_nfld(gpfield);
 
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -2454,8 +2481,8 @@ void TransIFS::__invtrans_adj(const functionspace::Spectral& sp, FieldSet& spfie
     }
 
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -2511,8 +2538,8 @@ void TransIFS::__invtrans_adj(const Spectral& sp, FieldSet& spfields, const func
         throw_Exception("invtrans_adj: different number of gridpoint fields than spectral fields", Here());
     }
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -2588,8 +2615,8 @@ void TransIFS::__invtrans_grad_adj(const Spectral& sp, FieldSet& spfields, const
         throw_Exception("__invtrans_grad_adj: different number of gridpoint fields than spectral fields", Here());
     }
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -2644,8 +2671,8 @@ void TransIFS::__invtrans_grad_adj(const Spectral& sp, FieldSet& spfields, const
         throw_Exception("dirtrans: different number of gridpoint fields than spectral fields", Here());
     }
     // Arrays Trans expects
-    std::vector<double> rgp(nfld * ngptot());
-    std::vector<double> rsp(nspec2() * nfld);
+    PooledBuffer<double> rgp(nfld * ngptot());
+    PooledBuffer<double> rsp(nspec2() * nfld);
     auto rgpview = LocalView<double, 2>(rgp.data(), make_shape(nfld, ngptot()));
     auto rspview = LocalView<double, 2>(rsp.data(), make_shape(nspec2(), nfld));
 
@@ -2718,9 +2745,9 @@ void TransIFS::__invtrans_vordiv2wind_adj(const Spectral& sp, Field& spvor, Fiel
     }
 
     // Arrays Trans expects
-    std::vector<double> rgp(2 * nfld * ngptot());
-    std::vector<double> rspvor(nspec2() * nfld);
-    std::vector<double> rspdiv(nspec2() * nfld);
+    PooledBuffer<double> rgp(2 * nfld * ngptot());
+    PooledBuffer<double> rspvor(nspec2() * nfld);
+    PooledBuffer<double> rspdiv(nspec2() * nfld);
     auto rgpview    = LocalView<double, 2>(rgp.data(), make_shape(2 * nfld, ngptot()));
     auto rspvorview = LocalView<double, 2>(rspvor.data(), make_shape(nspec2(), nfld));
     auto rspdivview = LocalView<double, 2>(rspdiv.data(), make_shape(nspec2(), nfld));
@@ -2792,9 +2819,9 @@ void TransIFS::__invtrans_vordiv2wind_adj(const Spectral& sp, Field& spvor, Fiel
     }
 
     // Arrays Trans expects
-    std::vector<double> rgp(2 * nfld * ngptot());
-    std::vector<double> rspvor(nspec2() * nfld);
-    std::vector<double> rspdiv(nspec2() * nfld);
+    PooledBuffer<double> rgp(2 * nfld * ngptot());
+    PooledBuffer<double> rspvor(nspec2() * nfld);
+    PooledBuffer<double> rspdiv(nspec2() * nfld);
     auto rgpview    = LocalView<double, 2>(rgp.data(), make_shape(2 * nfld, ngptot()));
     auto rspvorview = LocalView<double, 2>(rspvor.data(), make_shape(nspec2(), nfld));
     auto rspdivview = LocalView<double, 2>(rspdiv.data(), make_shape(nspec2(), nfld));

--- a/src/atlas/trans/local/TransLocal.cc
+++ b/src/atlas/trans/local/TransLocal.cc
@@ -13,7 +13,6 @@
 #include <cmath>
 #include <cstdlib>
 #include <fstream>
-#include <vector>
 
 #include "eckit/config/YAMLConfiguration.h"
 #include "eckit/eckit.h"
@@ -22,6 +21,8 @@
 #include "eckit/log/Bytes.h"
 #include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
+
+#include "pluto/pluto.h"
 
 #include "atlas/array.h"
 #include "atlas/field.h"
@@ -56,6 +57,33 @@ namespace trans {
 
 namespace {
 static TransBuilderGrid<TransLocal> builder("local", "local");
+
+template <typename Value>
+class PooledBuffer {
+public:
+    explicit PooledBuffer(const std::size_t size): size_(size), allocator_(pluto::host_pool_resource()), data_(nullptr) {
+        if (size_) {
+            data_ = allocator_.allocate(size_);
+        }
+    }
+
+    ~PooledBuffer() {
+        if (data_) {
+            allocator_.deallocate(data_, size_);
+        }
+    }
+
+    PooledBuffer(const PooledBuffer&)            = delete;
+    PooledBuffer& operator=(const PooledBuffer&) = delete;
+
+    Value* data() { return data_; }
+    Value& operator[](const std::size_t index) { return data_[index]; }
+
+private:
+    std::size_t size_;
+    pluto::allocator<Value> allocator_;
+    Value* data_{nullptr};
+};
 }  // namespace
 
 namespace {
@@ -531,8 +559,8 @@ TransLocal::TransLocal(const Cache& cache, const Grid& grid, const Domain& domai
             }
         }
         //Log::info() << "nlats=" << g.ny() << " nlatsGlobal=" << gs_global.ny() << std::endl;
-        std::vector<double> lats(nlatsLeg_);
-        std::vector<double> lons(nlonsMax);
+        PooledBuffer<double> lats(nlatsLeg_);
+        PooledBuffer<double> lons(nlonsMax);
         if (nlatsNH_ >= nlatsSH_ || useGlobalLeg) {
             for (idx_t j = 0; j < nlatsLeg_; ++j) {
                 double lat = gsLeg.y(j);
@@ -755,7 +783,7 @@ TransLocal::TransLocal(const Cache& cache, const Grid& grid, const Domain& domai
                     << "Furthermore, results may contain aliasing errors." << std::endl;
             }
 
-            std::vector<double> lats(grid_.size());
+            PooledBuffer<double> lats(grid_.size());
             alloc_aligned(legendre_, legendre_size(truncation_) * grid_.size(), "Legendre coeffs.");
             int j(0);
             for (PointLonLat p : grid_.lonlat()) {
@@ -905,7 +933,7 @@ void TransLocal::invtrans_vordiv2wind(const Field& spvor, const Field& spdiv, Fi
         const idx_t nb_grid_points = grid().size();
         const idx_t transformed_wind_stride_component = nb_vordiv_fields * nb_grid_points;
         const idx_t transformed_wind_stride_level = nb_grid_points;
-        std::vector<double> transformed_wind_data(2 * nb_vordiv_fields * nb_grid_points);
+        PooledBuffer<double> transformed_wind_data(2 * nb_vordiv_fields * nb_grid_points);
         auto transformed_wind = [&transformed_wind_stride_component, &transformed_wind_stride_level, &transformed_wind_data](idx_t component, idx_t level, idx_t point) {
             return transformed_wind_data[component * transformed_wind_stride_component + level * transformed_wind_stride_level + point];
         };
@@ -1494,7 +1522,7 @@ void TransLocal::invtrans_uv(const int truncation, const int nb_scalar_fields, c
             {
                 if (nb_vordiv_fields > 0) {
                     ATLAS_TRACE("compute u,v from U,V");
-                    std::vector<double> coslatinvs(nlats);
+                    PooledBuffer<double> coslatinvs(nlats);
                     for (idx_t j = 0; j < nlats; ++j) {
                         double lat = g.y(j);
                         if (lat > latPole) {
@@ -1579,11 +1607,11 @@ void TransLocal::invtrans(const int nb_scalar_fields, const double scalar_spectr
         ATLAS_TRACE("TransLocal::invtrans");
         int nb_vordiv_spec_ext = 2 * legendre_size(truncation_ + 1) * nb_vordiv_fields;
         int nb_scalar_ext      = 2 * legendre_size(truncation_ + 1) * nb_scalar_fields;
-        std::vector<double> U_ext(nb_vordiv_spec_ext);
-        std::vector<double> V_ext(nb_vordiv_spec_ext);
-        std::vector<double> scalar_ext(nb_scalar_ext);
-        std::vector<double> vorticity_spectra_extended(nb_vordiv_spec_ext);
-        std::vector<double> divergence_spectra_extended(nb_vordiv_spec_ext);
+        PooledBuffer<double> U_ext(nb_vordiv_spec_ext);
+        PooledBuffer<double> V_ext(nb_vordiv_spec_ext);
+        PooledBuffer<double> scalar_ext(nb_scalar_ext);
+        PooledBuffer<double> vorticity_spectra_extended(nb_vordiv_spec_ext);
+        PooledBuffer<double> divergence_spectra_extended(nb_vordiv_spec_ext);
 
         {
             ATLAS_TRACE("extend vordiv");
@@ -1605,7 +1633,7 @@ void TransLocal::invtrans(const int nb_scalar_fields, const double scalar_spectr
         }
         int nb_all_fields = 2 * nb_vordiv_fields + nb_scalar_fields;
         int nb_all_size   = 2 * legendre_size(truncation_ + 1) * nb_all_fields;
-        std::vector<double> all_spectra(nb_all_size);
+        PooledBuffer<double> all_spectra(nb_all_size);
         int k = 0, i = 0, j = 0, l = 0;
         {
             ATLAS_TRACE("merge all spectra");


### PR DESCRIPTION
### Description

This pull request refactors memory allocation for temporary arrays in the `TransIFS` implementation to improve performance and memory management. The main change is the introduction of a new `PooledBuffer` class that uses a pooled allocator from the `pluto` library, replacing standard `std::vector` allocations for large, short-lived buffers throughout the code.

**Memory management improvements:**

* Introduced a new `PooledBuffer` template class that allocates memory using `pluto::host_pool_resource()` for improved allocation efficiency and reduced heap fragmentation. (`src/atlas/trans/ifs/TransIFS.cc`)
* Replaced all instances of temporary `std::vector` allocations for large arrays (such as `rgp`, `rsp`, `rspvor`, `rspdiv`, and `nloen`) with `PooledBuffer` in all transformation and adjoint transformation routines. This affects all direct and inverse transform methods, ensuring consistent use of pooled memory. 
**Code cleanup:**

These changes should improve the performance and scalability of spectral transforms by reducing the overhead of frequent large memory allocations.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-409
<!-- STATIC-ANALYSIS_END -->