### PR TITLE
Disable Fortran when building the Python wheel

### DIFF
--- a/python/atlaslib-ecmwf/buildconfig
+++ b/python/atlaslib-ecmwf/buildconfig
@@ -11,7 +11,7 @@
 # TODO we duplicate information -- pyproject.toml's `name` and `packages` are derivable from $NAME and must stay consistent
 
 NAME="atlas"
-CMAKE_PARAMS="-Deckit_ROOT=/tmp/atlas/prereqs/eckitlib -DQhull_ROOT=/tmp/qhull/target -DENABLE_TESSELATION=1 -DENABLE_FFTW=0"
+CMAKE_PARAMS="-Deckit_ROOT=/tmp/atlas/prereqs/eckitlib -DQhull_ROOT=/tmp/qhull/target -DENABLE_TESSELATION=1 -DENABLE_FFTW=0 -DENABLE_FOTRAN=0"
 # -DFFTW_ROOT=/tmp/fftwInstall -DENABLE_FFTW=1 # we dont want fftw due to lic reasons => with enable=0, pocketfft gets picked up instead
 PYPROJECT_DIR="python/atlaslib-ecmwf"
 DEPENDENCIES='["eckitlib"]'


### PR DESCRIPTION
### Description
The wheels we currently get when installing atlaslib-ecmwf has a runtime dependency on the existence of a Fortran library. This is not desired, hence disable Fortran support when building the wheel.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-412
<!-- STATIC-ANALYSIS_END -->