### PR TITLE
Add global-index based edge-to-cell connectivity

### DIFF
--- a/src/atlas/mesh/actions/BuildEdges.cc
+++ b/src/atlas/mesh/actions/BuildEdges.cc
@@ -33,6 +33,7 @@
 #include "atlas/mesh/Mesh.h"
 #include "atlas/mesh/Nodes.h"
 #include "atlas/mesh/detail/AccumulateFacets.h"
+#include "atlas/mesh/actions/BuildXYZField.h"
 #include "atlas/parallel/mpi/mpi.h"
 #include "atlas/runtime/Exception.h"
 #include "atlas/runtime/Log.h"
@@ -353,6 +354,9 @@ void build_edges(Mesh& mesh, const eckit::Configuration& config) {
     bool sort_edges{false};
     config.get("sort_edges", sort_edges);
 
+    std::string node_order = "xy";
+    config.get("node_order", node_order);
+    ATLAS_ASSERT(node_order == "xy" || node_order == "global_index");
 
     mesh::Nodes& nodes = mesh.nodes();
     auto node_part     = array::make_view<int, 1>(nodes.partition());
@@ -425,6 +429,10 @@ void build_edges(Mesh& mesh, const eckit::Configuration& config) {
         const auto& cell_nodes = mesh.cells().node_connectivity();
 
         UniqueLonLat compute_uid(mesh);
+        BuildXYZField("xyz")(nodes);
+        const auto node_gidx   = array::make_view<gidx_t, 1>(nodes.global_index());
+        const auto node_lonlat = array::make_view<double, 2>(nodes.lonlat());
+        const auto node_xyz    = array::make_view<double, 2>(nodes.field("xyz"));
 
         auto edge_ridx    = array::make_indexview<idx_t, 1>(mesh.edges().remote_index());
         auto edge_part    = array::make_view<int, 1>(mesh.edges().partition());
@@ -437,9 +445,17 @@ void build_edges(Mesh& mesh, const eckit::Configuration& config) {
             const idx_t iedge = edge_halo_offsets[halo] + (edge - edge_start);
             const int ip1     = edge_nodes(edge, 0);
             const int ip2     = edge_nodes(edge, 1);
-            if (compute_uid(ip1) > compute_uid(ip2)) {
-                idx_t swapped[2] = {ip2, ip1};
-                edge_nodes.set(edge, swapped);
+            if (node_order == "global_index") {
+                if (node_gidx(ip1) > node_gidx(ip2)) {
+                    idx_t swapped[2] = {ip2, ip1};
+                    edge_nodes.set(edge, swapped);
+                }
+            }
+            else {
+                if (compute_uid(ip1) > compute_uid(ip2)) {
+                    idx_t swapped[2] = {ip2, ip1};
+                    edge_nodes.set(edge, swapped);
+                }
             }
 
             ATLAS_ASSERT(idx_t(edge_nodes(edge, 0)) < nb_nodes);
@@ -454,12 +470,55 @@ void build_edges(Mesh& mesh, const eckit::Configuration& config) {
             const idx_t e2 = edge_to_elem_data[2 * iedge + 1];
 
             ATLAS_ASSERT(e1 != cell_nodes.missing_value());
-            if (e2 == cell_nodes.missing_value()) {
-                // do nothing
+            if (node_order == "xy") {
+                if (e2 == cell_nodes.missing_value()) {
+                    continue;
+                }
+                else if (compute_uid(cell_nodes.row(e1)) > compute_uid(cell_nodes.row(e2))) {
+                    edge_to_elem_data[iedge * 2 + 0] = e2;
+                    edge_to_elem_data[iedge * 2 + 1] = e1;
+                }
             }
-            else if (compute_uid(cell_nodes.row(e1)) > compute_uid(cell_nodes.row(e2))) {
-                edge_to_elem_data[iedge * 2 + 0] = e2;
-                edge_to_elem_data[iedge * 2 + 1] = e1;
+            else {
+                const idx_t node1 = edge_nodes(edge, 0);
+                const idx_t node2 = edge_nodes(edge, 1);
+                const double edge_normal_x = node_xyz(node1, YY) * node_xyz(node2, ZZ) -
+                                            node_xyz(node1, ZZ) * node_xyz(node2, YY);
+                const double edge_normal_y = node_xyz(node1, ZZ) * node_xyz(node2, XX) -
+                                            node_xyz(node1, XX) * node_xyz(node2, ZZ);
+                const double edge_normal_z = node_xyz(node1, XX) * node_xyz(node2, YY) -
+                                            node_xyz(node1, YY) * node_xyz(node2, XX);
+                const double edge_length = std::sqrt(edge_normal_x * edge_normal_x + edge_normal_y * edge_normal_y +
+                                                    edge_normal_z * edge_normal_z);
+                double centre_x = 0.;
+                double centre_y = 0.;
+                double centre_z = 0.;
+                for (idx_t jnode = 0; jnode < cell_nodes.cols(e1); ++jnode) {
+                    const idx_t cell_node = cell_nodes(e1, jnode);
+                    centre_x += node_xyz(cell_node, XX);
+                    centre_y += node_xyz(cell_node, YY);
+                    centre_z += node_xyz(cell_node, ZZ);
+                }
+
+                bool e1_is_right = edge_normal_x * centre_x + edge_normal_y * centre_y + edge_normal_z * centre_z < 0.;
+                if (edge_length == 0.) {
+                    const double longitude1 = node_lonlat(node1, LON);
+                    const double longitude2 = node_lonlat(node2, LON);
+                    const bool north_pole = node_lonlat(node1, LAT) > 0.;
+                    e1_is_right = north_pole ? longitude1 > longitude2 : longitude1 < longitude2;
+                }
+
+                if (e1_is_right) {
+                    if (e2 == cell_nodes.missing_value()) {
+                        // Re-orient the edge such that e1 is on its left side.
+                        idx_t swapped[2] = {node2, node1};
+                        edge_nodes.set(edge, swapped);
+                    }
+                    else {
+                        edge_to_elem_data[iedge * 2 + 0] = e2;
+                        edge_to_elem_data[iedge * 2 + 1] = e1;
+                    }
+                }
             }
         }
 

--- a/src/atlas/mesh/actions/BuildEdges.cc
+++ b/src/atlas/mesh/actions/BuildEdges.cc
@@ -357,6 +357,9 @@ void build_edges(Mesh& mesh, const eckit::Configuration& config) {
     std::string node_order = "xy";
     config.get("node_order", node_order);
     ATLAS_ASSERT(node_order == "xy" || node_order == "global_index");
+    std::string cell_order = "xy";
+    config.get("cell_order", cell_order);
+    ATLAS_ASSERT(cell_order == "xy" || cell_order == "left_first" || cell_order == "right_first");
 
     mesh::Nodes& nodes = mesh.nodes();
     auto node_part     = array::make_view<int, 1>(nodes.partition());
@@ -470,7 +473,7 @@ void build_edges(Mesh& mesh, const eckit::Configuration& config) {
             const idx_t e2 = edge_to_elem_data[2 * iedge + 1];
 
             ATLAS_ASSERT(e1 != cell_nodes.missing_value());
-            if (node_order == "xy") {
+            if (cell_order == "xy") {
                 if (e2 == cell_nodes.missing_value()) {
                     continue;
                 }
@@ -480,6 +483,7 @@ void build_edges(Mesh& mesh, const eckit::Configuration& config) {
                 }
             }
             else {
+                bool left_cell_first = (cell_order == "left_first");
                 const idx_t node1 = edge_nodes(edge, 0);
                 const idx_t node2 = edge_nodes(edge, 1);
                 const double edge_normal_x = node_xyz(node1, YY) * node_xyz(node2, ZZ) -
@@ -515,8 +519,8 @@ void build_edges(Mesh& mesh, const eckit::Configuration& config) {
                         edge_nodes.set(edge, swapped);
                     }
                     else {
-                        edge_to_elem_data[iedge * 2 + 0] = e2;
-                        edge_to_elem_data[iedge * 2 + 1] = e1;
+                        edge_to_elem_data[iedge * 2 + 0] = (left_cell_first ? e2 : e1);
+                        edge_to_elem_data[iedge * 2 + 1] = (left_cell_first ? e1 : e2);
                     }
                 }
             }
@@ -653,6 +657,12 @@ void atlas__build_edges(Mesh::Implementation* mesh) {
     ATLAS_ASSERT(mesh != nullptr, "Cannot access uninitialised atlas_Mesh");
     Mesh m(mesh);
     build_edges(m);
+}
+void atlas__build_edges_config(Mesh::Implementation* mesh, const eckit::Configuration* config) {
+    ATLAS_ASSERT(mesh != nullptr, "Cannot access uninitialised atlas_Mesh");
+    ATLAS_ASSERT(config != nullptr, "Cannot access uninitialised atlas_Config");
+    Mesh m(mesh);
+    build_edges(m, *config);
 }
 void atlas__build_pole_edges(Mesh::Implementation*) {
     Log::info() << "ATLAS_WARNING: Deprecation warning: atlas_build_pole_edges is no longer required.\n"

--- a/src/atlas/mesh/actions/BuildEdges.h
+++ b/src/atlas/mesh/actions/BuildEdges.h
@@ -43,10 +43,15 @@ class MeshImpl;
 }  // namespace mesh
 }  // namespace atlas
 
+namespace eckit {
+class Configuration;
+}
+
 
 // C wrapper interfaces to C++ routines
 extern "C" {
 void atlas__build_edges(atlas::mesh::detail::MeshImpl* mesh);
+void atlas__build_edges_config(atlas::mesh::detail::MeshImpl* mesh, const eckit::Configuration* config);
 void atlas__build_pole_edges(atlas::mesh::detail::MeshImpl* mesh);
 void atlas__build_node_to_edge_connectivity(atlas::mesh::detail::MeshImpl* mesh);
 }

--- a/src/atlas_f/mesh/atlas_mesh_actions_module.F90
+++ b/src/atlas_f/mesh/atlas_mesh_actions_module.F90
@@ -71,11 +71,17 @@ subroutine atlas_build_halo(mesh,nelems)
   call atlas__build_halo(mesh%c_ptr(),nelems)
 end subroutine atlas_build_halo
 
-subroutine atlas_build_edges(mesh)
+subroutine atlas_build_edges(mesh, config)
   use atlas_BuildEdges_c_binding
   use atlas_Mesh_module, only: atlas_Mesh
+  use atlas_Config_module, only: atlas_Config
   type(atlas_Mesh), intent(inout) :: mesh
-  call atlas__build_edges(mesh%c_ptr())
+  type(atlas_Config), intent(in), optional :: config
+  if (present(config)) then
+    call atlas__build_edges_config(mesh%c_ptr(), config%c_ptr())
+  else
+    call atlas__build_edges(mesh%c_ptr())
+  end if
 end subroutine atlas_build_edges
 
 subroutine atlas_build_pole_edges(mesh)

--- a/src/tests/mesh/test_mesh_build_edges.cc
+++ b/src/tests/mesh/test_mesh_build_edges.cc
@@ -245,7 +245,7 @@ CASE("test_build_edges") {
     Mesh mesh = generator.generate(grid);
 
     // Accumulate facets of cells ( edges in 2D )
-    mesh::actions::build_edges(mesh, option::pole_edges(false));
+    mesh::actions::build_edges(mesh, Config("pole_edges", false)("node_order", "global_index"));
 
     std::vector<idx_t> edge_nodes_check{
         0,  21, 21, 22, 22, 1,  1,  0,  22, 23, 23, 2,  2,  1,  3,  25, 25, 26, 26, 4,  4,  3,  26, 27, 27, 5,  5,
@@ -264,17 +264,19 @@ CASE("test_build_edges") {
 
     {
         const mesh::HybridElements::Connectivity& edge_node_connectivity = mesh.edges().node_connectivity();
+        const mesh::HybridElements::Connectivity& edge_cell_connectivity = mesh.edges().cell_connectivity();
+        const auto node_gidx = array::make_view<gidx_t, 1>(mesh.nodes().global_index());
         EXPECT(mesh.projection().units() == "degrees");
-        const util::UniqueLonLat compute_uid(mesh);
         EXPECT_EQ(mesh.edges().size(), edge_nodes_check.size() / 2);
         for (idx_t jedge = 0; jedge < mesh.edges().size(); ++jedge) {
-            if (compute_uid(edge_nodes_check[2 * jedge + 0]) < compute_uid(edge_nodes_check[2 * jedge + 1])) {
-                EXPECT_EQ(edge_nodes_check[2 * jedge + 0], edge_node_connectivity(jedge, 0));
-                EXPECT_EQ(edge_nodes_check[2 * jedge + 1], edge_node_connectivity(jedge, 1));
-            }
-            else {
-                EXPECT_EQ(edge_nodes_check[2 * jedge + 0], edge_node_connectivity(jedge, 1));
-                EXPECT_EQ(edge_nodes_check[2 * jedge + 1], edge_node_connectivity(jedge, 0));
+            const idx_t expected_node1 = edge_nodes_check[2 * jedge + 0];
+            const idx_t expected_node2 = edge_nodes_check[2 * jedge + 1];
+            const idx_t node1          = edge_node_connectivity(jedge, 0);
+            const idx_t node2          = edge_node_connectivity(jedge, 1);
+            EXPECT((node1 == expected_node1 && node2 == expected_node2) ||
+                   (node1 == expected_node2 && node2 == expected_node1));
+            if (edge_cell_connectivity(jedge, 1) != edge_cell_connectivity.missing_value()) {
+                EXPECT(node_gidx(node1) < node_gidx(node2));
             }
         }
     }
@@ -454,21 +456,34 @@ CASE("test_build_edges") {
     {
         const mesh::HybridElements::Connectivity& cell_node_connectivity = mesh.cells().node_connectivity();
         const mesh::HybridElements::Connectivity& edge_cell_connectivity = mesh.edges().cell_connectivity();
-        const util::UniqueLonLat compute_uid(mesh);
+        const mesh::HybridElements::Connectivity& edge_node_connectivity = mesh.edges().node_connectivity();
+        const auto node_xyz = array::make_view<double, 2>(mesh.nodes().field("xyz"));
         EXPECT_EQ(mesh.edges().size(), edge_to_cell_check.size() / 2);
         for (idx_t jedge = 0; jedge < mesh.edges().size(); ++jedge) {
-            idx_t e1 = edge_to_cell_check[2 * jedge + 0];
-            idx_t e2 = edge_to_cell_check[2 * jedge + 1];
-            if (e2 == edge_cell_connectivity.missing_value() ||
-                compute_uid(cell_node_connectivity.row(e1)) < compute_uid(cell_node_connectivity.row(e2))) {
-                EXPECT_EQ(edge_to_cell_check[2 * jedge + 0], edge_cell_connectivity(jedge, 0));
-                EXPECT_EQ(edge_to_cell_check[2 * jedge + 1], edge_cell_connectivity(jedge, 1));
+            const idx_t expected_e1 = edge_to_cell_check[2 * jedge + 0];
+            const idx_t expected_e2 = edge_to_cell_check[2 * jedge + 1];
+            const idx_t e1          = edge_cell_connectivity(jedge, 0);
+            const idx_t e2          = edge_cell_connectivity(jedge, 1);
+            EXPECT((e1 == expected_e1 && e2 == expected_e2) || (e1 == expected_e2 && e2 == expected_e1));
+
+            const idx_t node1 = edge_node_connectivity(jedge, 0);
+            const idx_t node2 = edge_node_connectivity(jedge, 1);
+            const double normal_x = node_xyz(node1, YY) * node_xyz(node2, ZZ) -
+                                    node_xyz(node1, ZZ) * node_xyz(node2, YY);
+            const double normal_y = node_xyz(node1, ZZ) * node_xyz(node2, XX) -
+                                    node_xyz(node1, XX) * node_xyz(node2, ZZ);
+            const double normal_z = node_xyz(node1, XX) * node_xyz(node2, YY) -
+                                    node_xyz(node1, YY) * node_xyz(node2, XX);
+            double centre_x = 0.;
+            double centre_y = 0.;
+            double centre_z = 0.;
+            for (idx_t jnode = 0; jnode < cell_node_connectivity.cols(e1); ++jnode) {
+                const idx_t cell_node = cell_node_connectivity(e1, jnode);
+                centre_x += node_xyz(cell_node, XX);
+                centre_y += node_xyz(cell_node, YY);
+                centre_z += node_xyz(cell_node, ZZ);
             }
-            else {
-                std::cout << "jedge " << jedge << std::endl;
-                EXPECT_EQ(edge_to_cell_check[2 * jedge + 0], edge_cell_connectivity(jedge, 1));
-                EXPECT_EQ(edge_to_cell_check[2 * jedge + 1], edge_cell_connectivity(jedge, 0));
-            }
+            EXPECT(normal_x * centre_x + normal_y * centre_y + normal_z * centre_z >= 0.);
         }
     }
 
@@ -480,6 +495,30 @@ CASE("test_build_edges") {
                 std::cout << std::setw(3) << elem_edge_connectivity(jelem, jedge) << "  ";
             }
             std::cout << std::endl;
+        }
+    }
+}
+
+CASE("test_build_edges_node_order_xy") {
+    Grid grid("O2");
+    StructuredMeshGenerator generator(Config("angle", 29.0)("triangulate", false)("ghost_at_end", false));
+    Mesh mesh = generator.generate(grid);
+
+    mesh::actions::build_edges(mesh, Config("pole_edges", false)("node_order", "xy"));
+
+    const auto& edge_nodes = mesh.edges().node_connectivity();
+    const auto& edge_cells = mesh.edges().cell_connectivity();
+    const auto& cell_nodes = mesh.cells().node_connectivity();
+    UniqueLonLat compute_uid(mesh);
+
+    for (idx_t edge = 0; edge < mesh.edges().size(); ++edge) {
+        EXPECT(compute_uid(edge_nodes(edge, 0)) <= compute_uid(edge_nodes(edge, 1)));
+
+        const idx_t cell1 = edge_cells(edge, 0);
+        const idx_t cell2 = edge_cells(edge, 1);
+        EXPECT(cell1 != edge_cells.missing_value());
+        if (cell2 != edge_cells.missing_value()) {
+            EXPECT(compute_uid(cell_nodes.row(cell1)) <= compute_uid(cell_nodes.row(cell2)));
         }
     }
 }


### PR DESCRIPTION

### Description

Add a possibility for a global-index based edge-to-cell connectivity in addition to the already present geographical connectivity.

The global-index based connectivity appears to be commonly used in well-established external code packages and is hence useful to have in Atlas to ensure machine precision agreements if Atlas is to be used in those packages.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- STATIC-ANALYSIS_BEGIN -->
💣💥☠️ Static Analyzer Report ☠️💥💣
https://sites.ecmwf.int/docs/atlas/static-analyzer/PR-413
<!-- STATIC-ANALYSIS_END -->